### PR TITLE
Clone full history of dlpx-app-gate repository

### DIFF
--- a/live-build/misc/ansible-roles/appliance-build.virtualization-development/tasks/main.yml
+++ b/live-build/misc/ansible-roles/appliance-build.virtualization-development/tasks/main.yml
@@ -40,16 +40,6 @@
   retries: 3
   delay: 60
 
-#
-# We need to do a shallow clone here for a couple reasons:
-#
-# 1. To reduce the size needed to transfer over the network, which
-#    speeds up the time required to do a build.
-#
-# 2. To reduce the size of the resultant virtual machine images, which
-#    speeds up the time to transfer these images to wherever they're
-#    needed; along with reducing the cost of storing these images.
-#
 - git:
     repo: "{{ item.repo }}"
     dest:
@@ -57,7 +47,6 @@
     version: "{{ item.version }}"
     accept_hostkey: yes
     update: no
-    depth: 1
   with_items:
     - { repo: 'https://gitlab.delphix.com/app/dlpx-app-gate.git',
         version: projects/dx4linux,


### PR DESCRIPTION
Originally, we performed a very shallow clone of the dlpx-app-gate
repository, optimizing for latency of the build, and the size of the
resultant VM artifacts.

Not having the repository's history on our internal VM images is a
divergence from what we do for other images, and can pose a problem for
some of our internal developer tooling.

Thus, this change reverts this functionality; now we do a full clone
of the dlpx-app-gate repository, optimizing for developer productivity
and utility of the resultant VM images, rather than build latency.