### PR TITLE
Enforce "shellcheck" and "shfmtcheck" via CI tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,4 +10,6 @@ install:
  - ./scripts/docker-build.sh
 
 script:
+ - ./scripts/docker-run.sh make shellcheck
+ - ./scripts/docker-run.sh make shfmtcheck
  - ./scripts/docker-run.sh make internal-minimal


### PR DESCRIPTION
This change removes the old "shfmt" make target, and replaces it with a
new "shfmtcheck" target. This new target more closely resembles the
existing "shellcheck" target, in that now "shfmtcheck" doesn't modify
the files; instead it will report the lines that need to be modified.

Additionally, this change adds "shellcheck" and "shfmtcheck" make
targets to our automated CI testing, which will help us maintain a
consistent style across our shell scripts.