### PR TITLE
Rely on virtualization package dependencies

### DIFF
--- a/live-build/base/config/package-lists/tools.list.chroot
+++ b/live-build/base/config/package-lists/tools.list.chroot
@@ -24,7 +24,10 @@ atop
 dstat
 emacs
 gdb
+glances
 iftop
+procinfo
+sg3-utils
 strace
 tshark
 vim

--- a/live-build/misc/ansible-roles/appliance-build.virtualization-common/tasks/main.yml
+++ b/live-build/misc/ansible-roles/appliance-build.virtualization-common/tasks/main.yml
@@ -24,35 +24,6 @@
     state: present
     update_cache: no
 
-#
-# The delphix-virtualization package doesn't yet declare its dependencies.
-# As a result, we must explicitly install them here.
-#
-- apt:
-    name: "{{ item }}"
-    state: present
-  with_items:
-    - dmidecode
-    - fio
-    - glances
-    - nfs-kernel-server
-    - ntp
-    - ntpdate
-    - pigz
-    - postgresql-9.4
-    - postgresql-contrib-9.4
-    - procinfo
-    - python-minimal
-    - rsync
-    - sg3-utils
-    - targetcli-fb
-    - zfsutils-linux
-    - zip
-  register: result
-  until: result is not failed
-  retries: 3
-  delay: 60
-
 - lineinfile:
     dest: /etc/systemd/journald.conf
     regexp: "^#?{{ item.key }}="


### PR DESCRIPTION
This change removes the hard coded list of dependencies for the
virtualization package. The virtualization package should now contain
the list of its dependencies, so there's no reason to have a hard coded
list here. When pulling in the virtualization package, we'll pull in
that package's dependencies as well.