### PR TITLE
sysctl.conf: disable IPv6 addresses and promote secondaries

### DIFF
--- a/live-build/misc/ansible-roles/appliance-build.minimal-common/tasks/main.yml
+++ b/live-build/misc/ansible-roles/appliance-build.minimal-common/tasks/main.yml
@@ -175,3 +175,26 @@
         default_user:
           name: {{ lookup('env', 'APPLIANCE_USERNAME') }}
           lock_passwd: false
+
+#
+# IPv6 addresses are not supported by the product thus we need
+# to ensure that they cannot be added manually by default. In
+# addition, we wouldn't want to have our secondary addresses
+# deleted when someone deletes the primary IP address of a
+# network interface, thus we enable the promotion of secondary
+# addresses to primary ones.
+#
+# As for the priority prefix for our config file (see what that
+# means in /etc/sysctl.d/README) we pick 50 which is higher than
+# what other Ubuntu packages will be installing but less than
+# customization made by the end-user, which in our case would be
+# customer support.
+#
+- lineinfile:
+    create: yes
+    dest: /etc/sysctl.d/50-delphix-networking.conf
+    regexp: "^#?{{ item.key }}="
+    line: "{{ item.key }}={{ item.value }}"
+  with_items:
+    - { key: "net.ipv4.conf.all.promote_secondaries", value: "1" }
+    - { key: "net.ipv6.conf.all.disable_ipv6", value: "1" }


### PR DESCRIPTION
This is a change that we need in both dev and production.

Tested with internal-minimal.

==== Before change ====
```
delphix@appliance:~$ sysctl net.ipv6.conf.all.disable_ipv6
net.ipv6.conf.all.disable_ipv6 = 0
delphix@appliance:~$ sysctl net.ipv4.conf.all.promote_secondaries
net.ipv4.conf.all.promote_secondaries = 1
delphix@appliance:~$ grep secondaries /etc/sysctl.conf
delphix@appliance:~$ grep disable_ipv6 /etc/sysctl.conf
```

Not sure how the promotion of secondaries is set here but I
believe that we should be explicit.

==== After change ====
```
delphix@appliance:~$ tail /etc/sysctl.conf
#
# Protects against creating or following links under certain conditions
# Debian kernels have both set to 1 (restricted)
# See https://www.kernel.org/doc/Documentation/sysctl/fs.txt
#fs.protected_hardlinks=0
#fs.protected_symlinks=0
# BEGIN ANSIBLE MANAGED BLOCK
net.ipv4.conf.all.promote_secondaries=1
net.ipv6.conf.all.disable_ipv6=1
# END ANSIBLE MANAGED BLOCK
delphix@appliance:~$ sysctl net.ipv4.conf.all.promote_secondaries
net.ipv4.conf.all.promote_secondaries = 1
delphix@appliance:~$ sysctl net.ipv6.conf.all.disable_ipv6
net.ipv6.conf.all.disable_ipv6 = 1
```