### PR TITLE
Use TravisCI's "build matrix" feature

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,14 @@ branches:
    - trying
    - master
 
+env:
+  - TARGET=shellcheck
+  - TARGET=shfmtcheck
+  - TARGET=internal-minimal
+
 install:
  - sudo ./scripts/docker-install-ubuntu.sh
  - ./scripts/docker-build.sh
 
 script:
- - ./scripts/docker-run.sh make shellcheck
- - ./scripts/docker-run.sh make shfmtcheck
- - ./scripts/docker-run.sh make internal-minimal
+ - ./scripts/docker-run.sh make $TARGET


### PR DESCRIPTION
This change modifies the .travis.yml file, in order to run the three
test scripts concurrently, rather than serially. This ensures all tests
will be run for any given build, even if one of them fails.