### PR TITLE
Enable Ec2 datasource for internal artifacts

### DIFF
--- a/live-build/misc/ansible-roles/appliance-build.minimal-external/tasks/main.yml
+++ b/live-build/misc/ansible-roles/appliance-build.minimal-external/tasks/main.yml
@@ -19,4 +19,4 @@
     dest: /etc/cloud/cloud.cfg.d/99-delphix-external.cfg
     mode: 0644
     content: |
-      datasource_list: [ NoCloud, None ]
+      datasource_list: [ None ]

--- a/live-build/misc/ansible-roles/appliance-build.minimal-internal/tasks/main.yml
+++ b/live-build/misc/ansible-roles/appliance-build.minimal-internal/tasks/main.yml
@@ -19,4 +19,4 @@
     dest: /etc/cloud/cloud.cfg.d/99-delphix-internal.cfg
     mode: 0644
     content: |
-      datasource_list: [ NoCloud, None ]
+      datasource_list: [ Ec2, None ]


### PR DESCRIPTION
For our internally used VM artifacts, we want to enable the Ec2
datasource, such that cloud-init will populate the default user's
SSH authorized_keys file when running in AWS EC2.