### PR TITLE
Set log level to "debug" for systemd-networkd

### DIFF
--- a/live-build/misc/ansible-roles/appliance-build.minimal-common/tasks/main.yml
+++ b/live-build/misc/ansible-roles/appliance-build.minimal-common/tasks/main.yml
@@ -69,7 +69,22 @@
 # Also, we can't use the "service" module, as that fails when running
 # inside the chroot environment, so we have to use "command" here.
 #
+# Additionally, we raise the log level to help diagnose problems; in the
+# event that networking fails, this additional information is valuable.
+#
 - command: systemctl enable systemd-networkd.service
+
+- file:
+    path: /etc/systemd/system/systemd-networkd.service.d
+    state: directory
+    mode: 0755
+
+- copy:
+    dest: /etc/systemd/system/systemd-networkd.service.d/50-log-level.conf
+    mode: 0644
+    content: |
+      [Service]
+      Environment=SYSTEMD_LOG_LEVEL=debug
 
 #
 # Configure GRUB2 to allow access over the serial console.


### PR DESCRIPTION
This change modifies the log level of the "systemd-networkd" service,
such that the service's log will contain more information about what
exactly it is doing. This is helpful for diagnosing problems, in the
event that networking fails.

For example, without this change, the log contains the following:

    $ sudo journalctl -b -u systemd-networkd | cat
    -- Logs begin at Tue 2018-05-08 23:24:05 UTC, end at Tue 2018-05-08 23:44:35 UTC. --
    May 08 23:24:48 appliance.example.com systemd[1]: Starting Network Service...
    May 08 23:24:48 appliance.example.com systemd-networkd[1068]: Enumeration completed
    May 08 23:24:48 appliance.example.com systemd[1]: Started Network Service.
    May 08 23:24:48 appliance.example.com systemd-networkd[1068]: lo: Link is not managed by us
    May 08 23:24:48 appliance.example.com systemd-networkd[1068]: ens3: IPv6 successfully enabled
    May 08 23:24:48 appliance.example.com systemd-networkd[1068]: lo: Configured
    May 08 23:24:48 appliance.example.com systemd-networkd[1068]: ens3: Gained carrier
    May 08 23:24:49 appliance.example.com systemd-networkd[1068]: ens3: DHCPv4 address 10.0.2.15/24 via 10.0.2.2
    May 08 23:24:50 appliance.example.com systemd-networkd[1068]: ens3: Gained IPv6LL
    May 08 23:24:50 appliance.example.com systemd-networkd[1068]: ens3: Configured

With this change, the log will contains much more detailed information:

    $ sudo journalctl -b -u systemd-networkd | head -n 20
    -- Logs begin at Tue 2018-05-08 23:54:37 UTC, end at Tue 2018-05-08 23:57:30 UTC. --
    May 08 23:55:21 appliance.example.com systemd[1]: Starting Network Service...
    May 08 23:55:21 appliance.example.com systemd-networkd[1084]: Bus n/a: changing state UNSET → OPENING
    May 08 23:55:21 appliance.example.com systemd-networkd[1084]: Added inotify watch for /run on bus n/a: 2
    May 08 23:55:21 appliance.example.com systemd-networkd[1084]: Added inotify watch for /run/dbus on bus n/a: -1
    May 08 23:55:21 appliance.example.com systemd-networkd[1084]: Bus n/a: changing state OPENING → WATCH_BIND
    May 08 23:55:21 appliance.example.com systemd-networkd[1084]: Failed to open configuration file '/etc/systemd/networkd.conf': No such file or directory
    May 08 23:55:21 appliance.example.com systemd-networkd[1084]: timestamp of '/etc/systemd/network' changed
    May 08 23:55:21 appliance.example.com systemd-networkd[1084]: timestamp of '/run/systemd/network' changed
    May 08 23:55:21 appliance.example.com systemd-networkd[1084]: Ignoring /etc/systemd/network/dhcp-client.network, because it's not a regular file with suffix .netdev.
    May 08 23:55:21 appliance.example.com systemd-networkd[1084]: Ignoring /run/systemd/network/10-netplan-ens3.network, because it's not a regular file with suffix .netdev.
    May 08 23:55:21 appliance.example.com systemd-networkd[1084]: Ignoring /run/systemd/network/10-netplan-ens3.link, because it's not a regular file with suffix .netdev.
    May 08 23:55:21 appliance.example.com systemd-networkd[1084]: Ignoring /lib/systemd/network/80-container-vz.network, because it's not a regular file with suffix .netdev.
    May 08 23:55:21 appliance.example.com systemd-networkd[1084]: Ignoring /lib/systemd/network/99-default.link, because it's not a regular file with suffix .netdev.
    May 08 23:55:21 appliance.example.com systemd-networkd[1084]: Ignoring /lib/systemd/network/80-container-host0.network, because it's not a regular file with suffix .netdev.
    May 08 23:55:21 appliance.example.com systemd-networkd[1084]: Ignoring /lib/systemd/network/80-container-ve.network, because it's not a regular file with suffix .netdev.
    May 08 23:55:21 appliance.example.com systemd-networkd[1084]: Ignoring /run/systemd/network/10-netplan-ens3.link, because it's not a regular file with suffix .network.
    May 08 23:55:21 appliance.example.com systemd-networkd[1084]: Ignoring /lib/systemd/network/99-default.link, because it's not a regular file with suffix .network.
    May 08 23:55:21 appliance.example.com systemd-networkd[1084]: ens3: Flags change: +MULTICAST +BROADCAST
    May 08 23:55:21 appliance.example.com systemd-networkd[1084]: ens3: Link 2 added

Networking can fail even if the image is correctly configured (e.g. the
image is configured to use DHCP, when no DHCP server is listening), so
this additional information can be valuable in these situations.