### PR TITLE
Clone master branch of product repositories

### DIFF
--- a/live-build/misc/ansible-roles/appliance-build.masking-development/tasks/main.yml
+++ b/live-build/misc/ansible-roles/appliance-build.masking-development/tasks/main.yml
@@ -38,7 +38,7 @@
     update: no
   with_items:
     - { repo: 'https://gitlab.delphix.com/masking/dms-core-gate.git',
-        version: projects/dx4linux,
+        version: master,
         dest: dms-core-gate }
 
 - file:

--- a/live-build/misc/ansible-roles/appliance-build.virtualization-development/tasks/main.yml
+++ b/live-build/misc/ansible-roles/appliance-build.virtualization-development/tasks/main.yml
@@ -49,7 +49,7 @@
     update: no
   with_items:
     - { repo: 'https://gitlab.delphix.com/app/dlpx-app-gate.git',
-        version: projects/dx4linux,
+        version: master,
         dest: dlpx-app-gate }
 
 - file:


### PR DESCRIPTION
# Problem

In [this Jenkins job](http://selfservice.jenkins.delphix.com/job/dlpx-app-gate/job/master/job/integration-tests/job/post-push/job/dlpxdc.co/job/split-precommit-dxos/865/consoleFull), an old version of the code was tested. The job should have run against `28cd2478f71` (LX-978 Disable flaky tests in MetadataServiceTest on Linux), but instead it ran against `d59513a1f5b` (LX-142 Fix phonehome on Linux).

# Evaluation

Our Jenkins jobs fetch a specific refspec in order to reduce the amount of time it takes to clone the repository:

```
> git fetch --no-tags --progress https://gitlab.delphix.com/app/dlpx-app-gate.git +refs/heads/projects/dx4linux:refs/remotes/origin/projects/dx4linux # timeout=60
```

The Ansible roles that clone product repositories create a local branch named `projects/dx4linux`. When a local branch exists with the same name as the requested refspec, Jenkins [finds multiple candidate revisions when determining the revision to build](https://github.com/jenkinsci/git-plugin/blob/b0a18854a8c2d07c9bda1737e752d9d38997d3c2/src/main/java/hudson/plugins/git/GitSCM.java#L1101-L1114). It then chooses the head of local branch as the revision to build, ignoring the head of the remote branch:

```
> git rev-parse projects/dx4linux^{commit} # timeout=10
> git rev-parse refs/remotes/origin/projects/dx4linux^{commit} # timeout=10
Multiple candidate revisions
Checking out Revision d59513a1f5b705aa24239d3af19d09d9a89a79cf (projects/dx4linux)
```

The result is that automated test runs end up testing old revisions of the code, which is undesirable.

# Solution

[JENKINS-21464](https://issues.jenkins-ci.org/browse/JENKINS-21464) tracks this problem, but the bug was resolved as "Won't Fix." The comments to the bug show a way to work around the problem. To work around the problem, we clone the `master` branch of our product repositories rather than a specific branch. This prevents the Jenkins Git plugin from finding multiple candidate revisions when determining the revision to build.

# Testing

I set up a test system where I deleted the `projects/dx4linux` local branch. Then I ran [the same Jenkins job](http://selfservice.jenkins.delphix.com/job/dlpx-app-gate/job/master/job/integration-tests/job/post-push/job/dcenter/job/split-precommit-dxos/644/consoleFull) against it. Before (when a `projects/dx4linux` branch existed), this would have resulted in `Multiple candidate revisions` being printed (as described in the problem statement). With the `projects/dx4linux` branch deleted, there is only one candidate revision: the correct revision.