### PR TITLE
Reduce time spent waiting for EC2 datasource

### DIFF
--- a/live-build/misc/ansible-roles/appliance-build.minimal-internal/tasks/main.yml
+++ b/live-build/misc/ansible-roles/appliance-build.minimal-internal/tasks/main.yml
@@ -20,3 +20,7 @@
     mode: 0644
     content: |
       datasource_list: [ Ec2, None ]
+      datasource:
+        Ec2:
+          timeout: 10
+          max_wait: 24


### PR DESCRIPTION
Now that we're using the cloud-init EC2 datasource for our internal VM
artifacts, this adds roughly 100 seconds of additional latency to our
boot time (i.e. the time until ssh is available) for VMs not running in
EC2. This is because the default timeout is 50 seconds, and cloud-init
will attempt to contact 2 endpoints, waiting 50 seconds for each.

This change reduces this timeout to 10 seconds, reducing the total
additional boot time latency to roughly 20 seconds (when not running in
EC2). Further, the max_wait time was reduced to 24 seconds, to maintain
the same ratio of timeout to max_wait time as before (the default
max_wait is 120).