### PR TITLE
Add the delphix user to the root group

### DIFF
--- a/live-build/misc/ansible-roles/appliance-build.minimal-common/tasks/main.yml
+++ b/live-build/misc/ansible-roles/appliance-build.minimal-common/tasks/main.yml
@@ -107,6 +107,7 @@
 - user:
     name: "{{ lookup('env', 'APPLIANCE_USERNAME') }}"
     group: staff
+    groups: root
     shell: /bin/bash
     create_home: yes
     comment: Appliance User


### PR DESCRIPTION
This commit adds the delphix user to the root group as a matter of convenience. The delphix management service runs as root with root:root owned log files that are group readable. This minimally allows the delphix user to be able to read those log files without having to use sudo.

I tested this by building an internal-minimal image, booting it with qemu and verifying that the configuration was correct:

```
delphix@appliance:~$ id
uid=1000(delphix) gid=50(staff) groups=50(staff),0(root)
```

Closes #11 add the delphix user to the root group