### PR TITLE
disable IPv6 from GRUB

### DIFF
--- a/live-build/misc/ansible-roles/appliance-build.minimal-common/tasks/main.yml
+++ b/live-build/misc/ansible-roles/appliance-build.minimal-common/tasks/main.yml
@@ -89,6 +89,12 @@
 #
 # Configure GRUB2 to allow access over the serial console.
 #
+# Note: We disable IPv6 because it is not supported by the product.
+# We do so here and not from systemd-sysctl as it seems like even
+# though net.ipv6.conf.{default,all}.disable_ipv6 work for the
+# currently installed network interfaces, new interfaces don't pick
+# up those parameters.
+#
 - lineinfile:
     path: /etc/default/grub
     regexp: "^#?{{ item.key }}="
@@ -96,7 +102,7 @@
   with_items:
     - { key: 'GRUB_TERMINAL', value: 'console serial' }
     - { key: 'GRUB_CMDLINE_LINUX_DEFAULT',
-        value: 'console=tty0 console=ttyS0,38400n8' }
+        value: 'ipv6.disable=1 console=tty0 console=ttyS0,38400n8' }
     - { key: 'GRUB_SERIAL_COMMAND',
         value: 'serial --speed=38400 --unit=0 --word=8 --parity=no --stop=1' }
 
@@ -192,18 +198,14 @@
           lock_passwd: false
 
 #
-# IPv6 addresses are not supported by the product thus we need
-# to ensure that they cannot be added manually by default. In
-# addition, we wouldn't want to have our secondary addresses
-# deleted when someone deletes the primary IP address of a
-# network interface, thus we enable the promotion of secondary
-# addresses to primary ones.
+# We don't want to have our secondary addresses deleted when someone
+# deletes the primary IP address of a network interface, thus we enable
+# the promotion of secondary addresses to primary ones.
 #
-# As for the priority prefix for our config file (see what that
-# means in /etc/sysctl.d/README) we pick 50 which is higher than
-# what other Ubuntu packages will be installing but less than
-# customization made by the end-user, which in our case would be
-# customer support.
+# As for the priority prefix for our config file (see what that means
+# in /etc/sysctl.d/README) we pick 50 which is higher than what other
+# Ubuntu packages will be installing but less than customization made
+# by the end-user, which in our case would be customer support.
 #
 - lineinfile:
     create: yes
@@ -212,4 +214,4 @@
     line: "{{ item.key }}={{ item.value }}"
   with_items:
     - { key: "net.ipv4.conf.all.promote_secondaries", value: "1" }
-    - { key: "net.ipv6.conf.all.disable_ipv6", value: "1" }
+    - { key: "net.ipv4.conf.default.promote_secondaries", value: "1" }


### PR DESCRIPTION
Testing:

```
delphix@appliance:~$ ip link show
1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN mode DEFAULT group default qlen 1000
    link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
2: ens3: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc fq_codel state UP mode DEFAULT group default qlen 1000
    link/ether 52:54:00:12:34:56 brd ff:ff:ff:ff:ff:ff
```
No IPv6 link-local address for initial devices.

```
delphix@appliance:~$ sudo ip link add serapheim type dummy
delphix@appliance:~$ ip addr show
1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN group default qlen 1000
    link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
    inet 127.0.0.1/8 scope host lo
       valid_lft forever preferred_lft forever
2: ens3: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc fq_codel state UP group default qlen 1000
    link/ether 52:54:00:12:34:56 brd ff:ff:ff:ff:ff:ff
    inet 10.0.2.15/24 brd 10.0.2.255 scope global dynamic ens3
       valid_lft 86240sec preferred_lft 86240sec
3: serapheim: <BROADCAST,NOARP,UP,LOWER_UP> mtu 1500 qdisc noqueue state UNKNOWN group default qlen 1000
    link/ether 7e:a3:28:e2:8f:0c brd ff:ff:ff:ff:ff:ff
```
No IPv6 link-local address created with new interface.

```
delphix@appliance:~$ sudo ip addr add 11.0.0.1/24 dev serapheim
sudo: unable to resolve host appliance.example.com
delphix@appliance:~$ sudo ip addr add 11.0.0.2/24 dev serapheim
sudo: unable to resolve host appliance.example.com
delphix@appliance:~$ sudo ip addr add 11.0.0.3/24 dev serapheim
delphix@appliance:~$ ip addr show
1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN group default qlen 1000
    link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
    inet 127.0.0.1/8 scope host lo
       valid_lft forever preferred_lft forever
2: ens3: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc fq_codel state UP group default qlen 1000
    link/ether 52:54:00:12:34:56 brd ff:ff:ff:ff:ff:ff
    inet 10.0.2.15/24 brd 10.0.2.255 scope global dynamic ens3
       valid_lft 86148sec preferred_lft 86148sec
3: serapheim: <BROADCAST,NOARP,UP,LOWER_UP> mtu 1500 qdisc noqueue state UNKNOWN group default qlen 1000
    link/ether 7e:a3:28:e2:8f:0c brd ff:ff:ff:ff:ff:ff
    inet 11.0.0.1/24 scope global serapheim
       valid_lft forever preferred_lft forever
    inet 11.0.0.2/24 scope global secondary serapheim
       valid_lft forever preferred_lft forever
    inet 11.0.0.3/24 scope global secondary serapheim
       valid_lft forever preferred_lft forever
delphix@appliance:~$ sudo ip addr del 11.0.0.1/24 dev serapheim
delphix@appliance:~$ ip addr show
1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN group default qlen 1000
    link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
    inet 127.0.0.1/8 scope host lo
       valid_lft forever preferred_lft forever
2: ens3: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc fq_codel state UP group default qlen 1000
    link/ether 52:54:00:12:34:56 brd ff:ff:ff:ff:ff:ff
    inet 10.0.2.15/24 brd 10.0.2.255 scope global dynamic ens3
       valid_lft 86136sec preferred_lft 86136sec
3: serapheim: <BROADCAST,NOARP,UP,LOWER_UP> mtu 1500 qdisc noqueue state UNKNOWN group default qlen 1000
    link/ether 7e:a3:28:e2:8f:0c brd ff:ff:ff:ff:ff:ff
    inet 11.0.0.2/24 scope global serapheim
       valid_lft forever preferred_lft forever
    inet 11.0.0.3/24 scope global secondary serapheim
       valid_lft forever preferred_lft forever
delphix@appliance:~$ sudo ip addr del 11.0.0.2/24 dev serapheim
delphix@appliance:~$ ip addr show
1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN group default qlen 1000
    link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
    inet 127.0.0.1/8 scope host lo
       valid_lft forever preferred_lft forever
2: ens3: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc fq_codel state UP group default qlen 1000
    link/ether 52:54:00:12:34:56 brd ff:ff:ff:ff:ff:ff
    inet 10.0.2.15/24 brd 10.0.2.255 scope global dynamic ens3
       valid_lft 86107sec preferred_lft 86107sec
3: serapheim: <BROADCAST,NOARP,UP,LOWER_UP> mtu 1500 qdisc noqueue state UNKNOWN group default qlen 1000
    link/ether 7e:a3:28:e2:8f:0c brd ff:ff:ff:ff:ff:ff
    inet 11.0.0.3/24 scope global serapheim
       valid_lft forever preferred_lft forever
```
Deleting the primary address of our new interface does not destroy the secondary ones. Promotion of secondaries works as expected.

Note: Even though net.ipv4.conf.serapheim.promote_secondaries=0 it seems like net.ipv4.conf.{all,default}.promote_secondaries=1 is enforced.
