### PR TITLE
Use "--enable-debuginfo" when building SPL and ZFS

### DIFF
--- a/live-build/misc/ansible-roles/appliance-build.install-delphix-zfs-packages/tasks/main.yml
+++ b/live-build/misc/ansible-roles/appliance-build.install-delphix-zfs-packages/tasks/main.yml
@@ -24,7 +24,7 @@
 # compile the ZFS on Linux repositories from source, and install the
 # resultant build artifacts. Below is the logic to that work.
 #
-- shell: "sh autogen.sh && ./configure --prefix= && make"
+- shell: "sh autogen.sh && ./configure --enable-debuginfo --prefix= && make"
   args:
     chdir: "/export/home/{{ lookup('env', 'APPLIANCE_USERNAME') }}/spl"
     creates: "/export/home/{{ lookup('env', 'APPLIANCE_USERNAME') }}/spl/module/Module.symvers"
@@ -37,7 +37,7 @@
     chdir: "/export/home/{{ lookup('env', 'APPLIANCE_USERNAME') }}/spl"
   when: spl.changed
 
-- shell: "sh autogen.sh && ./configure --prefix= && make"
+- shell: "sh autogen.sh && ./configure --enable-debuginfo --prefix= && make"
   args:
     chdir: "/export/home/{{ lookup('env', 'APPLIANCE_USERNAME') }}/zfs"
     creates: "/export/home/{{ lookup('env', 'APPLIANCE_USERNAME') }}/zfs/module/Module.symvers"


### PR DESCRIPTION
By default, when building linux kernel modules, the compiler is pretty
aggressive when inlining functions, which can make it more difficult to
observe and debug a running system. In the interest of being able to
better debug production systems, this change modifies the configure flags
used when building the SPL and ZFS repositories.

By enabling the "--enable-debuginfo" configure flag, the two repositories
will be compiled using the "-fno-inline" compiler flag, which will make
stack traces and tools that leverage function boundary kprobes more
useful.