### PR TITLE
Add CLA check to bors configuration

### DIFF
--- a/bors.toml
+++ b/bors.toml
@@ -1,3 +1,7 @@
+pr_status = [
+  "license/cla"
+]
+
 status = [
   "continuous-integration/travis-ci/push"
 ]


### PR DESCRIPTION
This change will instruct bors to verify that the CLA has been signed,
prior to allowing a pull request to be merged.