### PR TITLE
Add the inotify-tools package to the base Linux image

### DIFF
--- a/live-build/base/config/package-lists/tools.list.chroot
+++ b/live-build/base/config/package-lists/tools.list.chroot
@@ -27,6 +27,7 @@ emacs
 gdb
 glances
 iftop
+inotify-tools
 procinfo
 sg3-utils
 strace


### PR DESCRIPTION
This commit adds the inotify-tools package to our base Linux image. The
tools (inotifywait and inotifywatch) can be very useful to debug
problems associated with filesystem activity (e.g. creation of a file,
deletion of a file in a directory, etc.).

I tested this by following the README and booting internal-minimal under
qemu. The package was there:

delphix@appliance:~$ inotifywait
No files specified to watch!
delphix@appliance:~$ inotifywatch
No files specified to watch!