### PR TITLE
Remove SPL

### DIFF
--- a/live-build/misc/ansible-roles/appliance-build.install-delphix-zfs-packages/tasks/main.yml
+++ b/live-build/misc/ansible-roles/appliance-build.install-delphix-zfs-packages/tasks/main.yml
@@ -26,19 +26,6 @@
 #
 - shell: "sh autogen.sh && ./configure --enable-debuginfo --prefix= && make"
   args:
-    chdir: "/export/home/{{ lookup('env', 'APPLIANCE_USERNAME') }}/spl"
-    creates: "/export/home/{{ lookup('env', 'APPLIANCE_USERNAME') }}/spl/module/Module.symvers"
-  become: true
-  become_user: "{{ lookup('env', 'APPLIANCE_USERNAME') }}"
-  register: spl
-
-- shell: "make install"
-  args:
-    chdir: "/export/home/{{ lookup('env', 'APPLIANCE_USERNAME') }}/spl"
-  when: spl.changed
-
-- shell: "sh autogen.sh && ./configure --enable-debuginfo --prefix= && make"
-  args:
     chdir: "/export/home/{{ lookup('env', 'APPLIANCE_USERNAME') }}/zfs"
     creates: "/export/home/{{ lookup('env', 'APPLIANCE_USERNAME') }}/zfs/module/Module.symvers"
   become: true

--- a/live-build/misc/ansible-roles/appliance-build.zfsonlinux-development/tasks/main.yml
+++ b/live-build/misc/ansible-roles/appliance-build.zfsonlinux-development/tasks/main.yml
@@ -65,9 +65,6 @@
     - { repo: 'https://github.com/delphix/zfs.git',
         version: master,
         dest: zfs }
-    - { repo: 'https://github.com/delphix/spl.git',
-        version: master,
-        dest: spl }
 
 - file:
     path: "/export/home/{{ lookup('env', 'APPLIANCE_USERNAME') }}/{{ item }}"
@@ -77,4 +74,3 @@
     recurse: yes
   with_items:
     - zfs
-    - spl


### PR DESCRIPTION
Since the SPL repo has been merged to ZFS, we don't need to build it any
more.  Building the ZFS repo includes SPL.