### PR TITLE
DNS debugging tools and logs

### DIFF
--- a/live-build/base/config/package-lists/tools.list.chroot
+++ b/live-build/base/config/package-lists/tools.list.chroot
@@ -22,6 +22,7 @@
 
 atop
 bpfcc-tools
+dnsutils
 dstat
 emacs
 gdb

--- a/live-build/misc/ansible-roles/appliance-build.minimal-common/tasks/main.yml
+++ b/live-build/misc/ansible-roles/appliance-build.minimal-common/tasks/main.yml
@@ -87,6 +87,23 @@
       Environment=SYSTEMD_LOG_LEVEL=debug
 
 #
+# Similarly to systemd-networkd, we also raise the log level of
+# systemd-resolved.service just in case we ever have to debug DNS
+# issues.
+#
+- file:
+    path: /etc/systemd/system/systemd-resolved.service.d
+    state: directory
+    mode: 0755
+
+- copy:
+    dest: /etc/systemd/system/systemd-resolved.service.d/50-log-level.conf
+    mode: 0644
+    content: |
+      [Service]
+      Environment=SYSTEMD_LOG_LEVEL=debug
+
+#
 # Configure GRUB2 to allow access over the serial console.
 #
 # Note: We disable IPv6 because it is not supported by the product.


### PR DESCRIPTION
new tools:
```
$ dig google.com

; <<>> DiG 9.11.3-1ubuntu1-Ubuntu <<>> google.com
;; global options: +cmd
;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 14310
;; flags: qr rd ra; QUERY: 1, ANSWER: 1, AUTHORITY: 0, ADDITIONAL: 1

;; OPT PSEUDOSECTION:
; EDNS: version: 0, flags:; udp: 65494
;; QUESTION SECTION:
;google.com.			IN	A

;; ANSWER SECTION:
google.com.		213	IN	A	216.58.194.206

;; Query time: 22 msec
;; SERVER: 10.0.2.3#53(10.0.2.3)
;; WHEN: Wed May 30 17:39:39 UTC 2018
;; MSG SIZE  rcvd: 55

$ nslookup google.com
Server:		10.0.2.3
Address:	10.0.2.3#53

Non-authoritative answer:
Name:	google.com
Address: 216.58.194.206
Name:	google.com
Address: 2607:f8b0:4005:805::200e
```

Without debug info:
```
...
-- Reboot --
May 30 16:38:32 appliance systemd[1]: Starting Network Name Resolution...
May 30 16:38:32 appliance systemd-resolved[1366]: Positive Trust Anchors:
May 30 16:38:32 appliance systemd-resolved[1366]: . IN DS 19036 8 2 49aac11d7b6f6446702e54a1607371607a1a41855200fd2ce1cdde32f24e8fb5
May 30 16:38:32 appliance systemd-resolved[1366]: . IN DS 20326 8 2 e06d44b80b8f1d39a95c0b0d7c65d08458e880409bbc683457104237c7f8ec8d
May 30 16:38:32 appliance systemd-resolved[1366]: Negative trust anchors: 10.in-addr.arpa 16.172.in-addr.arpa 17.172.in-addr.arpa 18.172.in-addr.arpa 19.172.in-addr.arpa 20.172.in-addr
May 30 16:38:32 appliance systemd-resolved[1366]: Using system hostname 'appliance'.
May 30 16:38:32 appliance systemd[1]: Started Network Name Resolution.
```

With debug info:
```
...
-- Reboot --
May 30 17:40:30 appliance systemd[1]: Starting Network Name Resolution...
May 30 17:40:30 appliance systemd-resolved[1434]: Positive Trust Anchors:
May 30 17:40:30 appliance systemd-resolved[1434]: . IN DS 19036 8 2 49aac11d7b6f6446702e54a1607371607a1a41855200fd2ce1cdde32f24e8fb5
May 30 17:40:30 appliance systemd-resolved[1434]: . IN DS 20326 8 2 e06d44b80b8f1d39a95c0b0d7c65d08458e880409bbc683457104237c7f8ec8d
May 30 17:40:30 appliance systemd-resolved[1434]: Negative trust anchors: 10.in-addr.arpa 16.172.in-addr.arpa 17.172.in-addr.arpa 18.172.in-addr.arpa 19.172.in-addr.arpa 20.172.in-addr.arpa 21.172.in-addr.arpa 22.172.in-addr.arpa 23.172.in-addr.arpa 24.172.in-addr.arpa 25.172.in-addr.arpa 26.172.in-addr.arpa 27.172.in-addr.arpa 28.172.in-addr.arpa 29.172.in-addr.arpa 30.172.in-addr.arpa 31.172.in-addr.arpa 168.192.in-addr.arpa d.f.ip6.arpa corp home internal intranet lan local private test
May 30 17:40:30 appliance systemd-resolved[1434]: Using system hostname 'appliance'.
May 30 17:40:30 appliance systemd-resolved[1434]: New scope on link *, protocol dns, family *
May 30 17:40:30 appliance systemd-resolved[1434]: Found new link 2/ens160
May 30 17:40:30 appliance systemd-resolved[1434]: Found new link 1/lo
May 30 17:40:30 appliance systemd-resolved[1434]: New scope on link ens160, protocol dns, family *
May 30 17:40:30 appliance systemd-resolved[1434]: Bus n/a: changing state UNSET → OPENING
May 30 17:40:30 appliance systemd-resolved[1434]: Added inotify watch for /run on bus n/a: 2
May 30 17:40:30 appliance systemd-resolved[1434]: Added inotify watch for /run/dbus on bus n/a: -1
May 30 17:40:30 appliance systemd-resolved[1434]: Bus n/a: changing state OPENING → WATCH_BIND
May 30 17:40:30 appliance systemd-resolved[1434]: Creating stub listener using UDP/TCP.
May 30 17:40:30 appliance systemd[1]: Started Network Name Resolution.
May 30 17:40:30 appliance systemd-resolved[1434]: Got inotify event on bus n/a.
May 30 17:40:30 appliance systemd-resolved[1434]: Added inotify watch for /run on bus n/a: 2
May 30 17:40:30 appliance systemd-resolved[1434]: Added inotify watch for /run/dbus on bus n/a: -1
May 30 17:40:30 appliance systemd-resolved[1434]: Got inotify event on bus n/a.
May 30 17:40:30 appliance systemd-resolved[1434]: Added inotify watch for /run on bus n/a: 2
May 30 17:40:30 appliance systemd-resolved[1434]: Added inotify watch for /run/dbus on bus n/a: -1
May 30 17:40:30 appliance systemd-resolved[1434]: Got inotify event on bus n/a.
May 30 17:40:30 appliance systemd-resolved[1434]: Added inotify watch for /run on bus n/a: 2
May 30 17:40:30 appliance systemd-resolved[1434]: Added inotify watch for /run/dbus on bus n/a: -1
May 30 17:40:31 appliance systemd-resolved[1434]: Got inotify event on bus n/a.
May 30 17:40:31 appliance systemd-resolved[1434]: Added inotify watch for /run on bus n/a: 2
May 30 17:40:31 appliance systemd-resolved[1434]: Added inotify watch for /run/dbus on bus n/a: -1
May 30 17:40:56 appliance systemd-resolved[1434]: Got inotify event on bus n/a.
May 30 17:40:56 appliance systemd-resolved[1434]: Bus n/a: changing state WATCH_BIND → AUTHENTICATING
May 30 17:40:56 appliance systemd-resolved[1434]: Bus n/a: changing state AUTHENTICATING → HELLO
May 30 17:40:56 appliance systemd-resolved[1434]: Sent message type=method_call sender=n/a destination=org.freedesktop.DBus path=/org/freedesktop/DBus interface=org.freedesktop.DBus member=Hello cookie=1 reply_cookie=0 signature=n/a error-name=n/a error-message=n/a
May 30 17:40:56 appliance systemd-resolved[1434]: Sent message type=method_call sender=n/a destination=org.freedesktop.DBus path=/org/freedesktop/DBus interface=org.freedesktop.DBus member=RequestName cookie=2 reply_cookie=0 signature=su error-name=n/a error-message=n/a
May 30 17:40:56 appliance systemd-resolved[1434]: Sent message type=method_call sender=n/a destination=org.freedesktop.DBus path=/org/freedesktop/DBus interface=org.freedesktop.DBus member=AddMatch cookie=3 reply_cookie=0 signature=s error-name=n/a error-message=n/a
May 30 17:40:56 appliance systemd-resolved[1434]: Got message type=method_return sender=org.freedesktop.DBus destination=:1.2 path=n/a interface=n/a member=n/a cookie=1 reply_cookie=1 signature=s error-name=n/a error-message=n/a
May 30 17:40:56 appliance systemd-resolved[1434]: Bus n/a: changing state HELLO → RUNNING
May 30 17:40:56 appliance systemd-resolved[1434]: Got message type=signal sender=org.freedesktop.DBus.Local destination=n/a path=/org/freedesktop/DBus/Local interface=org.freedesktop.DBus.Local member=Connected cookie=4294967295 reply_cookie=0 signature=n/a error-name=n/a error-message=n/a
May 30 17:40:56 appliance systemd-resolved[1434]: Got message type=signal sender=org.freedesktop.DBus destination=:1.2 path=/org/freedesktop/DBus interface=org.freedesktop.DBus member=NameAcquired cookie=2 reply_cookie=0 signature=s error-name=n/a error-message=n/a
May 30 17:40:56 appliance systemd-resolved[1434]: Got message type=signal sender=org.freedesktop.DBus destination=:1.2 path=/org/freedesktop/DBus interface=org.freedesktop.DBus member=NameAcquired cookie=3 reply_cookie=0 signature=s error-name=n/a error-message=n/a
May 30 17:40:56 appliance systemd-resolved[1434]: Got message type=method_return sender=org.freedesktop.DBus destination=:1.2 path=n/a interface=n/a member=n/a cookie=4 reply_cookie=2 signature=u error-name=n/a error-message=n/a
May 30 17:40:56 appliance systemd-resolved[1434]: Successfully acquired requested service name.
May 30 17:40:56 appliance systemd-resolved[1434]: Got message type=method_return sender=org.freedesktop.DBus destination=:1.2 path=n/a interface=n/a member=n/a cookie=5 reply_cookie=3 signature=n/a error-name=n/a error-message=n/a
May 30 17:40:56 appliance systemd-resolved[1434]: Match type='signal',sender='org.freedesktop.login1',path='/org/freedesktop/login1',interface='org.freedesktop.login1.Manager',member='PrepareForSleep' successfully installed.
```
