### PR TITLE
SPL has been merged into ZFS

### DIFF
--- a/live-build/misc/ansible-roles/appliance-build.install-delphix-zfs-packages/tasks/main.yml
+++ b/live-build/misc/ansible-roles/appliance-build.install-delphix-zfs-packages/tasks/main.yml
@@ -26,19 +26,6 @@
 #
 - shell: "sh autogen.sh && ./configure --enable-debuginfo --prefix= && make"
   args:
-    chdir: "/export/home/{{ lookup('env', 'APPLIANCE_USERNAME') }}/spl"
-    creates: "/export/home/{{ lookup('env', 'APPLIANCE_USERNAME') }}/spl/module/Module.symvers"
-  become: true
-  become_user: "{{ lookup('env', 'APPLIANCE_USERNAME') }}"
-  register: spl
-
-- shell: "make install"
-  args:
-    chdir: "/export/home/{{ lookup('env', 'APPLIANCE_USERNAME') }}/spl"
-  when: spl.changed
-
-- shell: "sh autogen.sh && ./configure --enable-debuginfo --prefix= && make"
-  args:
     chdir: "/export/home/{{ lookup('env', 'APPLIANCE_USERNAME') }}/zfs"
     creates: "/export/home/{{ lookup('env', 'APPLIANCE_USERNAME') }}/zfs/module/Module.symvers"
   become: true
@@ -50,6 +37,11 @@
     chdir: "/export/home/{{ lookup('env', 'APPLIANCE_USERNAME') }}/zfs"
   when: zfs.changed
 
+#
+# We need to remove the ZFS and SPL modules that are bundled with the Ubuntu
+# kernel so that they do not conflict with the ZFS module that we install.
+# We use dpkg-divert instead of rm so that dpkg is aware of our changes.
+#
 - shell: |
     VERSION=$(ls -1d /lib/modules/* | xargs basename)
     find /lib/modules/$VERSION/kernel/zfs \

--- a/live-build/misc/ansible-roles/appliance-build.zfsonlinux-development/tasks/main.yml
+++ b/live-build/misc/ansible-roles/appliance-build.zfsonlinux-development/tasks/main.yml
@@ -55,26 +55,16 @@
   delay: 60
 
 - git:
-    repo: "{{ item.repo }}"
+    repo: "https://github.com/delphix/zfs.git"
     dest:
-      "/export/home/{{ lookup('env', 'APPLIANCE_USERNAME') }}/{{ item.dest }}"
-    version: "{{ item.version }}"
+      "/export/home/{{ lookup('env', 'APPLIANCE_USERNAME') }}/zfs"
+    version: master
     accept_hostkey: yes
     update: no
-  with_items:
-    - { repo: 'https://github.com/delphix/zfs.git',
-        version: master,
-        dest: zfs }
-    - { repo: 'https://github.com/delphix/spl.git',
-        version: master,
-        dest: spl }
 
 - file:
-    path: "/export/home/{{ lookup('env', 'APPLIANCE_USERNAME') }}/{{ item }}"
+    path: "/export/home/{{ lookup('env', 'APPLIANCE_USERNAME') }}/zfs"
     owner: "{{ lookup('env', 'APPLIANCE_USERNAME') }}"
     group: staff
     state: directory
     recurse: yes
-  with_items:
-    - zfs
-    - spl


### PR DESCRIPTION
As SPL has been merged into the ZFS repo, we now only need to `make install` inside ZFS. No other changes are required.

**Testing**

Ran appliance-build: http://collins.d.delphix.com:32423/job/devops-gate/job/projects/job/dx4linux/job/appliance-build/job/master/job/post-push/2/console

Loaded the bits in qemu on a `bootstrap-18-04` dcoa system and verified that it still boots and that basic ZFS commands work. I've also verified that the image is indeed running the bits from https://github.com/delphix/zfs/pull/8 by temporarily modifying the ZFS repo in `appliance-build.zfsonlinux-development/tasks/main.yml`