### PR TITLE
LX-151 rsync service

### DIFF
--- a/live-build/misc/ansible-roles/appliance-build.virtualization-common/tasks/main.yml
+++ b/live-build/misc/ansible-roles/appliance-build.virtualization-common/tasks/main.yml
@@ -82,3 +82,13 @@
 
     systemctl enable /opt/delphix/server/systemd/unit/delphix-postgres@.service
     systemctl enable /opt/delphix/server/systemd/unit/delphix-mgmt.service
+
+#
+# In order for the rsync systemd service to start, it needs a config file.
+# Here we configure the port with its default value.
+#
+- copy:
+    dest: /etc/rsyncd.conf
+    mode: 0644
+    content: |
+      port = 873


### PR DESCRIPTION
### Background
On Illumos, we explicitly created our own `rsync` `smf` service and used an `rsync` binary checked into the app-gate repository. However, we don't appear to be doing any real customization to `rsync` so I thought it would be cleaner to just use the existing Ubuntu `rsync` binary and `systemd` service rather than replacing them with effectively identical versions.

The default `rsync.service` is already wanted by `multi-user`, and it the only thing it's missing to start up is the config file. I added the `port` specification in the config file because, even though 873 is the default value, I wanted to make it clear where it's specified - similar to what we do on Illumos in `delphix_rsync.xml`.

One thing to note is that linux's `rsync.service` file passes `--no-detach` when invoking `rsync` and I'm not sure yet whether we want that for delphix or not. 
 
### Testing
Created the image, logged in, checked that the `/etc/rsyncd.conf` had been created with the expected contents and that the `rsync` daemon service had successfully started.  
