### PR TITLE
LX-1039 enable auditd on linux

### DIFF
--- a/live-build/base/config/package-lists/minimal.list.chroot
+++ b/live-build/base/config/package-lists/minimal.list.chroot
@@ -42,3 +42,4 @@ net-tools
 open-vm-tools
 openssh-server
 ubuntu-minimal
+auditd

--- a/live-build/misc/ansible-roles/appliance-build.minimal-common/tasks/main.yml
+++ b/live-build/misc/ansible-roles/appliance-build.minimal-common/tasks/main.yml
@@ -233,3 +233,36 @@
   with_items:
     - { key: "net.ipv4.conf.all.promote_secondaries", value: "1" }
     - { key: "net.ipv4.conf.default.promote_secondaries", value: "1" }
+
+#
+# Configure command audit logging
+#
+# We want to record all commands executed on the appliance. Opt out for
+# setsid since all ExecuteUtils.execute wrap each call with setsid.
+#
+# Note we can't use the "service" module, as that fails when running
+# inside the chroot environment, so we enable auditd using "command".
+#
+- command: systemctl enable auditd.service
+
+- lineinfile:
+    dest: /etc/audit/auditd.conf
+    regexp: "{{ item.regex }}"
+    line: "{{ item.line }}"
+  with_items:
+    - { regex: "^num_logs =", line: "num_logs = 6" }
+    - { regex: "^max_log_file =", line: "max_log_file = 3072" }
+    - { regex: "^max_log_file_action =", line: "max_log_file_action = rotate" }
+    - { regex: "^log_format =", line: "log_format = RAW" }
+
+- blockinfile:
+    path: /etc/audit/rules.d/audit.rules
+    insertafter: EOF
+    block: |
+      ## Record all executed commands (excluding setsid)
+      -a exit,never -S execve -F exe=/usr/bin/setsid
+      -a exit,always -S execve
+
+      ## Record command exit failures (execve result is not command result)
+      -a exit,always -F a0!=0 -S exit_group
+      -a exit,always -F a0!=0 -S exit


### PR DESCRIPTION
Install the `auditd` package as part of the _minimal-common_ ansible role. Update the `/etc/audit/` config parameters for log rotation and add rules for recording all commands that are executed (i.e. via execve).

**Testing**
Booted  the build artifacts with QEMU and verified in the console that `auditd` was installed and that the config files were updated as expected.  Also used `ausearch(8)` and `aureport(8)` tools to confirm that command auditing is occurring.