### PR TITLE
Bump RAM size for OVA from 7GB to 8GB

### DIFF
--- a/live-build/misc/live-build-hooks/92-ova-machine-image.binary
+++ b/live-build/misc/live-build-hooks/92-ova-machine-image.binary
@@ -38,7 +38,7 @@ source /usr/share/livecd-rootfs/live-build/functions
 case "$APPLIANCE_VARIANT" in
 internal-*)
 	CPUS_COUNT=2
-	MEMORY_MB=$((7 * 1024))
+	MEMORY_MB=$((8 * 1024))
 	;;
 external-*)
 	CPUS_COUNT=8


### PR DESCRIPTION
We often run into OOM issues with our current OVA configuration when
running our automated integration tests. This change is an attempt to
alleviate that issue, by increasing the amount of memory allocated to
the OVA, from 7GB to 8GB (~15% increase).