### PR TITLE
Fetch masking packages from master prefix

### DIFF
--- a/scripts/run-live-build.sh
+++ b/scripts/run-live-build.sh
@@ -86,12 +86,11 @@ if ! [[ -n "$CI" && -n "$TRAVIS" ]]; then
 	#
 
 	BUCKET="snapshot-de-images"
-	GITBRANCH="projects/dx4linux"
 	JENKINSID="jenkins-ops"
 
 	if [[ -z "$AWS_S3_PREFIX_VIRTUALIZATION" ]]; then
 		URI="s3://$BUCKET/builds/$JENKINSID/dlpx-app-gate/"
-		URI+="$GITBRANCH/build-package/post-push/latest"
+		URI+="projects/dx4linux/build-package/post-push/latest"
 
 		aws s3 cp "$URI" .
 		AWS_S3_PREFIX_VIRTUALIZATION=$(cat latest)
@@ -102,7 +101,7 @@ if ! [[ -n "$CI" && -n "$TRAVIS" ]]; then
 
 	if [[ -z "$AWS_S3_PREFIX_MASKING" ]]; then
 		URI="s3://$BUCKET/builds/$JENKINSID/dms-core-gate/"
-		URI+="$GITBRANCH/build-package/post-push/latest"
+		URI+="master/build-package/post-push/latest"
 
 		aws s3 cp "$URI" .
 		AWS_S3_PREFIX_MASKING=$(cat latest)


### PR DESCRIPTION
The masking packages are now built from master rather than the project branch, so fetch them from there instead.

I didn't test this but verified that [this job](http://ops.jenkins.delphix.com/job/dms-core-gate/job/master/job/build-package/job/post-push/1/consoleFull) was in fact publishing to the `master` prefix:

```
10:55:36 [distributions] Running shell script
10:55:37 + aws s3 sync --delete --only-show-errors . s3://snapshot-de-images/builds/jenkins-ops/dms-core-gate/master/build-package/post-push/1
[Pipeline] writeFile
[Pipeline] sh
10:55:46 [distributions] Running shell script
10:55:46 + aws s3 cp latest s3://snapshot-de-images/builds/jenkins-ops/dms-core-gate/master/build-package/post-push/latest
10:55:46 Completed 65 Bytes/65 Bytes (599 Bytes/s) with 1 file(s) remaining
upload: ./latest to s3://snapshot-de-images/builds/jenkins-ops/dms-core-gate/master/build-package/post-push/latest
```