### PR TITLE
LX-1098 Add swap device to engine

### DIFF
--- a/bootstrap/roles/appliance-build.bootstrap/tasks/main.yml
+++ b/bootstrap/roles/appliance-build.bootstrap/tasks/main.yml
@@ -24,6 +24,7 @@
   with_items:
     - docker.io
     - python3-docker
+    - zfsutils-linux
 
 - docker_image:
     path: "{{ toplevel.stdout }}/docker"

--- a/live-build/misc/live-build-hooks/90-raw-disk-image.binary
+++ b/live-build/misc/live-build-hooks/90-raw-disk-image.binary
@@ -115,6 +115,15 @@ zfs mount rpool/ROOT/ubuntu
 rsync --info=stats3 -Wa binary/* /mnt/
 
 #
+# Set up a swap device.
+#
+zfs create -V 4G -b "$(getconf PAGESIZE)" \
+	-o logbias=throughput -o sync=always \
+	-o primarycache=metadata rpool/swap
+mkswap -f /dev/zvol/rpool/swap
+echo /dev/zvol/rpool/swap none swap defaults 0 0 >>/mnt/etc/fstab
+
+#
 # Now we need to install the bootloader. In order to do that, we'll chroot
 # into the newly populated root filesystem, so that we use the grub-install
 # and update-grub binaries installed in that filesystem.  Additionally, we


### PR DESCRIPTION
This patch adds a swap device to the engine early in the build process. We create the zvol with appropriate configuration and add it to the new machine's /etc/fstab file. In order to format the device, the /dev/zvol pseudo-device needs to exist. However, that device only exists if the bootstrap machine (not the docker container) has the zfsutils package installed. To solve this, an ansible playbook and task were added, which should be executed by the automation to install the package.  Finally, when we've finished the build we have to stop the zed service in order to unload the zfs kernel modules.