### PR TITLE
Building zfs kernel modules requires libelf-dev

### DIFF
--- a/live-build/misc/ansible-roles/appliance-build.zfsonlinux-development/tasks/main.yml
+++ b/live-build/misc/ansible-roles/appliance-build.zfsonlinux-development/tasks/main.yml
@@ -39,6 +39,7 @@
     - ksh
     - libattr1-dev
     - libblkid-dev
+    - libelf-dev
     - libselinux-dev
     - libssl-dev
     - libtool


### PR DESCRIPTION
libelf-dev is a new dependency for building kernel modules. Note that it doesn't fail the build, but generates warnings.

{noformat}
18:11:39 /usr/bin/make -C /usr/src/linux-headers-4.15.0-23-generic SUBDIRS=`pwd`  CONFIG_DEBUG_INFO=y CONFIG_ZFS=m modules
18:11:39 make[2]: Entering directory '/usr/src/linux-headers-4.15.0-23-generic'
18:11:40 Makefile:976: "Cannot use CONFIG_STACK_VALIDATION=y, please install libelf-dev, libelf-devel or elfutils-libelf-devel"
{noformat}

This change removes those warnings from git-zfs-make. Similar changes are done in the zfs-package-build job in LX-1106.