### PR TITLE
Docker image not rebuilt when testing locally even if Dockerfile changed

### DIFF
--- a/bootstrap/roles/appliance-build.bootstrap/tasks/main.yml
+++ b/bootstrap/roles/appliance-build.bootstrap/tasks/main.yml
@@ -29,6 +29,7 @@
 - docker_image:
     path: "{{ toplevel.stdout }}/docker"
     name: appliance-build
+    force: true
 
 - modprobe:
     name: zfs


### PR DESCRIPTION
When testing locally, the docker image will be generated the first time `ansible-playbook bootstrap/playbook.yml` is run. When the Dockerfile is changed, we want to be able to re-run `ansible-playbook bootstrap/playbook.yml` to rebuild the image. Unfortunately the `docker_image` ansible plugin only looks if the docker image with a given name exists, and won't rebuild it. We add a flag to rebuild it every time.

**Testing**
Tested by running `ansible-playbook bootstrap/playbook.yml` locally.