### PR TITLE
Allow checking format of scripts locally with: "make checks"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,10 @@ ALL_VARIANTS = $(shell find live-build/variants -maxdepth 1 -mindepth 1 -exec ba
 ALL_INTERNAL = $(shell find live-build/variants -maxdepth 1 -mindepth 1 -name 'internal-*' -exec basename {} \;)
 ALL_EXTERNAL = $(shell find live-build/variants -maxdepth 1 -mindepth 1 -name 'external-*' -exec basename {} \;)
 
+FINDEXEC.Darwin := -perm +111
+FINDEXEC.Linux := -executable
+FINDEXEC := $(FINDEXEC.$(shell uname -s))
+
 all-variants: $(ALL_VARIANTS)
 all-internal: $(ALL_INTERNAL)
 all-external: $(ALL_EXTERNAL)
@@ -37,8 +41,8 @@ $(ALL_VARIANTS): base
 
 shellcheck:
 	shellcheck --exclude=SC1091 \
-		$$(find scripts -type f -executable) \
-		$$(find live-build/misc/live-build-hooks -type f -executable)
+		$$(find scripts -type f $(FINDEXEC)) \
+		$$(find live-build/misc/live-build-hooks -type f $(FINDEXEC))
 
 #
 # There doesn't appear to be a way to have "shfmt" return non-zero when
@@ -61,8 +65,10 @@ shellcheck:
 # problematic lines are conveyed to the user so they can be fixed.
 #
 shfmtcheck:
-	! shfmt -d $$(find scripts -type f -executable) \
-		$$(find live-build/misc/live-build-hooks -type f -executable) | grep .
+	! shfmt -d $$(find scripts -type f $(FINDEXEC)) \
+		$$(find live-build/misc/live-build-hooks -type f $(FINDEXEC)) | grep .
 
 ansiblecheck:
 	ansible-lint $$(find bootstrap live-build/variants -name playbook.yml)
+
+check: shellcheck shfmtcheck ansiblecheck

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -45,7 +45,7 @@ RUN \
   rm -rf /var/lib/apt/lists/*
 
 RUN wget -nv -O /usr/local/bin/shfmt \
-  https://github.com/mvdan/sh/releases/download/v2.3.0/shfmt_v2.3.0_linux_amd64 && \
+  https://github.com/mvdan/sh/releases/download/v2.4.0/shfmt_v2.4.0_linux_amd64 && \
   chmod +x /usr/local/bin/shfmt
 
 RUN \

--- a/live-build/misc/live-build-hooks/92-ova-machine-image.binary
+++ b/live-build/misc/live-build-hooks/92-ova-machine-image.binary
@@ -74,7 +74,7 @@ find "$OVA_DIRECTORY" -type f | while read -r file; do
 	NAME=$(basename "$file")
 	HASH=$(sha1sum "$file" | awk '{print $1}')
 	cat <<-EOF >>"$OVA_DIRECTORY/$APPLIANCE_VARIANT.mf"
-	SHA1($NAME)= $HASH
+		SHA1($NAME)= $HASH
 	EOF
 done
 


### PR DESCRIPTION
I've adapted the Makefile's find commands to also work properly under OSX.
We can now run all the checks locally by executing `make checks` without needing a docker container
The prerequisites on OSX is to install shellcheck, shfmt and ansible-lint. This can be done easily with brew:
```
brew install shellcheck shfmt ansible-lint
```
Note that I've also added a small change to `92-ova-machine-image.binary` to make shfmt pass.

**Testing**
I've tested `make checks` on OSX and tested `./scripts/docker-run.sh make checks` on Linux.
I've also confirmed that the format change in `92-ova-machine-image.binary` doesn't affect the contents of the "$OVA_DIRECTORY/$APPLIANCE_VARIANT.mf" file created.