### PR TITLE
LX-1114 Missing utilities causing zfstest failures

### DIFF
--- a/live-build/base/config/package-lists/minimal.list.chroot
+++ b/live-build/base/config/package-lists/minimal.list.chroot
@@ -43,3 +43,10 @@ open-vm-tools
 openssh-server
 ubuntu-minimal
 auditd
+
+#
+# The following packages are required for the ZFS test suite to run
+# properly.
+#
+attr
+bc


### PR DESCRIPTION
The utilities `bc` `attr` and `setfattr` are missing from the build,
in turn causing 28 tests in the suite to fail. After this change,
those tests passed.