### PR TITLE
Label make targets as .PHONY

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,17 @@ FINDEXEC.Darwin := -perm +111
 FINDEXEC.Linux := -executable
 FINDEXEC := $(FINDEXEC.$(shell uname -s))
 
+.PHONY: \
+	all-external \
+	all-internal \
+	all-variants \
+	ansiblecheck \
+	base \
+	check \
+	shellcheck \
+	shfmtcheck \
+	$(ALL_VARIANTS)
+
 all-variants: $(ALL_VARIANTS)
 all-internal: $(ALL_INTERNAL)
 all-external: $(ALL_EXTERNAL)


### PR DESCRIPTION
All of our current make targets are actually "phony targets", since
they're not intended to result in a file of that same target name. See
also: https://www.gnu.org/software/make/manual/make.html#Phony-Targets

This is a simple change to list all of our make targets as ".PHONY".