### PR TITLE
Allow specifying different buckets and prefixes for each s3 component

### DIFF
--- a/live-build/misc/ansible-roles/appliance-build.install-delphix-s3-packages/tasks/main.yml
+++ b/live-build/misc/ansible-roles/appliance-build.install-delphix-s3-packages/tasks/main.yml
@@ -15,25 +15,22 @@
 #
 
 ---
-- fail:
-    msg: "Required variable 'bucket' undefined or empty."
-  when: bucket is undefined or bucket == ''
 
 - fail:
-    msg: "Required variable 'prefix' undefined or empty."
-  when: prefix is undefined or prefix == ''
+    msg: "Required variable 's3uri' undefined or empty."
+  when: s3uri is undefined or s3uri == ''
 
 #
 # We need to download the packages from S3 on the local system running
 # the playbook, because the awscli tools may not be available on the
-# remote system. Once the S3 directory/prefix containing the packages is
+# remote system. Once the S3 directory/uri containing the packages is
 # downloaded, we safely copy them to the remote system, and proceed with
 # the installation.
 #
-# Further, the expectation is for the S3 prefix to contain a directory
+# Further, the expectation is for the S3 uri to contain a directory
 # containing one or more .deb files, as well as a SHA256SUMS file that
 # can be used to verify the contents of the .deb files after the entire
-# S3 prefix is downloaded.
+# S3 uri is downloaded.
 #
 
 - tempfile:
@@ -42,7 +39,7 @@
   register: tempdir
   delegate_to: localhost
 
-- command: aws s3 sync --only-show-errors "s3://{{ bucket }}/{{ prefix }}" .
+- command: aws s3 sync --only-show-errors "{{ s3uri }}" .
   delegate_to: localhost
   args:
     chdir: "{{ tempdir.path }}"

--- a/live-build/misc/ansible-roles/appliance-build.install-delphix-zfs-packages/meta/main.yml
+++ b/live-build/misc/ansible-roles/appliance-build.install-delphix-zfs-packages/meta/main.yml
@@ -17,5 +17,4 @@
 ---
 dependencies:
   - role: appliance-build.install-delphix-s3-packages
-    bucket: "{{ lookup('env', 'AWS_S3_BUCKET') }}"
-    prefix: "{{ lookup('env', 'AWS_S3_PREFIX_ZFS') }}"
+    s3uri: "{{ lookup('env', 'AWS_S3_URI_ZFS') }}"

--- a/live-build/misc/ansible-roles/appliance-build.masking-common/meta/main.yml
+++ b/live-build/misc/ansible-roles/appliance-build.masking-common/meta/main.yml
@@ -18,5 +18,4 @@
 dependencies:
   - role: appliance-build.install-delphix-java8-packages
   - role: appliance-build.install-delphix-s3-packages
-    bucket: "{{ lookup('env', 'AWS_S3_BUCKET') }}"
-    prefix: "{{ lookup('env', 'AWS_S3_PREFIX_MASKING') }}"
+    s3uri: "{{ lookup('env', 'AWS_S3_URI_MASKING') }}"

--- a/live-build/misc/ansible-roles/appliance-build.virtualization-common/meta/main.yml
+++ b/live-build/misc/ansible-roles/appliance-build.virtualization-common/meta/main.yml
@@ -18,5 +18,4 @@
 dependencies:
   - role: appliance-build.install-delphix-java8-packages
   - role: appliance-build.install-delphix-s3-packages
-    bucket: "{{ lookup('env', 'AWS_S3_BUCKET') }}"
-    prefix: "{{ lookup('env', 'AWS_S3_PREFIX_VIRTUALIZATION') }}"
+    s3uri: "{{ lookup('env', 'AWS_S3_URI_VIRTUALIZATION') }}"

--- a/scripts/docker-run.sh
+++ b/scripts/docker-run.sh
@@ -44,7 +44,6 @@ $DOCKER_RUN --rm \
 	--volume /dev:/dev \
 	--env CI \
 	--env TRAVIS \
-	--env AWS_S3_BUCKET \
 	--env AWS_S3_PREFIX_MASKING \
 	--env AWS_S3_PREFIX_VIRTUALIZATION \
 	--env AWS_S3_PREFIX_ZFS \

--- a/scripts/run-live-build.sh
+++ b/scripts/run-live-build.sh
@@ -61,6 +61,43 @@ else
 	cd "$TOP/live-build/variants/$1"
 fi
 
+function get_s3_uri() {
+
+	local def_bucket="snapshot-de-images"
+	local jenkinsid="jenkins-ops"
+
+	local prefix="$1"
+	local latest="s3://$def_bucket/builds/$jenkinsid/$2"
+	local uri
+
+	if [[ -z "$prefix" ]]; then
+		#
+		# prefix is empty, so get latest version
+		#
+		aws s3 cp --quiet "$latest" .
+		prefix=$(cat latest)
+		uri="s3://$def_bucket/$prefix"
+		rm -f latest
+	elif [[ "$prefix" == s3* ]]; then
+		#
+		# prefix was set to full s3 URI: "s3://<bucket>/<prefix>"
+		#
+		uri="$prefix"
+	else
+		#
+		# We assume prefix is inside default bucket
+		#
+		uri="s3://$def_bucket/$prefix"
+	fi
+
+	if aws s3 ls "$uri" >/dev/null; then
+		echo "$uri"
+	else
+		echo "$uri not found." 1>&2
+		exit 1
+	fi
+}
+
 #
 # When performing minimal testing from within Travis CI, we won't have
 # access to the Delphix internal infrastructure. Thus, we want to skip
@@ -85,41 +122,18 @@ if ! [[ -n "$CI" && -n "$TRAVIS" ]]; then
 	# about these details.
 	#
 
-	BUCKET="snapshot-de-images"
-	JENKINSID="jenkins-ops"
+	AWS_S3_URI_VIRTUALIZATION=$(get_s3_uri "$AWS_S3_PREFIX_VIRTUALIZATION" \
+		"dlpx-app-gate/projects/dx4linux/build-package/post-push/latest")
 
-	if [[ -z "$AWS_S3_PREFIX_VIRTUALIZATION" ]]; then
-		URI="s3://$BUCKET/builds/$JENKINSID/dlpx-app-gate/"
-		URI+="projects/dx4linux/build-package/post-push/latest"
+	AWS_S3_URI_MASKING=$(get_s3_uri "$AWS_S3_PREFIX_MASKING" \
+		"dms-core-gate/master/build-package/post-push/latest")
 
-		aws s3 cp "$URI" .
-		AWS_S3_PREFIX_VIRTUALIZATION=$(cat latest)
-		export AWS_S3_PREFIX_VIRTUALIZATION
-		export AWS_S3_BUCKET="snapshot-de-images"
-		rm -f latest
-	fi
+	AWS_S3_URI_ZFS=$(get_s3_uri "$AWS_S3_PREFIX_ZFS" \
+		"devops-gate/projects/dx4linux/zfs-package-build/master/post-push/latest")
 
-	if [[ -z "$AWS_S3_PREFIX_MASKING" ]]; then
-		URI="s3://$BUCKET/builds/$JENKINSID/dms-core-gate/"
-		URI+="master/build-package/post-push/latest"
-
-		aws s3 cp "$URI" .
-		AWS_S3_PREFIX_MASKING=$(cat latest)
-		export AWS_S3_PREFIX_MASKING
-		export AWS_S3_BUCKET="snapshot-de-images"
-		rm -f latest
-	fi
-
-	if [[ -z "$AWS_S3_PREFIX_ZFS" ]]; then
-		URI="s3://$BUCKET/builds/$JENKINSID/devops-gate/"
-		URI+="projects/dx4linux/zfs-package-build/master/post-push/latest"
-
-		aws s3 cp "$URI" .
-		AWS_S3_PREFIX_ZFS=$(cat latest)
-		export AWS_S3_PREFIX_ZFS
-		export AWS_S3_BUCKET="snapshot-de-images"
-		rm -f latest
-	fi
+	export AWS_S3_URI_VIRTUALIZATION
+	export AWS_S3_URI_MASKING
+	export AWS_S3_URI_ZFS
 fi
 
 lb config


### PR DESCRIPTION
Right now, we cannot specify different buckets for the various delphix components fetched from s3. 
This change simplifies what is being passed down to live-build: instead of having separate prefix and bucket components, we pass the s3 url directly.
Note that the jenkins job can still pass us a prefix instead of a full URL, so we make sure that we can still handle that case.

### Testing
Custom ZFS s3 URL: http://ops.jenkins.delphix.com/job/devops-gate/job/projects/job/dx4linux/job/appliance-build/job/master/job/pre-push/60/parameters/ (pass)
git-ab-pre-push: http://ops.jenkins.delphix.com/job/devops-gate/job/projects/job/dx4linux/job/appliance-build/job/master/job/pre-push/59/ (pass)

