### PR TITLE
LX-960 Enable kernel crash dump support

### DIFF
--- a/live-build/base/config/package-lists/minimal.list.chroot
+++ b/live-build/base/config/package-lists/minimal.list.chroot
@@ -42,3 +42,9 @@ net-tools
 open-vm-tools
 openssh-server
 ubuntu-minimal
+
+#
+# The following package contains the GPG keys which allow us to download
+# from the repositories which contain packages containing debug symbols.
+#
+ubuntu-dbgsym-keyring

--- a/live-build/base/config/package-lists/tools.list.chroot
+++ b/live-build/base/config/package-lists/tools.list.chroot
@@ -22,6 +22,7 @@
 
 atop
 bpfcc-tools
+crash
 dnsutils
 dstat
 emacs
@@ -29,6 +30,7 @@ gdb
 glances
 iftop
 inotify-tools
+kdump-tools
 procinfo
 sg3-utils
 strace

--- a/live-build/misc/ansible-roles/appliance-build.minimal-common/tasks/main.yml
+++ b/live-build/misc/ansible-roles/appliance-build.minimal-common/tasks/main.yml
@@ -323,3 +323,41 @@
   with_items:
     - { key: 'kernel.core_pattern', value: '/var/crash/core.%e.%p.%t' }
     - { key: 'vm.overcommit_memory', value: '1' }
+
+#
+# Add the apt repos that have the debug versions of packages, so that we
+# can download a debug kernel to use with crash.
+#
+- apt_repository:
+    repo: "{{ item }}"
+  with_items:
+    - deb http://ddebs.ubuntu.com bionic main restricted universe multiverse
+    - deb http://ddebs.ubuntu.com bionic-updates main restricted universe multiverse
+    - deb http://ddebs.ubuntu.com bionic-proposed main restricted universe multiverse
+  retries: 3
+  delay: 30
+  register: result
+  until: result is succeeded
+
+- shell: ls /boot/vmlinuz-* | sed 's|/boot/vmlinuz-||'
+  register: kernel_version
+
+- apt:
+    name: 'linux-image-{{ item }}-dbgsym'
+  with_items:
+    - '{{ kernel_version.stdout_lines }}'
+  retries: 3
+  delay: 30
+  register: result
+  until: result is succeeded
+
+#
+# Increase the amount of memory reserved for the crash kernel.
+# Empirically, it seems we need about 512M to get it to boot. If the
+# system has less than 1G, disable crash dumps rather than reserving
+# half of memory for the crash kernel.
+#
+- lineinfile:
+    path: /etc/default/grub.d/kdump-tools.cfg
+    regexp: '^GRUB_CMDLINE_LINUX_DEFAULT='
+    line: 'GRUB_CMDLINE_LINUX_DEFAULT="$GRUB_CMDLINE_LINUX_DEFAULT crashkernel=1024M-:512M"'


### PR DESCRIPTION
This adds and configures `kdump` so that we can get crash dumps, and adds `crash` so that we can examine them.

Note that this adds some time to the build, because downloading debug kernel from the Ubuntu repository for debug packages is quite slow (it takes ~15min to download <600MB). Once we start mirroring all of the upstream Ubuntu packages, this should no longer be an issue.

This change requires expanding the size of the disk on the bootstrap vm, which is blocked until the fix for DOAM-786 is deployed. However, I've tested building a single variant, and used qemu to verify that crash dumps are gathered successfully. I'll run `git-ab-pre-push` after the bootstrap golden image is updated.