### PR TITLE
Upgrade to Java 8 update 171

### DIFF
--- a/scripts/build-ancillary-repository.sh
+++ b/scripts/build-ancillary-repository.sh
@@ -94,16 +94,14 @@ function build_delphix_java8_debs() {
 	local pkg_directory="$1"
 
 	local url="http://artifactory.delphix.com/artifactory"
-	local tarfile="jdk-8u131-linux-x64.tar.gz"
-	local jcefile="jce_policy-8.zip"
-	local debfile="oracle-java8-jdk_8u131_amd64.deb"
+	local tarfile="jdk-8u171-linux-x64.tar.gz"
+	local debfile="oracle-java8-jdk_8u171_amd64.deb"
 	local tmp_directory
 
 	tmp_directory=$(mktemp -d -p "$PWD" tmp.java.XXXXXXXXXX)
 	pushd "$tmp_directory" &>/dev/null
 
 	wget -nv "$url/java-binaries/linux/jdk/8/$tarfile" -O "$tarfile"
-	wget -nv "$url/java-binaries/jce/$jcefile" -O "$jcefile"
 
 	#
 	# We must run "make-jpkg" as a non-root user, and then use "fakeroot".
@@ -113,7 +111,7 @@ function build_delphix_java8_debs() {
 	#
 	chown -R nobody:nogroup .
 	runuser -u nobody -- \
-		fakeroot make-jpkg --jce-policy "$jcefile" "$tarfile" <<<y
+		fakeroot make-jpkg "$tarfile" <<<y
 
 	cp "$debfile" "$pkg_directory"
 


### PR DESCRIPTION
Trunk has been already updated to version 171.
We need this to merge with trunk.

### TESTING
http://ops.jenkins.delphix.com/job/devops-gate/job/projects/job/dx4linux/job/appliance-build/job/master/job/pre-push/87/ (passed)