### PR TITLE
The virtualization packages are now built from master rather than the project branch, so fetch them from there instead.

### DIFF
--- a/scripts/build-ancillary-repository.sh
+++ b/scripts/build-ancillary-repository.sh
@@ -171,7 +171,7 @@ function build_ancillary_repository() {
 AWS_S3_URI_VIRTUALIZATION=$(resolve_s3_uri \
 	"$AWS_S3_URI_VIRTUALIZATION" \
 	"$AWS_S3_PREFIX_VIRTUALIZATION" \
-	"dlpx-app-gate/projects/dx4linux/build-package/post-push/latest")
+	"dlpx-app-gate/master/build-package/post-push/latest")
 
 AWS_S3_URI_MASKING=$(resolve_s3_uri \
 	"$AWS_S3_URI_MASKING" \


### PR DESCRIPTION
Pending [TOOL-5988](http://reviews.delphix.com/r/41802/) and [TOOL-5989](http://reviews.delphix.com/r/41803/). I won't push this until I verify that packages are available in S3 with the new prefix.