### PR TITLE
LX-1194 ZFS panics should result in kernel panics

### DIFF
--- a/live-build/misc/ansible-roles/appliance-build.minimal-common/handlers/main.yml
+++ b/live-build/misc/ansible-roles/appliance-build.minimal-common/handlers/main.yml
@@ -1,0 +1,19 @@
+#
+# Copyright 2018 Delphix
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+---
+- shell: update-initramfs -u
+  listen: update initramfs

--- a/live-build/misc/ansible-roles/appliance-build.minimal-common/tasks/main.yml
+++ b/live-build/misc/ansible-roles/appliance-build.minimal-common/tasks/main.yml
@@ -361,3 +361,12 @@
     path: /etc/default/grub.d/kdump-tools.cfg
     regexp: '^GRUB_CMDLINE_LINUX_DEFAULT='
     line: 'GRUB_CMDLINE_LINUX_DEFAULT="$GRUB_CMDLINE_LINUX_DEFAULT crashkernel=1024M-:512M"'
+
+# Panic on ZFS assertion failures
+- lineinfile:
+    path: /etc/modprobe.d/zfs.conf
+    create: yes
+    line: 'options spl spl_panic_halt=1'
+  # Because the spl module is loaded from the initramfs when using zfs on root,
+  # we need to rebuild the initramfs to account for the modprobe.d change.
+  notify: update initramfs


### PR DESCRIPTION
Assertion failures in zfs call `spl_panic`, which by default does not trigger a kernel panic. This change sets the `spl_panic_halt` parameter for the `spl` module so that we will get a kernel panic, and therefore a crash dump, on zfs assertion failures.