### PR TITLE
Appliance does not take advantage of hardware RNGs

### DIFF
--- a/live-build/base/config/package-lists/minimal.list.chroot
+++ b/live-build/base/config/package-lists/minimal.list.chroot
@@ -41,6 +41,7 @@ debsums
 net-tools
 open-vm-tools
 openssh-server
+rng-tools
 ubuntu-minimal
 
 #


### PR DESCRIPTION
"You really, really want to run rngd" – H. Peter Anvin, Linux x86
architecture maintainer, quoted in "LCE: Don't play dice with random
numbers" (https://lwn.net/Articles/525459/)

/dev/random in Linux doesn't take advantage of Intel/AMD hardware RNGs,
leading to entropy exhaustion on EC2 VMs when applications do lots of
reads from /dev/random. In particular, the Oracle JDBC driver is one
such application. So is the Delphix Virtualization application, which
reads /dev/random at startup to create some key. When there isn't enough
entropy, these reads just hang.

The solution is to install the rng-tools package, which sets up the
rngd(8) daemon. This monitors the hardware RNGs and supplies data from
them to the kernel’s entropy pool.

Co-authored-by: Basil Crow <basil.crow@delphix.com>