### PR TITLE
Add "awscli" to virtualization development packages

### DIFF
--- a/live-build/misc/ansible-roles/appliance-build.qa-internal/tasks/main.yml
+++ b/live-build/misc/ansible-roles/appliance-build.qa-internal/tasks/main.yml
@@ -43,6 +43,7 @@
     state: present
   with_items:
     - ant
+    - awscli
     - build-essential
     - git
     - libcrypt-blowfish-dev


### PR DESCRIPTION
This change adds the "awscli" package to the list of virtualization
development dependencies. This makes it easier to download the upgrade
repositories that are generated via Jenkins and stored in AWS S3. These
upgrade repositories are needed for testing our upgrade logic on Linux.