### PR TITLE
Use "--ipc private" with "docker run"

### DIFF
--- a/scripts/docker-run.sh
+++ b/scripts/docker-run.sh
@@ -41,6 +41,7 @@ fi
 $DOCKER_RUN --rm \
 	--privileged \
 	--network host \
+	--ipc "private" \
 	--volume /dev:/dev \
 	--env AWS_S3_PREFIX_MASKING \
 	--env AWS_S3_PREFIX_VIRTUALIZATION \

--- a/scripts/docker-run.sh
+++ b/scripts/docker-run.sh
@@ -41,7 +41,7 @@ fi
 $DOCKER_RUN --rm \
 	--privileged \
 	--network host \
-	--ipc "private" \
+	--ipc "none" \
 	--volume /dev:/dev \
 	--env AWS_S3_PREFIX_MASKING \
 	--env AWS_S3_PREFIX_VIRTUALIZATION \


### PR DESCRIPTION
When running the docker container via the TravisCI automation, we're
seeing the following error:

    docker: Error response from daemon: oci runtime error: container_linux.go:265: starting container process caused "process_linux.go:368: container init caused \"rootfs_linux.go:57: mounting \\\"/var/lib/docker/containers/cf46734cb251f78e84b33e1ce222dbfda6f59b73f102ea0f2a072b327cb3e1af/shm\\\" to rootfs \\\"/var/lib/docker/overlay2/88fa4f0902de66da3647b57c9f5027ec13c4ed8f9a02e4217e39e5b59195119b/merged\\\" at \\\"/dev/shm\\\" caused \\\"evalSymlinksInScope: too many links in /var/lib/docker/overlay2/88fa4f0902de66da3647b57c9f5027ec13c4ed8f9a02e4217e39e5b59195119b/merged/dev/shm\\\"\"".

This change attempts to workaround this problem, by explicitly
specifying the "--ipc private" option to "docker run".