### PR TITLE
Should run apt update before fetching packages

### DIFF
--- a/live-build/misc/live-build-hooks/81-upgrade-repository.binary
+++ b/live-build/misc/live-build-hooks/81-upgrade-repository.binary
@@ -44,6 +44,8 @@ set -o pipefail
 mkdir -p /packages
 cd /packages
 
+apt-get update
+
 dpkg-query -Wf '${Package}=${Version}\n' | xargs apt-get download
 EOF
 


### PR DESCRIPTION
We have a few failures lately, such as:
http://ops.jenkins.delphix.com/job/devops-gate/job/projects/job/dx4linux/job/appliance-build/job/master/job/pre-push/119/console
http://ops.jenkins.delphix.com/job/devops-gate/job/projects/job/dx4linux/job/appliance-build/job/master/job/pre-push/120/console
http://ops.jenkins.delphix.com/job/devops-gate/job/projects/job/dx4linux/job/appliance-build/job/master/job/pre-push/123/console

It could be caused by a failure to update the packages list before running apt-download, or it could be issues with the Ubuntu repository. In any case, `apt update` would be a good thing to have there.

pre-push: http://ops.jenkins.delphix.com/job/devops-gate/job/projects/job/dx4linux/job/appliance-build-orchestrator-pre-push/23/console (passed)