### PR TITLE
LX-1213 Install azure udev rules

### DIFF
--- a/live-build/base/config/package-lists/minimal.list.chroot
+++ b/live-build/base/config/package-lists/minimal.list.chroot
@@ -43,6 +43,7 @@ open-vm-tools
 openssh-server
 rng-tools
 ubuntu-minimal
+walinuxagent
 
 #
 # The following package contains the GPG keys which allow us to download

--- a/live-build/misc/ansible-roles/appliance-build.minimal-common/tasks/main.yml
+++ b/live-build/misc/ansible-roles/appliance-build.minimal-common/tasks/main.yml
@@ -379,3 +379,9 @@
     line: "{{ item.key }}={{ item.value }}"
   with_items:
     - { key: "ChallengeResponseAuthentication", value: "yes" }
+
+#
+# Disable the Linux Azure Agent by default. Later this should be re-enabled on
+# Azure systems.
+#
+- command: systemctl disable walinuxagent.service


### PR DESCRIPTION
This change installs the Azure Linux agent by default as a core dependency but disables its service. We'll eventually want to re-enable the service for Azure VMs, though probably with reduced functionality (configured in `/etc/waagent.conf`). I decided to do this much now because we need the azure specific udev rules that come in this package and we'll need want the agent at some point as well. 

I tested this by running through the live build process and using qemu to check that the image booted properly, had the new udev rules and that `walinuxagent.service` was present but disabled. 