### PR TITLE
LX-194 pam module for linux - phase I (enable PAM module conversations)

### DIFF
--- a/live-build/misc/ansible-roles/appliance-build.minimal-common/tasks/main.yml
+++ b/live-build/misc/ansible-roles/appliance-build.minimal-common/tasks/main.yml
@@ -370,3 +370,11 @@
   # Because the spl module is loaded from the initramfs when using zfs on root,
   # we need to rebuild the initramfs to account for the modprobe.d change.
   notify: update initramfs
+
+# Configure SSH to allow PAM "conversations" (interactions with the user).
+- lineinfile:
+    path: /etc/ssh/sshd_config
+    regexp: "^#?{{ item.key }}="
+    line: "{{ item.key }}={{ item.value }}"
+  with_items:
+    - { key: "ChallengeResponseAuthentication", value: "yes" }


### PR DESCRIPTION
We need to enable PAM "conversations" -- the ability of PAM modules to display errors to the user (e.g. the user is locked out message) and soon also our own CRA interaction. Conversations in `sshd` are enabled via the `ChallengeResponseAuthentication` setting. Currently, `sshd_config` it disabled.

http://ops.jenkins.delphix.com/job/devops-gate/job/projects/job/dx4linux/job/appliance-build-orchestrator-pre-push/42/flowGraphTable/
