### PR TITLE
LX-1179 QA needs nftables installed on Linux DEs

### DIFF
--- a/live-build/misc/ansible-roles/appliance-build.qa-internal/handlers/main.yml
+++ b/live-build/misc/ansible-roles/appliance-build.qa-internal/handlers/main.yml
@@ -1,4 +1,5 @@
 #
+#
 # Copyright 2018 Delphix
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,16 +16,5 @@
 #
 
 ---
-- hosts: all
-  connection: chroot
-  gather_facts: no
-  vars:
-    ansible_python_interpreter: /usr/bin/python3
-  roles:
-    - appliance-build.minimal-common
-    - appliance-build.minimal-internal
-    - appliance-build.masking-common
-    - appliance-build.qa-internal
-    - appliance-build.virtualization-common
-    - appliance-build.virtualization-internal
-    - appliance-build.virtualization-standard
+- command: nft -f /etc/nftables.conf
+  listen: nftables

--- a/live-build/misc/ansible-roles/appliance-build.qa-internal/tasks/main.yml
+++ b/live-build/misc/ansible-roles/appliance-build.qa-internal/tasks/main.yml
@@ -13,6 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+# This file is intended only for QA-specific testing items and frameworks.
+# Anything required by customers should not be added here.
+#
 
 - apt:
     name: "{{ item }}"

--- a/live-build/misc/ansible-roles/appliance-build.qa-internal/tasks/main.yml
+++ b/live-build/misc/ansible-roles/appliance-build.qa-internal/tasks/main.yml
@@ -14,17 +14,20 @@
 # limitations under the License.
 #
 
----
-- hosts: all
-  connection: chroot
-  gather_facts: no
-  vars:
-    ansible_python_interpreter: /usr/bin/python3
-  roles:
-    - appliance-build.minimal-common
-    - appliance-build.minimal-internal
-    - appliance-build.masking-common
-    - appliance-build.qa-internal
-    - appliance-build.virtualization-common
-    - appliance-build.virtualization-internal
-    - appliance-build.virtualization-standard
+- apt:
+    name: "{{ item }}"
+    state: present
+  with_items:
+    - nftables
+  register: result
+  until: result is not failed
+  retries: 3
+  delay: 60
+
+- copy:
+    dest: /etc/nftables.conf
+    mode: 0644
+    content: |
+      #!/usr/sbin/nft -f
+      flush ruleset
+  notify: nftables


### PR DESCRIPTION
Completed steps 1-5 from https://github.com/delphix/appliance-build/blob/master/README.md

Logged into the VM and checked for the existence of nftables, plus ensured the default ruleset was flushed:

```
delphix@ip-10-110-202-152:~$ sudo nft list ruleset -a
delphix@ip-10-110-202-152:~$ cat /etc/nftables.conf 
#!/usr/sbin/nft -f
flush ruleset
```