### PR TITLE
LX-1217 Generate crash dump on NMI

### DIFF
--- a/live-build/misc/ansible-roles/appliance-build.minimal-common/tasks/main.yml
+++ b/live-build/misc/ansible-roles/appliance-build.minimal-common/tasks/main.yml
@@ -303,26 +303,27 @@
     state: directory
     mode: 0777
 
-#
-# Update sysctl.conf such that application cores are written into
-# /var/crash and tagged with the execname, process id, and seconds since
-# the epoch.
-#
-# Additionally in this file, we force the kernel to assume memory
-# allocations will succeed until we actually run out of memory. The
-# default heuristic can cause failure to generate an hprof dump on OOM
-# in the stack. Allowing overcommit lets the fork(2) succeed despite not
-# having enough memory which allows the script that generates the hprof
-# dump to run.
-#
 - lineinfile:
     create: yes
     dest: /etc/sysctl.conf
     regexp: "^#?{{ item.key }} ="
     line: "{{ item.key }} = {{ item.value }}"
   with_items:
+    #
+    # Application cores should be written into /var/crash and tagged with the
+    # execname, process id, and seconds since the epoch.
+    #
     - { key: 'kernel.core_pattern', value: '/var/crash/core.%e.%p.%t' }
+    #
+    # Force the kernel to allow memory allocations to succeed until we
+    # actually run out of memory. The default heuristic can cause failure to
+    # generate an hprof dump on OOM in the stack. Allowing overcommit lets the
+    # fork(2) succeed despite not having enough memory which allows the script
+    # that generates the hprof dump to run.
+    #
     - { key: 'vm.overcommit_memory', value: '1' }
+    # Enable gathering of crash dumps by sending an NMI
+    - { key: 'kernel.unknown_nmi_panic', value: '1' }
 
 #
 # Add the apt repos that have the debug versions of packages, so that we


### PR DESCRIPTION
The appliance should panic and generate a crash dump when it receives an NMI, to allow debugging of engines which are in some bad state such that interactive debugging isn't possible.