### PR TITLE
Use "sysctl.d" for appliance customizations

### DIFF
--- a/live-build/misc/ansible-roles/appliance-build.minimal-common/tasks/main.yml
+++ b/live-build/misc/ansible-roles/appliance-build.minimal-common/tasks/main.yml
@@ -226,10 +226,6 @@
           lock_passwd: false
 
 #
-# We don't want to have our secondary addresses deleted when someone
-# deletes the primary IP address of a network interface, thus we enable
-# the promotion of secondary addresses to primary ones.
-#
 # As for the priority prefix for our config file (see what that means
 # in /etc/sysctl.d/README) we pick 50 which is higher than what other
 # Ubuntu packages will be installing but less than customization made
@@ -237,12 +233,34 @@
 #
 - lineinfile:
     create: yes
-    dest: /etc/sysctl.d/50-delphix-networking.conf
+    dest: /etc/sysctl.d/50-delphix.conf
     regexp: "^#?{{ item.key }}="
     line: "{{ item.key }}={{ item.value }}"
   with_items:
+    #
+    # We don't want to have our secondary addresses deleted when someone
+    # deletes the primary IP address of a network interface, thus we
+    # enable the promotion of secondary addresses to primary ones.
+    #
     - { key: "net.ipv4.conf.all.promote_secondaries", value: "1" }
     - { key: "net.ipv4.conf.default.promote_secondaries", value: "1" }
+    #
+    # Application cores should be written into /var/crash and tagged with the
+    # execname, process id, and seconds since the epoch.
+    #
+    - { key: 'kernel.core_pattern', value: '/var/crash/core.%e.%p.%t' }
+    #
+    # Force the kernel to allow memory allocations to succeed until we
+    # actually run out of memory. The default heuristic can cause failure to
+    # generate an hprof dump on OOM in the stack. Allowing overcommit lets the
+    # fork(2) succeed despite not having enough memory which allows the script
+    # that generates the hprof dump to run.
+    #
+    - { key: 'vm.overcommit_memory', value: '1' }
+    #
+    # Enable gathering of crash dumps by sending an NMI
+    #
+    - { key: 'kernel.unknown_nmi_panic', value: '1' }
 
 #
 # Configure command audit logging
@@ -302,28 +320,6 @@
     path: /var/crash
     state: directory
     mode: 0777
-
-- lineinfile:
-    create: yes
-    dest: /etc/sysctl.conf
-    regexp: "^#?{{ item.key }} ="
-    line: "{{ item.key }} = {{ item.value }}"
-  with_items:
-    #
-    # Application cores should be written into /var/crash and tagged with the
-    # execname, process id, and seconds since the epoch.
-    #
-    - { key: 'kernel.core_pattern', value: '/var/crash/core.%e.%p.%t' }
-    #
-    # Force the kernel to allow memory allocations to succeed until we
-    # actually run out of memory. The default heuristic can cause failure to
-    # generate an hprof dump on OOM in the stack. Allowing overcommit lets the
-    # fork(2) succeed despite not having enough memory which allows the script
-    # that generates the hprof dump to run.
-    #
-    - { key: 'vm.overcommit_memory', value: '1' }
-    # Enable gathering of crash dumps by sending an NMI
-    - { key: 'kernel.unknown_nmi_panic', value: '1' }
 
 #
 # Add the apt repos that have the debug versions of packages, so that we


### PR DESCRIPTION
This change modifies the "minimal-common" Ansible role to no longer modify
the "/etc/sysctl.conf" file, but instead use the "sysctl.d" directory. This
should result in no changes to the normal operation of the appliance, but
makes upgrade more resilient as our "local" changes will not be overwritten
by the maintainer supplied "/etc/sysctl.conf" file.