### PR TITLE
Install snmp package containing client utilities by default.

### DIFF
--- a/live-build/base/config/package-lists/tools.list.chroot
+++ b/live-build/base/config/package-lists/tools.list.chroot
@@ -33,6 +33,7 @@ inotify-tools
 kdump-tools
 procinfo
 sg3-utils
+snmp
 strace
 tshark
 vim


### PR DESCRIPTION
This commit installs the snmp package to our base appliance image.
The SNMP client utilities included in this packge (e.g. snmpwalk and
snmpget) are useful for the field/support to debug the snmpd daemon.

Additionally, blackbox needs these utilities for test automation, so
installing this package kills two birds with one stone.

I tested this by installing the snmp package and making sure that the
snmpget and snmpwalk utilities get installed and work as expected.