### PR TITLE
bootstrap configuration should always use the latest apt index

### DIFF
--- a/bootstrap/roles/appliance-build.bootstrap/tasks/main.yml
+++ b/bootstrap/roles/appliance-build.bootstrap/tasks/main.yml
@@ -19,6 +19,16 @@
   register: toplevel
 
 - apt:
+    name: aptitude
+    state: present
+
+- apt:
+    update_cache: yes
+
+- apt:
+    upgrade: yes
+
+- apt:
     name: "{{ item }}"
     state: present
   with_items:


### PR DESCRIPTION
The `appliance-build.bootstrap apt` task has been failing when trying to install the latest packages. Basil suspects that the issue is that it's trying to install a package which is no longer available from Ubuntu because the `apt` index is old (it’s from when the `bootstrap-18-04` group was made). 

He suggested adding these commands to update the `apt` indices before performing the install so that the latest version is always pulled in.

Testing:
I ran `ansible-playbook bootstrap/playbook.yml` without the changes and saw the same failures we've been seeing in the Jenkins job. With the changes, `ansible-playbook bootstrap/playbook.yml` completes successfully. 