### PR TITLE
LX-198 delphix nsswitch functionality (nss and passwordless auth config)

### DIFF
--- a/live-build/misc/ansible-roles/appliance-build.delphix-ldap/tasks/main.yml
+++ b/live-build/misc/ansible-roles/appliance-build.delphix-ldap/tasks/main.yml
@@ -44,13 +44,18 @@
 
 - lineinfile:
     dest: /etc/nsswitch.conf
-    regexp: "{{ item.regexp }}"
-    line: "{{ item.line }}"
+    regexp: "^({{ item.db }}:(?!.*\\sldap\\s).*$)"
+    line: "\\1 ldap"
+    backrefs: yes
   with_items:
-    - { regexp: "^automount:.*$", line: "automount:\tfiles ldap" }
-    - { regexp: "^group:.*$", line: "group:\tcompat ldap" }
-    - { regexp: "^passwd:.*$", line: "passwd:\tcompat ldap" }
-    - { regexp: "^shadow:.*$", line: "shadow:\tcompat ldap" }
+    - { db: "passwd" }
+    - { db: "group" }
+    - { db: "shadow" }
+
+- lineinfile:
+    dest: /etc/nsswitch.conf
+    regexp: "^automount:.*$"
+    line: "automount:\tfiles ldap"
 
 - file:
     path: /home

--- a/live-build/misc/ansible-roles/appliance-build.minimal-common/tasks/main.yml
+++ b/live-build/misc/ansible-roles/appliance-build.minimal-common/tasks/main.yml
@@ -30,6 +30,12 @@
   when: lookup('env', 'APPLIANCE_USERNAME') == ''
 
 #
+# Apt cache needs to be up to date.
+#
+- apt:
+    update_cache: yes
+
+#
 # To adhere to the priciple of least surprise, we disable automatic
 # upgrades here; this package can always be added on a specific system
 # when it's desired.
@@ -374,8 +380,8 @@
 
 - lineinfile:
     path: /etc/ssh/sshd_config
-    regexp: "^#?{{ item.key }}="
-    line: "{{ item.key }}={{ item.value }}"
+    regexp: "^#?{{ item.key }} "
+    line: "{{ item.key }} {{ item.value }}"
   with_items:
     #
     # Configure SSH to allow PAM "conversations" (interactions with the user).

--- a/live-build/misc/ansible-roles/appliance-build.virtualization-development/tasks/main.yml
+++ b/live-build/misc/ansible-roles/appliance-build.virtualization-development/tasks/main.yml
@@ -36,6 +36,9 @@
     - ant
     - git
     - libcurl4-openssl-dev
+    - libnss3-dev
+    - libnss3-dbg
+    - libnss3-tools
     - libpam0g-dev
     - libssl-dev
   register: result


### PR DESCRIPTION
### Change
This companion change of LX-198 configures the CLI NSS module in virtualization appliances. This includes updates to the NSS configuration to add the new module and the NSCD configuration to prevent our module from being skipped by the `passwd` NSCD cache. For development variants, it also adds the `libnss3` development libraries.

It also takes charge of creating the `cli` user used as a placeholder of the uid 65434 assumed by all cli users. This user is no longer created by app gate code because `refresh_databases.sh` is going away (whose real purpose was to update `/etc/passwd` and `/etc/shadow` with native engine users, which we don't want to do anymore).

Finally, this change fixes a minor issue in configuring sshd and, more importantly, fixes the LDAP role which in its current form removes any modules from the NSS `passwd` database other than `files` (i.e. the `systemd` module and the new  `delphix` NSS module).

### Testing
The appliance build process completes successfully for the `internal-dev` variant: http://selfservice.jenkins.delphix.com/job/devops-gate/job/projects/job/dx4linux/job/appliance-build-orchestrator-pre-push/41/flowGraphTable/
Cloned a VM from the resulting group in DCoA and verified it contains all the configuration changes and including the new NSS module deployed to it (the latter is thanks to the app-gate solution to be reviewed separately).