### PR TITLE
Install common MIBs and enable MIB loading for SNMP client tools.

### DIFF
--- a/live-build/base/config/package-lists/tools.list.chroot
+++ b/live-build/base/config/package-lists/tools.list.chroot
@@ -34,6 +34,7 @@ kdump-tools
 procinfo
 sg3-utils
 snmp
+snmp-mibs-downloader
 strace
 tshark
 vim

--- a/live-build/misc/ansible-roles/appliance-build.minimal-common/tasks/main.yml
+++ b/live-build/misc/ansible-roles/appliance-build.minimal-common/tasks/main.yml
@@ -400,6 +400,14 @@
     replace: '#\1'
 
 #
+# Enable SNMP client tools to load MIBs by default.
+#
+- replace:
+    path: /etc/snmp/snmp.conf
+    regexp: '^(mibs\s+:\s+)'
+    replace: '#\1'
+
+#
 # Disable the Linux Azure Agent by default. Later this should be re-enabled on
 # Azure systems.
 #


### PR DESCRIPTION
The snmp-mibs-downloader package downloads most common MIBs, and
includes a utility that can be used to download new MIBs. These MIBs are
used by tools such as snmpget and snmpwalk to resolve numeric OIDs to
human readable object names.

### Testing

`git ab-pre-push`: http://selfservice.jenkins.delphix.com/job/devops-gate/job/projects/job/dx4linux/job/appliance-build-orchestrator-pre-push/76/flowGraphTable/