### PR TITLE
LX-1279 internal-dev variant should have nftables installed

### DIFF
--- a/live-build/variants/internal-dev/ansible/playbook.yml
+++ b/live-build/variants/internal-dev/ansible/playbook.yml
@@ -25,6 +25,7 @@
     - appliance-build.minimal-internal
     - appliance-build.masking-common
     - appliance-build.masking-development
+    - appliance-build.qa-internal
     - appliance-build.virtualization-common
     - appliance-build.virtualization-internal
     - appliance-build.virtualization-standard


### PR DESCRIPTION
This change modifies the internal-dev configuration to also install the "nftables" package.
The internal-dev variant should have nftables installed so that blackbox tests that use this utility can be run against the dev variant.

### TESTING
- Ran live-build on a bootstrap VM and verified nftables exists.
- [ab-pre-push job](http://selfservice.jenkins.delphix.com/job/devops-gate/job/projects/job/dx4linux/job/appliance-build-orchestrator-pre-push/74/console)
- Verified the resulting image boots and has nftables installed. The cloned VM: pg-ab-nftables.dlpxdc.co