### PR TITLE
Add passwordless sudo for LDAP users on internal-dev appliances

### DIFF
--- a/live-build/misc/ansible-roles/appliance-build.delphix-ldap/files/80-internal-ldap
+++ b/live-build/misc/ansible-roles/appliance-build.delphix-ldap/files/80-internal-ldap
@@ -1,0 +1,10 @@
+#
+# For convenience, allow passwordless sudo for all ldap users on internal
+# development appliances. Delphix ldap users are in a group with gid 10 because
+# on Illumos gid 10 is assigned to the group staff. On Linux, gid 10 is assigned
+# to the group uucp, so a side effect of this entry is that passwordless sudo is
+# allowed for uucp. We can fix this eventually if we create a new ldap group
+# with a unique gid and add all users to that group in addition to the group
+# staff.
+#
+%#10 ALL=(ALL) NOPASSWD:ALL

--- a/live-build/misc/ansible-roles/appliance-build.delphix-ldap/tasks/main.yml
+++ b/live-build/misc/ansible-roles/appliance-build.delphix-ldap/tasks/main.yml
@@ -67,3 +67,11 @@
 - lineinfile:
     dest: etc/auto.master
     line: "/home   auto_home    -nobrowse"
+
+- copy:
+    src: 80-internal-ldap
+    dest: /etc/sudoers.d/
+    owner: root
+    group: root
+    mode: 0444
+  when: passwordless_ldap_sudo is defined and passwordless_ldap_sudo == true

--- a/live-build/variants/internal-dev/ansible/playbook.yml
+++ b/live-build/variants/internal-dev/ansible/playbook.yml
@@ -20,6 +20,7 @@
   gather_facts: no
   vars:
     ansible_python_interpreter: /usr/bin/python3
+    passwordless_ldap_sudo: true
   roles:
     #
     # In order for the local appliance user (e.g. delphix) to be created


### PR DESCRIPTION
This works on Illumos appliances, so developers will expect it to work
on Linux as well. Here we do something slightly better than what we do
on Illumos by restricting passwordless sudo to LDAP users, which makes
it less likely that users will overlook bugs where we accidentally rely
on these extra privileges which don't exist on the version we ship.