### PR TITLE
Temporarily install build dependencies in Virtualization Engine product variants

### DIFF
--- a/live-build/misc/ansible-roles/appliance-build.qa-internal/tasks/main.yml
+++ b/live-build/misc/ansible-roles/appliance-build.qa-internal/tasks/main.yml
@@ -27,6 +27,36 @@
   retries: 3
   delay: 60
 
+#
+# We would ideally limit the build dependencies to the "internal-dev" variant.
+# However, we want to use the "internal-qa" variant to do pre-push testing, and
+# we currently do pre-push testing by building the code under test on the
+# Delphix Engine (and changing this workflow would require a significant amount
+# of work). As a temporary workaround, we install the build dependencies on the
+# "internal-qa" variant. In the long term, we should change the pre-push jobs to
+# do builds on a separate bootstrap VM rather than on a Delphix Engine. Then we
+# can move the build dependencies from the list below back into the
+# "internal-dev" playbook.
+#
+- apt:
+    name: "{{ item }}"
+    state: present
+  with_items:
+    - ant
+    - gcc
+    - git
+    - libcrypt-blowfish-dev
+    - libcurl4-openssl-dev
+    - libnss3-dbg
+    - libnss3-dev
+    - libnss3-tools
+    - libpam0g-dev
+    - libssl-dev
+  register: result
+  until: result is not failed
+  retries: 3
+  delay: 60
+
 - copy:
     dest: /etc/nftables.conf
     mode: 0644

--- a/live-build/misc/ansible-roles/appliance-build.virtualization-development/tasks/main.yml
+++ b/live-build/misc/ansible-roles/appliance-build.virtualization-development/tasks/main.yml
@@ -44,24 +44,6 @@
       [Service]
       Environment=DLPX_DEBUG=true
 
-- apt:
-    name: "{{ item }}"
-    state: present
-  with_items:
-    - ant
-    - git
-    - libcrypt-blowfish-dev
-    - libcurl4-openssl-dev
-    - libnss3-dev
-    - libnss3-dbg
-    - libnss3-tools
-    - libpam0g-dev
-    - libssl-dev
-  register: result
-  until: result is not failed
-  retries: 3
-  delay: 60
-
 - git:
     repo: "{{ item.repo }}"
     dest:


### PR DESCRIPTION
As the comment states, we would like to use the `internal-qa` variant for pre-push testing; however, in order to do that, we would currently need to revamp our entire pre-push testing workflow. As a workaround, we temporarily include the build dependencies in the `internal-qa` variant to avoid having to revamp the pre-push testing workflow. Once the pre-push testing workflow is redone, we can move the build dependencies back into the `internal-dev` variant.