### PR TITLE
Add build-essential to the list of build dependencies for the Virtualization Engine

### DIFF
--- a/live-build/misc/ansible-roles/appliance-build.qa-internal/tasks/main.yml
+++ b/live-build/misc/ansible-roles/appliance-build.qa-internal/tasks/main.yml
@@ -43,7 +43,7 @@
     state: present
   with_items:
     - ant
-    - gcc
+    - build-essential
     - git
     - libcrypt-blowfish-dev
     - libcurl4-openssl-dev


### PR DESCRIPTION
We currently install `gcc` but not `g++` and `make`. `g++` and `make` are needed to build the Virtualization Engine. Instead, this change installs `build-essential`, which includes `gcc`, `g++`, and `make`.

Testing done: Installed `build-essential` on a QA variant VM. Then successfully built the Virtualization Engine.