### PR TITLE
Fetch ZFS packages from master S3 bucket

### DIFF
--- a/scripts/build-ancillary-repository.sh
+++ b/scripts/build-ancillary-repository.sh
@@ -181,7 +181,7 @@ AWS_S3_URI_MASKING=$(resolve_s3_uri \
 AWS_S3_URI_ZFS=$(resolve_s3_uri \
 	"$AWS_S3_URI_ZFS" \
 	"$AWS_S3_PREFIX_ZFS" \
-	"devops-gate/projects/dx4linux/zfs-package-build/master/post-push/latest")
+	"devops-gate/master/zfs-package-build/master/post-push/latest")
 
 #
 # All package files will be placed into this temporary directory, such


### PR DESCRIPTION
The ZFS packages are now built from master rather than the project branch, so fetch them from there instead.