### PR TITLE
Don't use "no_log" with the "user" module

### DIFF
--- a/live-build/misc/ansible-roles/appliance-build.minimal-common/tasks/main.yml
+++ b/live-build/misc/ansible-roles/appliance-build.minimal-common/tasks/main.yml
@@ -153,7 +153,6 @@
     home: "/export/home/{{ lookup('env', 'APPLIANCE_USERNAME') }}"
     password:
       "{{ lookup('env', 'APPLIANCE_PASSWORD') | password_hash('sha512') }}"
-  no_log: true
 
 #
 # We also want the delphix user to have passwordless sudo access, so we

--- a/live-build/misc/ansible-roles/appliance-build.virtualization-development/tasks/main.yml
+++ b/live-build/misc/ansible-roles/appliance-build.virtualization-development/tasks/main.yml
@@ -87,4 +87,3 @@
     name: root
     password:
       "{{ lookup('env', 'APPLIANCE_PASSWORD') | password_hash('sha512') }}"
-  no_log: true


### PR DESCRIPTION
We currently use the "no_log" field when using the "user" module in
Ansible to avoid leaking the contents of the user password. This is
unnecessary since the contents of the password will automatically be
hidden by Ansible, even when running with Ansible's verbose options.

For example, if I remove "no_log" and cause the "user" module to fail,
I see the following output:

    TASK [appliance-build.minimal-common : user]
    ...
    fatal: [binary]: FAILED! => {
        "changed": false,
        "invocation": {
            "module_args": {
    ...
                "password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
    ...
    }

By no longer using "no_log", we can get more details when the "user"
module fails, which helps us diagnose problems on first failure.