### PR TITLE
Set tunable to enable accurate zfs send size estimates

### DIFF
--- a/live-build/misc/ansible-roles/appliance-build.minimal-common/tasks/main.yml
+++ b/live-build/misc/ansible-roles/appliance-build.minimal-common/tasks/main.yml
@@ -451,6 +451,13 @@
       # tunables, that we use on our illumos-based DelphixOS.
       #
       options zfs zfs_mg_noalloc_threshold=5
+
+      #
+      # Our data blocks are of size 8k, but the filesystems usually have a
+      # recordsize of 128k. That causes incorrect size estimates in zfs
+      # send. Overriding the property here fixes that.
+      #
+      options zfs zfs_override_estimate_recordsize=8192
   #
   # Because the spl module is loaded from the initramfs when using zfs on root,
   # we need to rebuild the initramfs to account for the modprobe.d change.


### PR DESCRIPTION
This change can safely land before the corresponding change to zfs, since the property will be silently ignore if it isn't valid.