### PR TITLE
LX-199 linux CRA implementation (appliance-build part)

### DIFF
--- a/live-build/misc/ansible-roles/appliance-build.minimal-common/tasks/main.yml
+++ b/live-build/misc/ansible-roles/appliance-build.minimal-common/tasks/main.yml
@@ -544,3 +544,10 @@
     state: directory
     mode: 0755
     recurse: yes
+
+#
+# Install, but do not enable, the challenge-response PAM module for support
+# logins with the 'delphix' user.
+#
+- apt:
+    name: 'pam-challenge-response'


### PR DESCRIPTION
Install CRA PAM module. By default, it is not enabled. The corresponding app gate change will include an updated script to allow support to enable and disabling CRA, just like in illumos.