### PR TITLE
install shellcheck

### DIFF
--- a/live-build/misc/ansible-roles/appliance-build.zfsonlinux-development/tasks/main.yml
+++ b/live-build/misc/ansible-roles/appliance-build.zfsonlinux-development/tasks/main.yml
@@ -48,6 +48,7 @@
     - nfs-kernel-server
     - parted
     - python-minimal
+    - shellcheck
     - targetcli-fb
     - unzip
     - uuid-dev


### PR DESCRIPTION
This utility is needed when running `make checkstyle` in the ZFS repo.

testing: running http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/86/