### PR TITLE
Fix assignment of the AWS_S3_URI_PLATFORM variable

### DIFF
--- a/scripts/build-ancillary-repository.sh
+++ b/scripts/build-ancillary-repository.sh
@@ -185,7 +185,7 @@ AWS_S3_URI_VIRTUALIZATION=$(resolve_s3_uri \
 AWS_S3_URI_PLATFORM=$(resolve_s3_uri \
 	"$AWS_S3_URI_PLATFORM" \
 	"$AWS_S3_PREFIX_PLATFORM" \
-	"dlpx-app-gate/master/build-package/post-push/latest")
+	"devops-gate/master/delphix-platform/master/post-push/latest")
 
 AWS_S3_URI_MASKING=$(resolve_s3_uri \
 	"$AWS_S3_URI_MASKING" \


### PR DESCRIPTION
In the "build-ancillary-repository.sh" script, we incorrectly use the
virtualization package's "latest" S3 prefix when assigning a value to
the AWS_S3_URI_PLATFORM variable.

If either the AWS_S3_URI_PLATFORM or AWS_S3_PREFIX_PLATFORM variables
are set, this won't cause a problem, but for "manual" builds that
"latest" prefix will be used (i.e. when neither of those environment
variables are set). As a result, we'll fail to download the
"delphix-platform" package (and add it to the ancillary repository),
which will result in the build failing with the error:

    E: Unable to locate package delphix-platform

The fix is to simply use the proper "latest" S3 prefix for this package.