### PR TITLE
Install new version of delphix-entire on upgrade

### DIFF
--- a/live-build/misc/upgrade-scripts/execute
+++ b/live-build/misc/upgrade-scripts/execute
@@ -17,6 +17,8 @@
 
 . "${BASH_SOURCE%/*}/common.sh"
 
+set -o pipefail
+
 function usage() {
 	echo "$(basename "$0"): $*" >&2
 	echo "Usage: $(basename "$0") <version>"
@@ -28,6 +30,18 @@ function apt_get() {
 		-o Dpkg::Options::="--force-confdef" \
 		-o Dpkg::Options::="--force-confold" \
 		"$@"
+}
+
+function pkg_version_impl() {
+	apt-cache policy "$1" | grep "$2" | awk '{print $2}'
+}
+
+function pkg_version_installed() {
+	pkg_version_impl "$1" "Installed:"
+}
+
+function pkg_version_candidate() {
+	pkg_version_impl "$1" "Candidate:"
 }
 
 while getopts ':' c; do
@@ -50,6 +64,11 @@ EOF
 	die "failed to configure apt sources"
 
 apt_get update || die "failed to update apt sources"
-apt_get dist-upgrade -y || die "failed to upgrade apt packages"
+
+INSTALLED_VERSION=$(pkg_version_installed "delphix-entire")
+CANDIDATE_VERSION=$(pkg_version_candidate "delphix-entire")
+
+apt_get install -y "delphix-entire=$CANDIDATE_VERSION" ||
+	die "upgrade failed; from '$INSTALLED_VERSION' to '$CANDIDATE_VERSION'"
 
 exit 0

--- a/live-build/misc/upgrade-scripts/verify
+++ b/live-build/misc/upgrade-scripts/verify
@@ -93,7 +93,7 @@ systemd-run --machine="$CONTAINER" --quiet --pipe --wait -- \
 	"$TOP/execute" "$DLPX_VERSION" ||
 	die "'$TOP/execute' failed in verification container"
 
-report_progress_inc 60 "Performing appliacation upgrade verification"
+report_progress_inc 60 "Performing application upgrade verification"
 
 if [[ -n "$DLPX_DEBUG" ]] && $DLPX_DEBUG; then
 	VERIFY_DEBUG_OPT="-Ddelphix.debug=true"


### PR DESCRIPTION
The purpose of this change is to replace the use of "dist-upgrade" on
upgrade, with installing the specific new version of "delphix-entire".
This way, we're more sure of exactly what packages (and the specific
versions of those packages) we'll end up with after the upgrade.