### PR TITLE
LX-1418 Bind mount /var/delphix/server/upgrade-verify to save logs fr…

### DIFF
--- a/live-build/misc/upgrade-scripts/verify
+++ b/live-build/misc/upgrade-scripts/verify
@@ -18,6 +18,8 @@
 TOP="${BASH_SOURCE%/*}"
 . "$TOP/common.sh"
 
+UPGRADE_VERIFY_CONTAINER_LOG_DIR=/var/delphix/server/upgrade-verify
+
 function usage() {
 	echo "$(basename "$0"): $*" >&2
 	echo "Usage: $(basename "$0") -v <version>"
@@ -26,6 +28,23 @@ function usage() {
 
 function report_progress_inc() {
 	echo "Progress increment: $(date +%T:%N%z), $1, $2"
+}
+
+function collect_logs() {
+	verify_logs_dest="$DROPBOX_DIR/verify_logs"
+
+	if [[ -d "$verify_logs_dest" ]]; then
+		rm -rf "$verify_logs_dest"
+	else
+		mkdir "$verify_logs_dest"
+	fi
+
+	for log_dir in "$@"; do
+		if [[ -d "$log_dir" ]]; then
+			cp -r "$log_dir" "$verify_logs_dest"
+		fi
+	done
+
 }
 
 function cleanup() {
@@ -42,6 +61,15 @@ function cleanup() {
 	# further cleanup for us to do here.
 	#
 	[[ -z "$CONTAINER" ]] && return
+
+	#
+	# Before cleaning the container, we need to copy logs to the
+	# container's host for debugging purpose. Otherwise the logs will
+	# be cleaned up as part of container deletion.
+	#
+	report_progress_inc 70 "Collecting verification logs"
+	local logs_dirs_to_copy="$UPGRADE_VERIFY_CONTAINER_LOG_DIR"
+	collect_logs $logs_dirs_to_copy
 
 	#
 	# On failure, and when DLPX_DEBUG is true, we avoid cleaning up
@@ -105,7 +133,7 @@ fi
 
 systemd-run --machine="$CONTAINER" --quiet --pipe --wait -- \
 	/usr/bin/java \
-	-Dlog.dir=/var/delphix/server/upgrade-verify \
+	-Dlog.dir="$UPGRADE_VERIFY_CONTAINER_LOG_DIR" \
 	-Dmdsverify=true \
 	$VERIFY_DEBUG_OPT \
 	-jar /opt/delphix/server/lib/exec/upgrade-verify/upgrade-verify.jar \


### PR DESCRIPTION
…om upgrade verify

**Problem**
* upgrade-verify.jar logs are saved within the container at `/var/delphix/server/upgrade-verify/`. However, because this directory is created within the container and purged along with container cleanup code, we cannot inspect it for debugging.

**Possible solutions**
1. Expose `/var/delphix/server/upgrade-verify` from the container's host such that files are not purged when container gets destroyed.
2. Disable container cleanup code if it fails. Currently we only keep the failed container only if `$DLPX_DEBUG` option is set.

**Fix**
* Went with option 1) since it's the easiest solution. Also, option 2) might give more space overhead on customer's environment.

**Tests**
* Log files are now saved in the container's host

```
delphix@harry-dlpx-linux-trunk:/var/delphix/server/upgrade-verify$ ls -la
total 14
drwxr-xr-x 2 root root    8 Oct 19 00:51 .
drwxr-xr-x 8 root root   10 Oct 19 00:47 ..
-rw-r--r-- 1 root root 7573 Oct 19 00:51 debug.log
-rw-r--r-- 1 root root    0 Oct 19 00:51 error.log
-rw-r--r-- 1 root root    0 Oct 19 00:51 info.log
-rw-r--r-- 1 root root    0 Oct 19 00:51 opensource.log
-rw-r--r-- 1 root root    0 Oct 19 00:51 sshj.log
-rw-r--r-- 1 root root    0 Oct 19 00:51 trace.log
```