### PR TITLE
LX-1539 Add version.info to Linux upgrade image

### DIFF
--- a/live-build/misc/live-build-hooks/82-upgrade-repository.binary
+++ b/live-build/misc/live-build-hooks/82-upgrade-repository.binary
@@ -149,6 +149,10 @@ aptly repo add upgrade-repository ./*.deb
 
 aptly publish repo -skip-signing upgrade-repository
 
-tar -czf "$APPLIANCE_VARIANT.upgrade.tar.gz" -C upgrade-scripts . -C ~/.aptly .
+# Include version information about this image.
+cp config/hooks/template.info version.info
+sed -i "s/@@VERSION@@/$VERSION/" version.info
+
+tar -czf "$APPLIANCE_VARIANT.upgrade.tar.gz" version.info -C upgrade-scripts . -C ~/.aptly .
 
 rm -rf binary/packages

--- a/live-build/misc/live-build-hooks/template.info
+++ b/live-build/misc/live-build-hooks/template.info
@@ -1,0 +1,21 @@
+#
+# This file is used by app-gate to identify an image's version metadata
+# after it is uploaded.
+#
+# Note that any changes to this file's format is a flag-day and must be
+# coupled with an app-gate change.
+#
+
+# The application (product) version.
+VERSION=@@VERSION@@
+
+# The minimum version an engine must be on, in order to upgrade to this image.
+MINIMUM_VERSION=5.3.0.0
+
+#
+# The minimum version from which a reboot upgrade is optional.
+# If the current version before upgrade is greater than or equal to this
+# version, a reboot is optional.
+# If the current version is less than this value, a reboot is mandatory.
+#
+MINIMUM_REBOOT_OPTIONAL_VERSION=5.3.0.0


### PR DESCRIPTION
Added a version.info file in the upgrade image.
`DLPX_MIN_VERSION` (same as on Illumos) is for limiting how far a customer can jump with an upgrade (right now on Illumos we have it as 2 major releases)
`DLPX_MIN_REBOOTED_VERSION` is a new field that we will use to disallow deferred upgrades for a version.  Open to any better names for this..

Testing:
1. Ran `git ab-pre-push -v internal-dev`
2. Uploaded upgrade image
3. Verified version.info contents were correct
```
delphix@dt-linux:~$ cat /var/dlpx-update/9999.0.0.0/version.info 
#
# This file is used by app-gate to identify an image's version metadata
# after it is uploaded.
#
# Note that any changes to this file's format is a flag-day and must be
# coupled with an app-gate change.
#

# The application (product) version.
VERSION=2018.10.23.00

# The minimum version an engine must be on, in order to upgrade to this image.
MINIMUM_VERSION=5.3.0.0

# The minimum version an engine did a reboot upgrade to, in order to upgrade to this image.
MINIMUM_REBOOT_REQUIRED_VERSION=5.3.0.0
```