### PR TITLE
LX-1415 Investigate automatic stack restart after deferred upgrade

### DIFF
--- a/live-build/misc/upgrade-scripts/execute
+++ b/live-build/misc/upgrade-scripts/execute
@@ -71,4 +71,8 @@ CANDIDATE_VERSION=$(pkg_version_candidate "delphix-entire")
 apt_get install -y "delphix-entire=$CANDIDATE_VERSION" ||
 	die "upgrade failed; from '$INSTALLED_VERSION' to '$CANDIDATE_VERSION'"
 
+# We treat all upgrades as deferred for now. LX-224 addresses reboot upgrade.
+systemctl restart delphix-platform ||
+	die "failed to restart services after upgrade from '$INSTALLED_VERSION' to '$CANDIDATE_VERSION'"
+
 exit 0


### PR DESCRIPTION
**Changes**

* Adds a logic to automatically restart `delphix-platform` service after upgrading packages. (I.e. deferred upgrade)
* In case of full-upgrade, we do **not** want to restart `delphix-platform`. As of now, full-upgrade is not supported and will be addressed with [LX-224](https://jira.delphix.com/browse/LX-224) once full-upgrade is implemented.

**Testing**

* [`git-ab-pre-push`](http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/152/)
* Modified `execute` script of an upgrade image and ran it.
    * Checked that `dpkg -l` correctly shows that packages are updated
    * Checked that `systemctl status delphix-mgmt` correctly shows that the service is restarted.

