### PR TITLE
Allow building with LDAP users

### DIFF
--- a/live-build/misc/ansible-roles/appliance-build.delphix-ldap/files/80-internal-ldap
+++ b/live-build/misc/ansible-roles/appliance-build.delphix-ldap/files/80-internal-ldap
@@ -1,10 +1,6 @@
 #
 # For convenience, allow passwordless sudo for all ldap users on internal
-# development appliances. Delphix ldap users are in a group with gid 10 because
-# on Illumos gid 10 is assigned to the group staff. On Linux, gid 10 is assigned
-# to the group uucp, so a side effect of this entry is that passwordless sudo is
-# allowed for uucp. We can fix this eventually if we create a new ldap group
-# with a unique gid and add all users to that group in addition to the group
-# staff.
+# development appliances. Delphix ldap users are the only members of the staff
+# group, so allow passwordless sudo for that whole group.
 #
-%#10 ALL=(ALL) NOPASSWD:ALL
+%staff ALL=(ALL) NOPASSWD:ALL

--- a/live-build/misc/ansible-roles/appliance-build.masking-development/tasks/main.yml
+++ b/live-build/misc/ansible-roles/appliance-build.masking-development/tasks/main.yml
@@ -45,6 +45,7 @@
     path: "/export/home/{{ lookup('env', 'APPLIANCE_USERNAME') }}/{{ item }}"
     owner: "{{ lookup('env', 'APPLIANCE_USERNAME') }}"
     group: staff
+    mode: "g+w"
     state: directory
     recurse: yes
   with_items:

--- a/live-build/misc/ansible-roles/appliance-build.virtualization-development/tasks/main.yml
+++ b/live-build/misc/ansible-roles/appliance-build.virtualization-development/tasks/main.yml
@@ -75,6 +75,7 @@
     path: "/export/home/{{ lookup('env', 'APPLIANCE_USERNAME') }}/{{ item }}"
     owner: "{{ lookup('env', 'APPLIANCE_USERNAME') }}"
     group: staff
+    mode: "g+w"
     state: directory
     recurse: yes
   with_items:


### PR DESCRIPTION
Our LDAP users are now members of the staff group. The files in the git
repos cloned on the internal-dev variant are already owned by the staff
group, but they need to be group writable in order to allow LDAP users
to push changes.