### PR TITLE
Add new "run" option to "upgrade-container" script

### DIFF
--- a/live-build/misc/upgrade-scripts/upgrade-container
+++ b/live-build/misc/upgrade-scripts/upgrade-container
@@ -227,16 +227,14 @@ function start() {
 	#
 	# shellcheck disable=SC2034
 	for i in {1..600}; do
-		if systemd-run --machine="$CONTAINER" --quiet --wait -- \
-			/bin/systemctl is-active default.target 2>/dev/null; then
+		if run /bin/systemctl is-active default.target &>/dev/null; then
 			break
 		fi
 
 		sleep 1
 	done
 
-	systemd-run --machine="$CONTAINER" --quiet --wait -- \
-		/bin/systemctl is-active default.target ||
+	run /bin/systemctl is-active default.target &>/dev/null ||
 		die "'default.target' inactive in container '$CONTAINER'"
 }
 
@@ -266,6 +264,10 @@ function destroy() {
 		rm -d "/var/lib/machines/$CONTAINER" ||
 			die "failed to remove container directory: '$CONTAINER'"
 	fi
+}
+
+function run() {
+	systemd-run --machine="$CONTAINER" --quiet --wait --pipe -- "$@"
 }
 
 function usage() {
@@ -317,6 +319,12 @@ destroy)
 	[[ $# -gt 2 ]] && usage "too many arguments specified"
 	CONTAINER="$2"
 	destroy
+	;;
+run)
+	[[ $# -lt 3 ]] && usage "too few arguments specified"
+	CONTAINER="$2"
+	shift 2
+	run "$@"
 	;;
 *)
 	usage

--- a/live-build/misc/upgrade-scripts/verify
+++ b/live-build/misc/upgrade-scripts/verify
@@ -89,8 +89,7 @@ report_progress_inc 20 "Starting upgrade verification container"
 
 report_progress_inc 40 "Performing package upgrade verification"
 
-systemd-run --machine="$CONTAINER" --quiet --pipe --wait -- \
-	"$TOP/execute" "$DLPX_VERSION" ||
+"$TOP/upgrade-container" run "$CONTAINER" "$TOP/execute" "$DLPX_VERSION" ||
 	die "'$TOP/execute' failed in verification container"
 
 report_progress_inc 60 "Performing application upgrade verification"
@@ -103,7 +102,7 @@ if $opt_d; then
 	VERIFY_LIVE_MDS_OPT="-disableConsistentMdsZfsDataUtil"
 fi
 
-systemd-run --machine="$CONTAINER" --quiet --pipe --wait -- \
+"$TOP/upgrade-container" run "$CONTAINER" \
 	/usr/bin/java \
 	-Dlog.dir=/var/delphix/server/upgrade-verify \
 	-Dmdsverify=true \
@@ -123,11 +122,11 @@ systemd-run --machine="$CONTAINER" --quiet --pipe --wait -- \
 #
 MDS_SNAPNAME="MDS-CLONE-upgradeverify"
 
-systemd-run --machine="$CONTAINER" --quiet --pipe --wait -- \
+"$TOP/upgrade-container" run "$CONTAINER" \
 	/opt/delphix/server/bin/dx_manage_pg stop -s "$MDS_SNAPNAME" ||
 	die "failed to stop postgres"
 
-systemd-run --machine="$CONTAINER" --quiet --pipe --wait -- \
+"$TOP/upgrade-container" run "$CONTAINER" \
 	/opt/delphix/server/bin/dx_manage_pg cleanup -s "$MDS_SNAPNAME" ||
 	die "failed to cleanup postgres"
 


### PR DESCRIPTION
This change adds a new "run" option to the "upgrade-container" script
which is a wrapper around the "systemd-run" command. This is meant to
make it slighly easier to run commands in a given upgrade container
during development and/or testing.

This also provides a thin layer of encapsulation between users/scripts
that need to run commands in the container, and the details of actually
doing that (e.g. we could potentially modify the implementation of this
"run" option without modifying the consumers of it).