### PR TITLE
Infer version from path of script being executed

### DIFF
--- a/live-build/misc/upgrade-scripts/common.sh
+++ b/live-build/misc/upgrade-scripts/common.sh
@@ -22,3 +22,11 @@ function die() {
 	echo "$(basename "$0"): $*" >&2
 	exit 1
 }
+
+function get_image_path() {
+	readlink -f "${BASH_SOURCE%/*}"
+}
+
+function get_image_version() {
+	basename "$(get_image_path)"
+}

--- a/live-build/misc/upgrade-scripts/execute
+++ b/live-build/misc/upgrade-scripts/execute
@@ -17,6 +17,9 @@
 
 . "${BASH_SOURCE%/*}/common.sh"
 
+IMAGE_VERSION=$(get_image_version)
+[[ -n "$IMAGE_VERSION" ]] || die "failed to determine image version"
+
 set -o pipefail
 
 function usage() {
@@ -39,21 +42,18 @@ while getopts ':' c; do
 	esac
 done
 
-[[ $# -eq 1 ]] || die "Must specify a target verison."
-DLPX_VERSION="$1"
-
 [[ -d "$UPDATE_DIR" ]] || die "update directory '$UPDATE_DIR' does not exist"
-[[ -d "$UPDATE_DIR/$DLPX_VERSION" ]] ||
-	die "upgrade image for version '$DLPX_VERSION' was not unpacked"
-[[ -f "$UPDATE_DIR/$DLPX_VERSION/version.info" ]] ||
-	die "upgrade image for version '$DLPX_VERSION' is missing version.info"
+[[ -d "$UPDATE_DIR/$IMAGE_VERSION" ]] ||
+	die "upgrade image for version '$IMAGE_VERSION' was not unpacked"
+[[ -f "$UPDATE_DIR/$IMAGE_VERSION/version.info" ]] ||
+	die "upgrade image for version '$IMAGE_VERSION' is missing version.info"
 
 #
 # We need to be careful when sourcing this file, since it can conflict
 # with (and clobber) functions and/or variables previously defined.
 #
-. "$UPDATE_DIR/$DLPX_VERSION/version.info" ||
-	die "failed to source version.info file for version '$DLPX_VERSION'"
+. "$UPDATE_DIR/$IMAGE_VERSION/version.info" ||
+	die "failed to source version.info file for version '$IMAGE_VERSION'"
 
 [[ -n "$VERSION" ]] ||
 	die "VERSION variable is empty after sourcing version.info"
@@ -62,7 +62,7 @@ DLPX_VERSION="$1"
 	die "MINIMUM_VERSION variable is empty after sourcing version.info"
 
 cat <<EOF >/etc/apt/sources.list ||
-	deb [trusted=yes] file://$UPDATE_DIR/$DLPX_VERSION/public bionic delphix
+deb [trusted=yes] file://$UPDATE_DIR/$IMAGE_VERSION/public bionic delphix
 EOF
 	die "failed to configure apt sources"
 

--- a/live-build/misc/upgrade-scripts/upgrade-container
+++ b/live-build/misc/upgrade-scripts/upgrade-container
@@ -17,6 +17,9 @@
 
 . "${BASH_SOURCE%/*}/common.sh"
 
+IMAGE_VERSION=$(get_image_version)
+[[ -n "$IMAGE_VERSION" ]] || die "failed to determine image version"
+
 CONTAINER=
 
 function create_cleanup() {
@@ -201,7 +204,7 @@ function create_upgrade_container_not_in_place() {
 	#
 	debootstrap --no-check-gpg \
 		--components=delphix --include=systemd-container \
-		bionic "$DIRECTORY" "file://$UPDATE_DIR/$DLPX_VERSION/public" \
+		bionic "$DIRECTORY" "file://$UPDATE_DIR/$IMAGE_VERSION/public" \
 		1>&2 || die "failed to debootstrap upgrade filesystem"
 
 	create_upgrade_container_common
@@ -291,9 +294,8 @@ create)
 		create_upgrade_container_in_place
 		;;
 	not-in-place)
-		[[ $# -lt 3 ]] && usage "too few arguments specified"
-		[[ $# -gt 3 ]] && usage "too many arguments specified"
-		DLPX_VERSION="$3"
+		[[ $# -lt 2 ]] && usage "too few arguments specified"
+		[[ $# -gt 2 ]] && usage "too many arguments specified"
 		create_upgrade_container_not_in_place
 		;;
 	*)
@@ -327,6 +329,6 @@ run)
 	run "$@"
 	;;
 *)
-	usage
+	usage "invalid option specified: '$1'"
 	;;
 esac

--- a/live-build/misc/upgrade-scripts/verify
+++ b/live-build/misc/upgrade-scripts/verify
@@ -15,8 +15,13 @@
 # limitations under the License.
 #
 
-TOP="${BASH_SOURCE%/*}"
-. "$TOP/common.sh"
+. "${BASH_SOURCE%/*}/common.sh"
+
+IMAGE_PATH=$(get_image_path)
+[[ -n "$IMAGE_PATH" ]] || die "failed to determine image path"
+
+IMAGE_VERSION=$(get_image_version)
+[[ -n "$IMAGE_VERSION" ]] || die "failed to determine image version"
 
 function usage() {
 	echo "$(basename "$0"): $*" >&2
@@ -54,8 +59,8 @@ function cleanup() {
 	else
 		report_progress_inc 80 "Performing upgrade verification cleanup"
 
-		"$TOP/upgrade-container" stop "$CONTAINER"
-		"$TOP/upgrade-container" destroy "$CONTAINER"
+		"$IMAGE_PATH/upgrade-container" stop "$CONTAINER"
+		"$IMAGE_PATH/upgrade-container" destroy "$CONTAINER"
 	fi
 
 	[[ $rc -eq 0 ]] &&
@@ -63,9 +68,8 @@ function cleanup() {
 }
 
 opt_d=false
-while getopts ':df:l:o:v:' c; do
+while getopts ':df:l:o:' c; do
 	case "$c" in
-	v) DLPX_VERSION=$OPTARG ;;
 	f | l | o) eval "opt_$c=$OPTARG" ;;
 	d) eval "opt_$c=true" ;;
 	*) usage "illegal option -- $OPTARG" ;;
@@ -73,24 +77,23 @@ while getopts ':df:l:o:v:' c; do
 done
 
 [[ "$EUID" -ne 0 ]] && die "must be run as root"
-[[ -n "$DLPX_VERSION" ]] || usage
 
 trap cleanup EXIT
 
 report_progress_inc 0 "Creating upgrade verification container"
 
-CONTAINER=$("$TOP/upgrade-container" create in-place)
+CONTAINER=$("$IMAGE_PATH/upgrade-container" create in-place)
 [[ -n "$CONTAINER" ]] || die "failed to create verify container"
 
 report_progress_inc 20 "Starting upgrade verification container"
 
-"$TOP/upgrade-container" start "$CONTAINER" ||
+"$IMAGE_PATH/upgrade-container" start "$CONTAINER" ||
 	die "failed to start verify container '$CONTAINER'"
 
 report_progress_inc 40 "Performing package upgrade verification"
 
-"$TOP/upgrade-container" run "$CONTAINER" "$TOP/execute" "$DLPX_VERSION" ||
-	die "'$TOP/execute' failed in verification container"
+"$IMAGE_PATH/upgrade-container" run "$CONTAINER" "$IMAGE_PATH/execute" ||
+	die "'$IMAGE_PATH/execute' failed in verification container"
 
 report_progress_inc 60 "Performing application upgrade verification"
 
@@ -102,7 +105,7 @@ if $opt_d; then
 	VERIFY_LIVE_MDS_OPT="-disableConsistentMdsZfsDataUtil"
 fi
 
-"$TOP/upgrade-container" run "$CONTAINER" \
+"$IMAGE_PATH/upgrade-container" run "$CONTAINER" \
 	/usr/bin/java \
 	-Dlog.dir=/var/delphix/server/upgrade-verify \
 	-Dmdsverify=true \
@@ -111,7 +114,7 @@ fi
 	-d "${opt_o:-$DROPBOX_DIR/upgrade_verify_report.json}" \
 	-f "${opt_f:-1}" \
 	-l "${opt_l:-en-US}" \
-	-v "$DLPX_VERSION" \
+	-v "$IMAGE_VERSION" \
 	-pl 60 -ph 80 \
 	$VERIFY_LIVE_MDS_OPT ||
 	die "'upgrade-verify.jar' failed in verification container"
@@ -122,11 +125,11 @@ fi
 #
 MDS_SNAPNAME="MDS-CLONE-upgradeverify"
 
-"$TOP/upgrade-container" run "$CONTAINER" \
+"$IMAGE_PATH/upgrade-container" run "$CONTAINER" \
 	/opt/delphix/server/bin/dx_manage_pg stop -s "$MDS_SNAPNAME" ||
 	die "failed to stop postgres"
 
-"$TOP/upgrade-container" run "$CONTAINER" \
+"$IMAGE_PATH/upgrade-container" run "$CONTAINER" \
 	/opt/delphix/server/bin/dx_manage_pg cleanup -s "$MDS_SNAPNAME" ||
 	die "failed to cleanup postgres"
 


### PR DESCRIPTION
This changes the interface of the upgrade scripts such that the version
being used for the upgrade or verification does not have to be specified
as an option/parameter to the script. Rather, we now infer the version
from the path of the script being executed, since all of these scripts
will reside in a version specific subdirectory of "/var/dlpx-update".

This eliminates the inconsistency between the scripts, where some would
require the version to be specified using "-v", and others would require
the version to be passed as a positional parameter.