### PR TITLE
Add "upgrade" script that can upgrade an appliance

### DIFF
--- a/live-build/misc/upgrade-scripts/common.sh
+++ b/live-build/misc/upgrade-scripts/common.sh
@@ -23,6 +23,10 @@ function die() {
 	exit 1
 }
 
+function warn() {
+	echo "$(basename "$0"): $*" >&2
+}
+
 function get_image_path() {
 	readlink -f "${BASH_SOURCE%/*}"
 }

--- a/live-build/misc/upgrade-scripts/upgrade
+++ b/live-build/misc/upgrade-scripts/upgrade
@@ -1,0 +1,198 @@
+#!/bin/bash
+#
+# Copyright 2018 Delphix
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+. "${BASH_SOURCE%/*}/common.sh"
+
+IMAGE_PATH=$(get_image_path)
+[[ -n "$IMAGE_PATH" ]] || die "failed to determine image path"
+
+#
+# This variable is used to determine if the application verification
+# checks should be run as part of the upgrade. The default value can be
+# overridden by setting this environment variable to "true", and/or
+# passing the "-v" option to this script (see the scripts usage). If
+# both, the environment variable and the "-v" option are specified, the
+# "-v" option takes precedence.
+#
+DLPX_UPGRADE_SKIP_VERIFY=${DLPX_UPGRADE_SKIP_VERIFY:-"false"}
+
+function usage() {
+	echo "$(basename "$0"): $*" >&2
+
+	PREFIX_STRING="Usage: $(basename "$0")"
+	PREFIX_NCHARS=$(echo -n "$PREFIX_STRING" | wc -c)
+	PREFIX_SPACES=$(printf "%.s " $(seq "$PREFIX_NCHARS"))
+
+	echo "$PREFIX_STRING [-v] in-place"
+	echo "$PREFIX_SPACES [-v] not-in-place"
+
+	exit 2
+}
+
+function cleanup_container() {
+	#
+	# If the CONTAINER variable is empty, this means container
+	# creation failed. In that case, the container creation process
+	# will have already cleaned up after itself, and there's no
+	# further cleanup for us to do here.
+	#
+	[[ -z "$CONTAINER" ]] && return
+
+	"$IMAGE_PATH/upgrade-container" stop "$CONTAINER" ||
+		warn "failed to stop '$CONTAINER'"
+
+	"$IMAGE_PATH/upgrade-container" destroy "$CONTAINER" ||
+		warn "failed to destroy '$CONTAINER'"
+}
+
+function cleanup_in_place_upgrade() {
+	#
+	# Capture the exit code here, and use that to determine if
+	# upgrade verification was successful or not.
+	#
+	local rc="$?"
+
+	if [[ "$rc" == "0" || "$DLPX_DEBUG" != "true" ]]; then
+		#
+		# On success, or on failure when DLPX_DEBUG is not true,
+		# we clean up the container previously created. When
+		# DLPX_DEBUG is true, we leave the container around on
+		# failure to aid debugging efforts.
+		#
+		cleanup_container
+	fi
+
+	return "$rc"
+}
+
+function upgrade_in_place() {
+	trap cleanup_in_place_upgrade EXIT
+
+	CONTAINER=$("$IMAGE_PATH/upgrade-container" create in-place)
+	[[ -n "$CONTAINER" ]] || die "failed to create container"
+
+	"$IMAGE_PATH/upgrade-container" start "$CONTAINER" ||
+		die "failed to start '$CONTAINER'"
+
+	"$IMAGE_PATH/upgrade-container" run "$CONTAINER" \
+		"$IMAGE_PATH/execute" ||
+		die "'$IMAGE_PATH/execute' failed in '$CONTAINER'"
+
+	"$IMAGE_PATH/upgrade-container" run "$CONTAINER" \
+		/bin/systemctl start delphix-platform ||
+		die "'systemctl start delphix-platform' failed in '$CONTAINER'"
+
+	if [[ "$DLPX_UPGRADE_SKIP_VERIFY" != "true" ]]; then
+		"$IMAGE_PATH/upgrade-container" run "$CONTAINER" \
+			"$IMAGE_PATH/verify-impl" "$@" ||
+			die "'$IMAGE_PATH/verify-impl' '$*' failed in '$CONTAINER'"
+	fi
+
+	"$IMAGE_PATH/execute" ||
+		die "'$IMAGE_PATH/execute' failed in running appliance."
+}
+
+function cleanup_not_in_place_upgrade() {
+	#
+	# Capture the exit code here, and use that to determine if
+	# upgrade verification was successful or not.
+	#
+	local rc="$?"
+
+	if [[ "$rc" != "0" && "$DLPX_DEBUG" != "true" ]]; then
+		#
+		# On failure and when DLPX_DEBUG is not true, we clean
+		# up the container previously created.
+		#
+		# Unlike in-place upgrades, the container is not cleaned
+		# up on success; instead the container will have been
+		# already stopped and converted to be used as the root
+		# filesystem for the appliance after the next reboot.
+		#
+		cleanup_container
+	fi
+
+	return "$rc"
+}
+
+function upgrade_not_in_place() {
+	trap cleanup_not_in_place_upgrade EXIT
+
+	CONTAINER=$("$IMAGE_PATH/upgrade-container" create not-in-place)
+	[[ -n "$CONTAINER" ]] || die "failed to create upgrade container"
+
+	"$IMAGE_PATH/upgrade-container" start "$CONTAINER" ||
+		die "failed to start upgrade '$CONTAINER'"
+
+	"$IMAGE_PATH/upgrade-container" run "$CONTAINER" \
+		"$IMAGE_PATH/execute" ||
+		die "'$IMAGE_PATH/execute' failed in '$CONTAINER'"
+
+	"$IMAGE_PATH/upgrade-container" run "$CONTAINER" \
+		/bin/systemctl start delphix-platform ||
+		die "'systemctl start delphix-platform' failed in '$CONTAINER'"
+
+	if [[ "$DLPX_UPGRADE_SKIP_VERIFY" != "true" ]]; then
+		"$IMAGE_PATH/upgrade-container" run "$CONTAINER" \
+			"$IMAGE_PATH/verify-impl" "$@" ||
+			die "'$IMAGE_PATH/verify-impl' '$*' failed in '$CONTAINER'"
+	fi
+
+	"$IMAGE_PATH/upgrade-container" stop "$CONTAINER" ||
+		die "failed to stop '$CONTAINER'"
+
+	#
+	# After this point, we no longer want to execute the normal
+	# cleanup handler on any failure. The following command will
+	# convert the container to be used as the next boot/root
+	# filesystem, and thus the "stop" and "destroy" container logic
+	# will no longer work. So, if the "convert-to-bootfs" script
+	# fails, we'll need to manually rectify the situation.
+	#
+	trap - EXIT
+
+	"$IMAGE_PATH/upgrade-container" convert-to-bootfs "$CONTAINER" ||
+		die "failed to convert-to-bootfs '$CONTAINER'"
+}
+
+[[ "$EUID" -ne 0 ]] && die "must be run as root"
+
+while getopts ':v' c; do
+	case "$c" in
+	v)
+		DLPX_UPGRADE_SKIP_VERIFY="true"
+		;;
+	*)
+		usage "invalid option -- '$c'"
+		;;
+	esac
+done
+shift $((OPTIND - 1))
+
+case "$1" in
+in-place)
+	shift 1
+	upgrade_in_place "$@"
+	;;
+not-in-place)
+	shift 1
+	upgrade_not_in_place "$@"
+	;;
+*)
+	usage "invalid option -- '$1'"
+	;;
+esac

--- a/live-build/misc/upgrade-scripts/upgrade-container
+++ b/live-build/misc/upgrade-scripts/upgrade-container
@@ -146,6 +146,16 @@ function create_upgrade_container_common() {
 	echo "$CONTAINER"
 }
 
+function get_mounted_rootfs_name() {
+	local rootfs
+
+	rootfs=$(mount | awk '$3 == "/" {print $1}')
+	[[ -n "$rootfs" ]] ||
+		die "failed to determine the mounted root filesystem name"
+
+	echo "$rootfs"
+}
+
 function create_upgrade_container_in_place() {
 	trap create_cleanup EXIT
 
@@ -161,10 +171,11 @@ function create_upgrade_container_in_place() {
 	CONTAINER=$(basename "$DIRECTORY")
 	[[ -n "$CONTAINER" ]] || die "failed to obtain upgrade name"
 
-	zfs snapshot "rpool/ROOT/ubuntu@$CONTAINER" ||
+	ROOTFS=$(get_mounted_rootfs_name)
+	zfs snapshot "$ROOTFS@$CONTAINER" ||
 		die "failed to create upgrade snapshot"
 	zfs clone -o mountpoint="$DIRECTORY" \
-		"rpool/ROOT/ubuntu@$CONTAINER" \
+		"$ROOTFS@$CONTAINER" \
 		"rpool/ROOT/$CONTAINER" ||
 		die "failed to create upgrade clone"
 
@@ -258,8 +269,9 @@ function destroy() {
 			die "failed to destroy container dataset: '$CONTAINER'"
 	fi
 
-	if zfs list "rpool/ROOT/ubuntu@$CONTAINER" &>/dev/null; then
-		zfs destroy "rpool/ROOT/ubuntu@$CONTAINER" ||
+	ROOTFS=$(get_mounted_rootfs_name)
+	if zfs list "$ROOTFS@$CONTAINER" &>/dev/null; then
+		zfs destroy "$ROOTFS@$CONTAINER" ||
 			die "failed to destroy container snapshot: '$CONTAINER'"
 	fi
 
@@ -273,12 +285,149 @@ function run() {
 	systemd-run --machine="$CONTAINER" --quiet --wait --pipe -- "$@"
 }
 
+function get_bootloader_devices() {
+	#
+	# When installing/updating the bootloader during upgrade, we
+	# need to determine which devices are being used as bootloader
+	# devices. We determine this by listing the devices used by the
+	# rpool. Additionally, we have to filter out devices that could
+	# be attached to the rpool, but would never be used for the
+	# bootloader. Finally, we need to strip off any parition
+	# information, since we want to install the bootloader directly
+	# to the device, rather than to a partition of the device.
+	#
+	zpool list -vH rpool |
+		awk '! /rpool|mirror|replacing|spare/ {print $1}' |
+		sed 's/[0-9]*$//'
+}
+
+function migrate_password_for_user() {
+	local user="$1"
+	local password
+
+	password="$(awk -F: "\$1 == \"$user\" {print \$2}" /etc/shadow)"
+	chroot "/var/lib/machines/$CONTAINER" usermod -p "$password" "$user" ||
+		die "'usermod -p ... $user' failed for '$CONTAINER'"
+}
+
+function migrate_file() {
+	local path="$1"
+	local directory
+
+	if [[ -f "$path" ]]; then
+		directory="$(dirname "$path")"
+		mkdir -p "/var/lib/machines/${CONTAINER}${directory}" ||
+			die "'mkdir -p $directory' failed for '$CONTAINER'"
+		cp "$path" "/var/lib/machines/${CONTAINER}${path}" ||
+			die "'cp $path' failed for '$CONTAINER'"
+	fi
+}
+
+function convert_to_bootfs_cleanup() {
+	for dir in /proc /sys /dev; do
+		umount -R "/var/lib/machines/${CONTAINER}${dir}" ||
+			warn "'umount -R' of '$dir' failed"
+	done
+}
+
+#
+# The purpose of this function is to convert an existing upgrade
+# container (specified by the $CONTAINER global variable) into the next
+# boot filesystem used by the appliance; i.e. after calling this
+# function, the container's root filesystem will be used as the
+# appliance's root filesystem, the next time the appliance boots.
+#
+# This is done by updating the appliance's bootloader (i.e. grub) to
+# point to the container's filesystem, along with setting the mountpoint
+# of the filesystem to be "/" instead of "/var/lib/machines/$CONTAINER".
+# This effectively removes the container, since systemd-nspawn only
+# looks in /var/lib/machines, so it'll no longer find the container
+# after the mountpoint changes.
+#
+function convert_to_bootfs() {
+	trap convert_to_bootfs_cleanup EXIT
+
+	for dir in /proc /sys /dev; do
+		mount --rbind "$dir" "/var/lib/machines/${CONTAINER}${dir}" ||
+			die "'mount --rbind' of '$dir' failed"
+		mount --make-rslave "/var/lib/machines/${CONTAINER}${dir}" ||
+			die "'mount --make-rslave' of '$dir' failed"
+	done
+
+	#
+	# When performing a not-in-place upgrade, the root and delphix
+	# users will not have any password by default. Thus, we need to
+	# explicitly configure the passwords on the new root filesystem.
+	# Here, we ensure the passwords for the root and delphix user on
+	# the new root filesystem match their current values.
+	#
+	migrate_password_for_user delphix
+	migrate_password_for_user root
+
+	#
+	# LX-72 Until we have a proper solution for migrating the
+	# configuration of a given appliance to the new root filesystem
+	# (i.e. any configuration that isn't supplied by a package), we
+	# resort to explicitly migrating some of this configuration
+	# here. The files listed here are dynamically generated and/or
+	# modified by appliance-build.
+	#
+	while read -r file; do
+		migrate_file "$file"
+	done <<-EOF
+		/etc/cloud/cloud.cfg.d/99-delphix-development.cfg
+		/etc/cloud/cloud.cfg.d/99-delphix-internal.cfg
+		/etc/issue
+		/etc/nftables.conf
+		/etc/ssh/sshd_config
+		/etc/systemd/system/delphix-masking.service.d/override.conf
+		/etc/systemd/system/delphix-mgmt.service.d/override.conf
+		/etc/systemd/system/delphix-postgres@.service.d/override.conf
+		/var/opt/delphix/server.conf
+	EOF
+
+	chroot "/var/lib/machines/$CONTAINER" update-grub ||
+		die "'update-grub' failed in '$CONTAINER'"
+
+	for dev in $(get_bootloader_devices); do
+		[[ -e "/dev/$dev" ]] ||
+			die "bootloader device '/dev/$dev' not found"
+
+		[[ -b "/dev/$dev" ]] ||
+			die "bootloader device '/dev/$dev' not block device"
+
+		chroot "/var/lib/machines/$CONTAINER" \
+			grub-install "/dev/$dev" ||
+			die "'grub-install /dev/$dev' failed in '$CONTAINER'"
+	done
+
+	convert_to_bootfs_cleanup
+	trap - EXIT
+
+	zfs umount "rpool/ROOT/$CONTAINER" ||
+		die "'zfs umount rpool/ROOT/$CONTAINER' failed"
+
+	zfs set canmount=noauto "rpool/ROOT/$CONTAINER" ||
+		die "'zfs set canmount=noauto rpool/ROOT/$CONTAINER' failed"
+
+	zfs set mountpoint=/ "rpool/ROOT/$CONTAINER" ||
+		die "'zfs set mountpoint=/ rpool/ROOT/$CONTAINER' failed"
+}
+
 function usage() {
 	echo "$(basename "$0"): $*" >&2
-	echo "Usage: $(basename "$0") create  [in-place|not-in-place <version>]"
-	echo "                        start   <container>"
-	echo "                        stop    <container>"
-	echo "                        destroy <container>"
+
+	PREFIX_STRING="Usage: $(basename "$0")"
+	PREFIX_NCHARS=$(echo -n "$PREFIX_STRING" | wc -c)
+	PREFIX_SPACES=$(printf "%.s " $(seq "$PREFIX_NCHARS"))
+
+	echo "$PREFIX_STRING create [in-place|not-in-place]"
+	echo "$PREFIX_SPACES start <container>"
+	echo "$PREFIX_SPACES stop <container>"
+	echo "$PREFIX_SPACES destroy <container>"
+	echo "$PREFIX_SPACES run <container> <command>"
+	echo "$PREFIX_SPACES convert-to-bootfs <container>"
+
 	exit 2
 }
 
@@ -327,6 +476,12 @@ run)
 	CONTAINER="$2"
 	shift 2
 	run "$@"
+	;;
+convert-to-bootfs)
+	[[ $# -lt 2 ]] && usage "too few arguments specified"
+	[[ $# -gt 2 ]] && usage "too many arguments specified"
+	CONTAINER="$2"
+	convert_to_bootfs
 	;;
 *)
 	usage "invalid option specified: '$1'"

--- a/live-build/misc/upgrade-scripts/verify
+++ b/live-build/misc/upgrade-scripts/verify
@@ -20,16 +20,9 @@
 IMAGE_PATH=$(get_image_path)
 [[ -n "$IMAGE_PATH" ]] || die "failed to determine image path"
 
-IMAGE_VERSION=$(get_image_version)
-[[ -n "$IMAGE_VERSION" ]] || die "failed to determine image version"
+[[ "$EUID" -ne 0 ]] && die "must be run as root"
 
-function usage() {
-	echo "$(basename "$0"): $*" >&2
-	echo "Usage: $(basename "$0") -v <version>"
-	exit 2
-}
-
-function report_progress_inc() {
+function report_progress() {
 	echo "Progress increment: $(date +%T:%N%z), $1, $2"
 }
 
@@ -48,94 +41,46 @@ function cleanup() {
 	#
 	[[ -z "$CONTAINER" ]] && return
 
-	#
-	# On failure, and when DLPX_DEBUG is true, we avoid cleaning up
-	# the verification container. This is intended to make it easier
-	# to diagnose and debug verification failures on developer
-	# machines.
-	#
-	if [[ $rc -ne 0 ]] && [[ -n "$DLPX_DEBUG" ]] && $DLPX_DEBUG; then
-		report_progress_inc 80 "Skipping upgrade verification cleanup"
-	else
-		report_progress_inc 80 "Performing upgrade verification cleanup"
+	if [[ "$rc" == "0" || "$DLPX_DEBUG" != "true" ]]; then
+		report_progress 80 "Performing upgrade verification cleanup"
 
-		"$IMAGE_PATH/upgrade-container" stop "$CONTAINER"
-		"$IMAGE_PATH/upgrade-container" destroy "$CONTAINER"
+		#
+		# On success, or on failure when DLPX_DEBUG is not true,
+		# we clean up the container previously created. When
+		# DLPX_DEBUG is true, we leave the container around on
+		# failure to aid debugging efforts.
+		#
+		"$IMAGE_PATH/upgrade-container" stop "$CONTAINER" ||
+			warn "failed to stop container '$CONTAINER'"
+		"$IMAGE_PATH/upgrade-container" destroy "$CONTAINER" ||
+			warn "failed to stop container '$CONTAINER'"
+	else
+		report_progress 80 "Skipping upgrade verification cleanup"
 	fi
 
-	[[ $rc -eq 0 ]] &&
-		report_progress_inc 100 "Upgrade verification was successful"
+	return "$rc"
 }
-
-opt_d=false
-while getopts ':df:l:o:' c; do
-	case "$c" in
-	f | l | o) eval "opt_$c=$OPTARG" ;;
-	d) eval "opt_$c=true" ;;
-	*) usage "illegal option -- $OPTARG" ;;
-	esac
-done
-
-[[ "$EUID" -ne 0 ]] && die "must be run as root"
 
 trap cleanup EXIT
 
-report_progress_inc 0 "Creating upgrade verification container"
-
+report_progress 0 "Creating upgrade verification container"
 CONTAINER=$("$IMAGE_PATH/upgrade-container" create in-place)
-[[ -n "$CONTAINER" ]] || die "failed to create verify container"
+[[ -n "$CONTAINER" ]] || die "failed to create container"
 
-report_progress_inc 20 "Starting upgrade verification container"
-
+report_progress 20 "Starting upgrade verification container"
 "$IMAGE_PATH/upgrade-container" start "$CONTAINER" ||
-	die "failed to start verify container '$CONTAINER'"
+	die "failed to start '$CONTAINER'"
 
-report_progress_inc 40 "Performing package upgrade verification"
-
+report_progress 40 "Performing package upgrade verification"
 "$IMAGE_PATH/upgrade-container" run "$CONTAINER" "$IMAGE_PATH/execute" ||
-	die "'$IMAGE_PATH/execute' failed in verification container"
+	die "'$IMAGE_PATH/execute' failed in '$CONTAINER'"
 
-report_progress_inc 60 "Performing application upgrade verification"
-
-if [[ -n "$DLPX_DEBUG" ]] && $DLPX_DEBUG; then
-	VERIFY_DEBUG_OPT="-Ddelphix.debug=true"
-fi
-
-if $opt_d; then
-	VERIFY_LIVE_MDS_OPT="-disableConsistentMdsZfsDataUtil"
-fi
-
+report_progress 60 "Performing application upgrade verification"
 "$IMAGE_PATH/upgrade-container" run "$CONTAINER" \
-	/usr/bin/java \
-	-Dlog.dir=/var/delphix/server/upgrade-verify \
-	-Dmdsverify=true \
-	$VERIFY_DEBUG_OPT \
-	-jar /opt/delphix/server/lib/exec/upgrade-verify/upgrade-verify.jar \
-	-d "${opt_o:-$DROPBOX_DIR/upgrade_verify_report.json}" \
-	-f "${opt_f:-1}" \
-	-l "${opt_l:-en-US}" \
-	-v "$IMAGE_VERSION" \
-	-pl 60 -ph 80 \
-	$VERIFY_LIVE_MDS_OPT ||
-	die "'upgrade-verify.jar' failed in verification container"
-
-#
-# This name is used by the "upgrade-verify.jar" just executed, so we
-# cannot change this value without also modifying that JAR.
-#
-MDS_SNAPNAME="MDS-CLONE-upgradeverify"
-
-"$IMAGE_PATH/upgrade-container" run "$CONTAINER" \
-	/opt/delphix/server/bin/dx_manage_pg stop -s "$MDS_SNAPNAME" ||
-	die "failed to stop postgres"
-
-"$IMAGE_PATH/upgrade-container" run "$CONTAINER" \
-	/opt/delphix/server/bin/dx_manage_pg cleanup -s "$MDS_SNAPNAME" ||
-	die "failed to cleanup postgres"
+	"$IMAGE_PATH/verify-impl" "$@" ||
+	die "'$IMAGE_PATH/verify-impl' '$*' failed in '$CONTAINER'"
 
 #
 # The cleanup logic will be run on EXIT, so rather than reporting 100
 # percent here, we use the cleanup logic to do the final reporting.
 #
-
-exit 0

--- a/live-build/misc/upgrade-scripts/verify-impl
+++ b/live-build/misc/upgrade-scripts/verify-impl
@@ -1,0 +1,73 @@
+#!/bin/bash
+#
+# Copyright 2018 Delphix
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+. "${BASH_SOURCE%/*}/common.sh"
+
+IMAGE_VERSION=$(get_image_version)
+[[ -n "$IMAGE_VERSION" ]] || die "failed to determine image version"
+
+function usage() {
+	echo "$(basename "$0"): $*" >&2
+	echo "Usage: $(basename "$0") [-d] [-f format] [-l locale] [-o path]"
+	exit 2
+}
+
+opt_d=false
+while getopts ':df:l:o:' c; do
+	case "$c" in
+	f | l | o) eval "opt_$c=$OPTARG" ;;
+	d) eval "opt_$c=true" ;;
+	*) usage "illegal option -- $OPTARG" ;;
+	esac
+done
+
+[[ "$EUID" -ne 0 ]] && die "must be run as root"
+
+if [[ -n "$DLPX_DEBUG" ]] && $DLPX_DEBUG; then
+	VERIFY_DEBUG_OPT="-Ddelphix.debug=true"
+fi
+
+if $opt_d; then
+	VERIFY_LIVE_MDS_OPT="-disableConsistentMdsZfsDataUtil"
+fi
+
+/usr/bin/java \
+	-Dlog.dir=/var/delphix/server/upgrade-verify \
+	-Dmdsverify=true \
+	$VERIFY_DEBUG_OPT \
+	-jar /opt/delphix/server/lib/exec/upgrade-verify/upgrade-verify.jar \
+	-d "${opt_o:-$DROPBOX_DIR/upgrade_verify_report.json}" \
+	-f "${opt_f:-1}" \
+	-l "${opt_l:-en-US}" \
+	-v "$IMAGE_VERSION" \
+	-pl 60 -ph 80 \
+	$VERIFY_LIVE_MDS_OPT ||
+	die "'upgrade-verify.jar' failed in verification container"
+
+#
+# This name is used by the "upgrade-verify.jar" just executed, so we
+# cannot change this value without also modifying that JAR.
+#
+MDS_SNAPNAME="MDS-CLONE-upgradeverify"
+
+/opt/delphix/server/bin/dx_manage_pg stop -s "$MDS_SNAPNAME" ||
+	die "failed to stop postgres"
+
+/opt/delphix/server/bin/dx_manage_pg cleanup -s "$MDS_SNAPNAME" ||
+	die "failed to cleanup postgres"
+
+exit 0


### PR DESCRIPTION
This change adds a new "upgrade" script to the set of upgrade-scripts. This
new script is intended to be used to upgrade an existing appliance to the
version contained in the upgrade image; it script supports both,
"in-place" and "not-in-place" upgrades.