### PR TITLE
Configure delphix user's password during build

### DIFF
--- a/live-build/misc/ansible-roles/appliance-build.masking-development/tasks/main.yml
+++ b/live-build/misc/ansible-roles/appliance-build.masking-development/tasks/main.yml
@@ -15,10 +15,6 @@
 #
 
 ---
-- fail:
-    msg: "Required environment variable 'APPLIANCE_USERNAME' is empty."
-  when: lookup('env', 'APPLIANCE_USERNAME') == ''
-
 - apt:
     name: "{{ item }}"
     state: present
@@ -32,7 +28,7 @@
 - git:
     repo: "{{ item.repo }}"
     dest:
-      "/export/home/{{ lookup('env', 'APPLIANCE_USERNAME') }}/{{ item.dest }}"
+      "/export/home/delphix/{{ item.dest }}"
     version: "{{ item.version }}"
     accept_hostkey: yes
     update: no
@@ -42,8 +38,8 @@
         dest: dms-core-gate }
 
 - file:
-    path: "/export/home/{{ lookup('env', 'APPLIANCE_USERNAME') }}/{{ item }}"
-    owner: "{{ lookup('env', 'APPLIANCE_USERNAME') }}"
+    path: "/export/home/delphix/{{ item }}"
+    owner: "delphix"
     group: staff
     mode: "g+w"
     state: directory

--- a/live-build/misc/ansible-roles/appliance-build.minimal-common/tasks/main.yml
+++ b/live-build/misc/ansible-roles/appliance-build.minimal-common/tasks/main.yml
@@ -16,6 +16,35 @@
 
 ---
 #
+# When using the APPLIANCE_PASSWORD variable, we have to be careful to
+# specify "no_log" to prevent it from being leaked to stdout (e.g. if
+# ansible is run with verbosity).
+#
+- fail:
+    msg: "Required environment variable 'APPLIANCE_PASSWORD' is empty."
+  when: lookup('env', 'APPLIANCE_PASSWORD') == ''
+  no_log: true
+
+#
+# While the "delphix-platform" package will take care of creating the
+# delphix user, it won't configure the user's password. Thus, we have to
+# do that here, during the intial build of the appliance.
+#
+- user:
+    name: delphix
+    password:
+      "{{ lookup('env', 'APPLIANCE_PASSWORD') | password_hash('sha512') }}"
+
+#
+# We also want the root user's password to match the delphix user's
+# password, so we also set that here.
+#
+- user:
+    name: root
+    password:
+      "{{ lookup('env', 'APPLIANCE_PASSWORD') | password_hash('sha512') }}"
+
+#
 # The virtualization package uses the /etc/issue file to store a
 # customer-supplied banner that is displayed prior to login. By default,
 # there should be no banner. Thus, we need to remove this file to

--- a/live-build/misc/ansible-roles/appliance-build.virtualization-development/tasks/main.yml
+++ b/live-build/misc/ansible-roles/appliance-build.virtualization-development/tasks/main.yml
@@ -15,20 +15,6 @@
 #
 
 ---
-#
-# When using the APPLIANCE_PASSWORD variable, we have to be careful to
-# specify "no_log" to prevent it from being leaked to stdout (e.g. if
-# ansible is run with verbosity).
-#
-- fail:
-    msg: "Required environment variable 'APPLIANCE_PASSWORD' is empty."
-  when: lookup('env', 'APPLIANCE_PASSWORD') == ''
-  no_log: true
-
-- fail:
-    msg: "Required environment variable 'APPLIANCE_USERNAME' is empty."
-  when: lookup('env', 'APPLIANCE_USERNAME') == ''
-
 - file:
     path: "/etc/systemd/system/delphix-mgmt.service.d"
     owner: root
@@ -62,7 +48,7 @@
 - git:
     repo: "{{ item.repo }}"
     dest:
-      "/export/home/{{ lookup('env', 'APPLIANCE_USERNAME') }}/{{ item.dest }}"
+      "/export/home/delphix/{{ item.dest }}"
     version: "{{ item.version }}"
     accept_hostkey: yes
     update: no
@@ -72,8 +58,8 @@
         dest: dlpx-app-gate }
 
 - file:
-    path: "/export/home/{{ lookup('env', 'APPLIANCE_USERNAME') }}/{{ item }}"
-    owner: "{{ lookup('env', 'APPLIANCE_USERNAME') }}"
+    path: "/export/home/delphix/{{ item }}"
+    owner: "delphix"
     group: staff
     mode: "g+w"
     state: directory
@@ -82,7 +68,7 @@
     - dlpx-app-gate
 
 - authorized_key:
-    user: "{{ lookup('env', 'APPLIANCE_USERNAME') }}"
+    user: "delphix"
     state: present
     key:
       "ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAyvw2gQRkDqrRY5qxUn0VYAL6Rtt1/\
@@ -98,8 +84,3 @@
     line: "{{ item.key }}={{ item.value }}"
   with_items:
     - { key: "PermitRootLogin", value: "yes" }
-
-- user:
-    name: root
-    password:
-      "{{ lookup('env', 'APPLIANCE_PASSWORD') | password_hash('sha512') }}"

--- a/live-build/misc/ansible-roles/appliance-build.zfsonlinux-development/tasks/main.yml
+++ b/live-build/misc/ansible-roles/appliance-build.zfsonlinux-development/tasks/main.yml
@@ -18,10 +18,6 @@
 # This role allows building ZFS on the appliance.
 #
 ---
-- fail:
-    msg: "Required environment variable 'APPLIANCE_USERNAME' is empty."
-  when: lookup('env', 'APPLIANCE_USERNAME') == ''
-
 - apt:
     name: "{{ item }}"
     state: present
@@ -62,14 +58,14 @@
 - git:
     repo: "https://github.com/delphix/zfs.git"
     dest:
-      "/export/home/{{ lookup('env', 'APPLIANCE_USERNAME') }}/zfs"
+      "/export/home/delphix/zfs"
     version: master
     accept_hostkey: yes
     update: no
 
 - file:
-    path: "/export/home/{{ lookup('env', 'APPLIANCE_USERNAME') }}/zfs"
-    owner: "{{ lookup('env', 'APPLIANCE_USERNAME') }}"
+    path: "/export/home/delphix/zfs"
+    owner: "delphix"
     group: staff
     state: directory
     recurse: yes

--- a/scripts/docker-run.sh
+++ b/scripts/docker-run.sh
@@ -52,7 +52,6 @@ $DOCKER_RUN --rm \
 	--env AWS_S3_URI_MASKING \
 	--env AWS_S3_URI_ZFS \
 	--env APPLIANCE_PASSWORD \
-	--env APPLIANCE_USERNAME \
 	--env AWS_ACCESS_KEY_ID \
 	--env AWS_SECRET_ACCESS_KEY \
 	--volume "$TOP:/opt/appliance-build" \

--- a/scripts/run-live-build.sh
+++ b/scripts/run-live-build.sh
@@ -41,10 +41,9 @@ set -o errexit
 set -o pipefail
 
 #
-# Allow the appliance username and password to be configured via these
-# environment variables, but use sane defaults if they're missing.
+# Allow the appliance user's password to be configured via this
+# environment variable, but use a sane default if its missing.
 #
-export APPLIANCE_USERNAME="${APPLIANCE_USERNAME:-delphix}"
 export APPLIANCE_PASSWORD="${APPLIANCE_PASSWORD:-delphix}"
 
 #


### PR DESCRIPTION
Soon the delphix-platform will remove it's current logic that handles
configuration of the delphix user's password. Thus, we (now) need to
handle configuration of the password in this repository, as part of the
initial appliance build.

Additionally, we're removing the ability to change the appliance's
username, since this flexibility is unnecessary, and only serves to make
things more difficult on upgrade and/or migration.