### PR TITLE
Use packages generated by linux-pkg

### DIFF
--- a/live-build/base/config/archives/localhost.pref
+++ b/live-build/base/config/archives/localhost.pref
@@ -1,0 +1,26 @@
+#
+# Copyright 2018 Delphix
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+#
+# This sets the preferences for the ancillary repository added in sources file
+# localhost.list. Any package coming from that repository will have the highest
+# priority. Since the priority value is over 1000, downgrades will be allowed
+# to satisfy package dependencies.
+#
+
+Package: *
+Pin: origin "localhost"
+Pin-Priority: 1001

--- a/live-build/misc/upgrade-scripts/execute
+++ b/live-build/misc/upgrade-scripts/execute
@@ -35,7 +35,7 @@ function apt_get() {
 		"$@"
 }
 
-while getopts ':' c; do
+while getopts ':rlBfs' c; do
 	case $c in
 	r | l | B | f | s) ;; # LX-72: For now, silently ignore these.
 	*) usage "illegal options -- $OPTARG" ;;

--- a/scripts/build-ancillary-repository.sh
+++ b/scripts/build-ancillary-repository.sh
@@ -182,10 +182,10 @@ AWS_S3_URI_VIRTUALIZATION=$(resolve_s3_uri \
 	"$AWS_S3_PREFIX_VIRTUALIZATION" \
 	"dlpx-app-gate/master/build-package/post-push/latest")
 
-AWS_S3_URI_PLATFORM=$(resolve_s3_uri \
-	"$AWS_S3_URI_PLATFORM" \
-	"$AWS_S3_PREFIX_PLATFORM" \
-	"devops-gate/master/delphix-platform/master/post-push/latest")
+AWS_S3_URI_LINUX_PKG=$(resolve_s3_uri \
+	"$AWS_S3_URI_LINUX_PKG" \
+	"$AWS_S3_PREFIX_LINUX_PKG" \
+	"devops-gate/master/linux-pkg-build/master/post-push/latest")
 
 AWS_S3_URI_MASKING=$(resolve_s3_uri \
 	"$AWS_S3_URI_MASKING" \
@@ -209,7 +209,7 @@ PKG_DIRECTORY=$(mktemp -d -p "$PWD" tmp.pkgs.XXXXXXXXXX)
 # proceed to download these packages.
 #
 download_delphix_s3_debs "$PKG_DIRECTORY" "$AWS_S3_URI_VIRTUALIZATION"
-download_delphix_s3_debs "$PKG_DIRECTORY" "$AWS_S3_URI_PLATFORM"
+download_delphix_s3_debs "$PKG_DIRECTORY" "$AWS_S3_URI_LINUX_PKG"
 download_delphix_s3_debs "$PKG_DIRECTORY" "$AWS_S3_URI_MASKING"
 download_delphix_s3_debs "$PKG_DIRECTORY" "$AWS_S3_URI_ZFS"
 

--- a/scripts/docker-run.sh
+++ b/scripts/docker-run.sh
@@ -44,11 +44,11 @@ $DOCKER_RUN --rm \
 	--ipc "none" \
 	--volume /dev:/dev \
 	--env AWS_S3_PREFIX_VIRTUALIZATION \
-	--env AWS_S3_PREFIX_PLATFORM \
+	--env AWS_S3_PREFIX_LINUX_PKG \
 	--env AWS_S3_PREFIX_MASKING \
 	--env AWS_S3_PREFIX_ZFS \
 	--env AWS_S3_URI_VIRTUALIZATION \
-	--env AWS_S3_URI_PLATFORM \
+	--env AWS_S3_URI_LINUX_PKG \
 	--env AWS_S3_URI_MASKING \
 	--env AWS_S3_URI_ZFS \
 	--env APPLIANCE_PASSWORD \


### PR DESCRIPTION
delphix-platform will be a package generated by the linux-pkg framework.

Note that this is a breaking change, and should be pushed along with changes in other repositories.
See main review http://reviews.delphix.com/r/44644 for more details.