### PR TITLE
DLPX-61294 Linux upgrade verify fails, trunk to trunk

### DIFF
--- a/live-build/misc/upgrade-scripts/verify
+++ b/live-build/misc/upgrade-scripts/verify
@@ -58,6 +58,11 @@ function cleanup() {
 		report_progress 80 "Skipping upgrade verification cleanup"
 	fi
 
+	[[ $rc -eq 0 ]] &&
+		# On success, we must report 100 progress. Java stack treats
+		# script execution a failure if non-zero status is reported or
+		# 100 progress is not reported.
+		report_progress 100 "Upgrade verification was successful"
 	return "$rc"
 }
 


### PR DESCRIPTION
## Summary
We need to report 100 progress at the end for any scripts that is called by `UpgradeManagerImpl#runScriptWithStdoutCallback` because it treats script execution as failure if any of the following condition is true:
* non-zero exit status is received.
* 100 progress is not reported.


## Testing
*  Uploaded new script to the failing VM and ran verify from the UI.
* `git-ab-pre-push` is [here](http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/210/)