### PR TITLE
Add python-pip for zfstest log processing

### DIFF
--- a/live-build/misc/ansible-roles/appliance-build.qa-internal/tasks/main.yml
+++ b/live-build/misc/ansible-roles/appliance-build.qa-internal/tasks/main.yml
@@ -53,6 +53,7 @@
     - libnss3-tools
     - libpam0g-dev
     - libssl-dev
+    - python-pip
   register: result
   until: result is not failed
   retries: 3


### PR DESCRIPTION
The log processing script requires the ordereddict and junit modules.
It would be preferable to install these modules via apt as packages,
but the packages in the apt repo do not work correctly, so we install
pip and use it to install the needed modules.

Testing:
I built the qa variant and verified `pip` was available. pre-push build is
running [here](http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build/job/master/job/pre-push/170/console)