### PR TITLE
Lx 1418 Add mechanism to save container logs to a host

### DIFF
--- a/live-build/misc/upgrade-scripts/common.sh
+++ b/live-build/misc/upgrade-scripts/common.sh
@@ -15,7 +15,10 @@
 # limitations under the License.
 #
 
+# shellcheck disable=SC2034
 UPDATE_DIR=${UPDATE_DIR:-"/var/dlpx-update"}
+UPDATE_VERIFY_LOG_DIR=${UPDATE_DIR}/verify-logs
+SUPPORT_INFO_SCRIPT=${SUPPORT_INFO_SCRIPT:-"/opt/delphix/server/bin/support_info"}
 DROPBOX_DIR=${DROPBOX_DIR:-"/var/delphix/dropbox"}
 
 function die() {

--- a/live-build/misc/upgrade-scripts/upgrade-container
+++ b/live-build/misc/upgrade-scripts/upgrade-container
@@ -282,7 +282,7 @@ function destroy() {
 }
 
 function run() {
-	systemd-run --machine="$CONTAINER" --quiet --wait --pipe -- "$@"
+	systemd-run --machine="$CONTAINER" --setenv=CONTAINER="$CONTAINER" --quiet --wait --pipe -- "$@"
 }
 
 function get_bootloader_devices() {

--- a/live-build/misc/upgrade-scripts/verify-impl
+++ b/live-build/misc/upgrade-scripts/verify-impl
@@ -26,6 +26,24 @@ function usage() {
 	exit 2
 }
 
+function cleanup() {
+	local rc="$?"
+
+	#
+	# Persist container logs by saving to the container's host.
+	# Delete and create verify log destination directory to save only one copy of log to limit
+	# space usage.
+	#
+	rm -rf "${UPDATE_VERIFY_LOG_DIR:?}" ||
+		die "Failed to remove verify log directory ${UPDATE_VERIFY_LOG_DIR}."
+	mkdir -p "${UPDATE_VERIFY_LOG_DIR}/${CONTAINER}" ||
+		die "Failed to create verify log directory ${UPDATE_VERIFY_LOG_DIR}/${CONTAINER}."
+	${SUPPORT_INFO_SCRIPT} -o "${UPDATE_VERIFY_LOG_DIR}/${CONTAINER}" -t "log dropbox" ||
+		die "Failed to collect verify logs."
+
+	return "$rc"
+}
+
 opt_d=false
 while getopts ':df:l:o:' c; do
 	case "$c" in
@@ -44,6 +62,8 @@ fi
 if $opt_d; then
 	VERIFY_LIVE_MDS_OPT="-disableConsistentMdsZfsDataUtil"
 fi
+
+trap cleanup EXIT
 
 /usr/bin/java \
 	-Dlog.dir=/var/delphix/server/upgrade-verify \


### PR DESCRIPTION
This is a reattempt of a discarded PR https://github.com/delphix/appliance-build/pull/132

Just to summarize, we discussed that adding additional binding directory and cherry-picking logs to copy was not a clean solution and should be leveraging `support_info` script if possible.

This PR uses `support_info` script to collect logs within the container and saves to `/var/dlpx-update/verify-logs` directory.

There is one TODO as noted below but just wanted to get early feedback how do you guys think about the approach.

TODO:
* I need to disable progress reporting from `support_info` script since app-gate doesn't know which ones are coming from `verify` script.

Testing
* Bundle collected at expected location
```Complete! The compressed log bundle is at /var/dlpx-update/verify-logs/dlpx-support-423FB6DC-D163-8354-29BA-516F13D1FCCE-20181128-01-44-47.tar.gz```

* Expected contents are there
```delphix@harry-dlpxtrunk:/var/dlpx-update/verify-logs/archive$ ls -la
total 23
drwxr-xr-x 5 root root  5 Nov 28 01:51 .
drwxr-xr-x 3 root root  4 Nov 28 01:51 ..
drwxr-xr-x 2 root root  3 Nov 28 01:44 dropbox
drwxr-xr-x 5 root root  5 Nov 28 01:44 log
drwxr-xr-x 2 root root 18 Nov 28 01:44 misc
delphix@harry-dlpxtrunk:/var/dlpx-update/verify-logs/archive$ cd dropbox/
delphix@harry-dlpxtrunk:/var/dlpx-update/verify-logs/archive/dropbox$ ls
upgrade_verify_report.json
delphix@harry-dlpxtrunk:/var/dlpx-update/verify-logs/archive/dropbox$ cd ../log/
delphix@harry-dlpxtrunk:/var/dlpx-update/verify-logs/archive/log$ ls -la
total 8
drwxr-xr-x 5 root root  5 Nov 28 01:44 .
drwxr-xr-x 5 root root  5 Nov 28 01:51 ..
drwxr-xr-x 4 root root 12 Nov 28 01:44 mgmt_log
drwxr-xr-x 2 root root  4 Nov 28 01:44 pg_log
drwxr-xr-x 9 root root 30 Nov 28 01:44 sys_log
```


`git-ab-pre-push` is [here](http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/262/)
