### PR TITLE
Remove "ansible-done" file during upgrade

### DIFF
--- a/live-build/misc/upgrade-scripts/upgrade
+++ b/live-build/misc/upgrade-scripts/upgrade
@@ -93,6 +93,10 @@ function upgrade_in_place() {
 		die "'$IMAGE_PATH/execute' failed in '$CONTAINER'"
 
 	"$IMAGE_PATH/upgrade-container" run "$CONTAINER" \
+		/bin/rm -f /etc/delphix-platform/ansible-done ||
+		die "'rm -f /etc/delphix-platform/ansible-done' failed in '$CONTAINER'"
+
+	"$IMAGE_PATH/upgrade-container" run "$CONTAINER" \
 		/bin/systemctl start delphix-platform ||
 		die "'systemctl start delphix-platform' failed in '$CONTAINER'"
 
@@ -141,6 +145,10 @@ function upgrade_not_in_place() {
 	"$IMAGE_PATH/upgrade-container" run "$CONTAINER" \
 		"$IMAGE_PATH/execute" ||
 		die "'$IMAGE_PATH/execute' failed in '$CONTAINER'"
+
+	"$IMAGE_PATH/upgrade-container" run "$CONTAINER" \
+		/bin/rm -f /etc/delphix-platform/ansible-done ||
+		die "'rm -f /etc/delphix-platform/ansible-done' failed in '$CONTAINER'"
 
 	"$IMAGE_PATH/upgrade-container" run "$CONTAINER" \
 		/bin/systemctl start delphix-platform ||


### PR DESCRIPTION
This change updates the upgrade logic such that we properly remove the
"delphix-platform" service's "ansible-done" file prior to restarting the
service. Otherwise, restarting the service may not do anything useful,
since the service will only run the new ansible logic if this file
doesn't exist; i.e. if the file exists, the service is basically a noop.