### PR TITLE
Enable disk.EnableUUID in the OVA Template

### DIFF
--- a/live-build/misc/live-build-hooks/template.ovf
+++ b/live-build/misc/live-build-hooks/template.ovf
@@ -148,6 +148,7 @@
       <vmw:Config ovf:required="false" vmw:key="tools.beforeGuestStandby" vmw:value="true"/>
       <vmw:Config ovf:required="false" vmw:key="tools.syncTimeWithHost" vmw:value="false"/>
       <vmw:Config ovf:required="false" vmw:key="tools.toolsUpgradePolicy" vmw:value="manual"/>
+      <vmw:ExtraConfig ovf:required="false" vmw:key="disk.EnableUUID" vmw:value="true"/>
     </VirtualHardwareSection>
     <AnnotationSection ovf:required="false">
       <Info>A human-readable annotation</Info>


### PR DESCRIPTION
This fixes the device ids and serial numbers for Linux based VMs on ESXi by providing the `disk.EnableUUID` key.

Confirmed by building a complete OVA archive using pre-push (build #266) and using that OVA to create a new VM.  The VM boots and has properly configured device UUIDs (as seen by `udevadm info`).  Also confirmed that the 'disk.EnableUUID' key was present in the VM's vmx file.