### PR TITLE
LX-1551, LX-1553 - dx_apply & dx_execute 

### DIFF
--- a/live-build/misc/live-build-hooks/90-linux-migration-artifact.binary
+++ b/live-build/misc/live-build-hooks/90-linux-migration-artifact.binary
@@ -131,28 +131,28 @@ cp migration-scripts/* $DEPOT_DIRECTORY
 )
 
 #
-# DLPX_SIGNING_LOGIN is used for signing our migration image.
+# DELPHIX_SIGNATURE_TOKEN is used for signing our migration image.
 # The signature is later unpacked and verified on the VM
-# performing the migration. If DLPX_SIGNING_LOGIN has not been
+# performing the migration. If DELPHIX_SIGNATURE_TOKEN has not been
 # specified by the user when running this hook we skip generating
-# the signature for this image.
+# the signature for this image. Similarly for DELPHIX_SIGNATURE_URL.
 #
-if [[ -n "${DLPX_SIGNING_LOGIN:-}" ]] && [[ -n "${DLPX_KEY_URL:-}" ]]; then
+if [[ -n "${DELPHIX_SIGNATURE_TOKEN:-}" ]] && [[ -n "${DELPHIX_SIGNATURE_URL:-}" ]]; then
 	#
 	# Generate depot/hashes.sig[.<release>]
 	#
 	# Assumption: we always migrate from version 5.3
 	#
-	UPGRADE_VERSION="5.3"
-	DLPX_SIGNING_URL="$DLPX_KEY_URL/upgrade/keyVersion/$UPGRADE_VERSION/sign"
+	VERSION="5.3"
+	SIGN_URL="$DELPHIX_SIGNATURE_URL/upgrade/keyVersion/$VERSION/sign"
 
 	set -o pipefail
 	curl -s -f -H "Content-Type: application/json" \
-		-u "$DLPX_SIGNING_LOGIN" "$DLPX_SIGNING_URL" -d @- <<-EOF |
+		-u "$DELPHIX_SIGNATURE_TOKEN" "$SIGN_URL" -d @- <<-EOF |
 			{"data": "$(base64 -w 0 $DEPOT_DIRECTORY/hashes)"}
 		EOF
 		jq -r .signature |
-		base64 -d >$DEPOT_DIRECTORY/hashes.sig.$UPGRADE_VERSION
+		base64 -d >$DEPOT_DIRECTORY/hashes.sig.$VERSION
 fi
 
 #

--- a/live-build/misc/migration-scripts/dx_apply
+++ b/live-build/misc/migration-scripts/dx_apply
@@ -16,9 +16,227 @@
 #
 
 #
-# [WIP]
-# The existence of this file is checked by dx_unpack, thus we provide
-# it as an empty file until the needed functionality is added.
+# Creates the dataset layout/hierarchy expected by linux-upgrade for the
+# archive from the migration image to be unpacked. It also takes the
+# required steps and adds an entry to the FreeBSD bootloader so we can
+# optionally boot into Linux.
 #
+
+set -o pipefail
+
+function die() {
+	echo "$(basename "$0"): $*" >&2
+	exit 1
+}
+
+function usage() {
+	echo "$(basename "$0"): $*" >&2
+	echo "Usage: $(basename "$0") <archive-directory>"
+	exit 2
+}
+
+[[ "$(uname -s)" == "SunOS" ]] || die "script can only be used in illumos"
+
+while getopts ':h' opt; do
+	case $opt in
+	h) usage ;;
+	*) usage "Invalid option: -$OPTARG." ;;
+	esac
+done
+
+ARCHIVE_DIR="$1"
+[[ -n $ARCHIVE_DIR ]] || usage
+[[ -d $ARCHIVE_DIR ]] || die "$ARCHIVE_DIR is not a directory"
+[[ -f $ARCHIVE_DIR/version.info ]] ||
+	die "$ARCHIVE_DIR does not have a version.info file"
+. "$ARCHIVE_DIR/version.info"
+#
+# WIP: Assert MINIMUM VERSION field for migration.
+# The idea here is to ensure that we are running this script against
+# a migration archive, by ensuring that it has the right value for
+# the MINIMUM_VERSION field.
+#
+
+#
+# Get the root dataset and the current ZFS pool that we're currently using.
+#
+RDS=$(mount | awk '/^\/ /{ print $3 }')
+RPOOL=${RDS%%/*}
+
+#
+# Cleanup any previous intermediate state.
+#
+rm -rf /tmp/delphix.* ||
+	die "failed to destroy old delphix temporary directories"
+rm -f /boot/vmlinuz-* /boot/initrd.img-* ||
+	die "failed to destroy previously copied Linux kernel data"
+zfs destroy -r "$RPOOL/ROOT" 2>/dev/null
+zfs list "RPOOL/ROOT" 2>/dev/null &&
+	die "could not destroy linux root dataset from previous run"
+sed -i '/set mainmenu_caption\[8\]/d' /boot/menu.rc.local
+[[ "$(grep -cF 'mainmenu_caption[8]' /boot/menu.rc.local)" -eq 0 ]] ||
+	die "failed to cleanup mainmenu_caption from previous run"
+sed -i '/set mainansi_caption\[8\]/d' /boot/menu.rc.local
+[[ "$(grep -cF 'mainansi_caption[8]' /boot/menu.rc.local)" -eq 0 ]] ||
+	die "failed to cleanup mainansi_caption from previous run"
+sed -i '/set mainmenu_keycode\[8\]/d' /boot/menu.rc.local
+[[ "$(grep -cF 'mainmenu_keycode[8]' /boot/menu.rc.local)" -eq 0 ]] ||
+	die "failed to cleanup mainmenu_keycode from previous run"
+sed -i '/set mainmenu_command\[8\]/d' /boot/menu.rc.local
+[[ "$(grep -cF 'mainmenu_command[8]' /boot/menu.rc.local)" -eq 0 ]] ||
+	die "failed to cleanup mainmenu_command from previous run"
+
+#
+# Check that the version to which we are upgrading is compatible with the
+# currently installed version. (Look at version.info to see if we are
+# above the minimum version required. Since we are doing a migration
+# the minimum version should be the latest 5.3)
+#
+# CURRENT_DDS=$(dirname "$(mount | awk '/^\/opt\/delphix /{ print $3 }')")
+# CURRENT_VERSION=$(basename $current_dds)
+#
+# WIP: check if current version is 5.3, if not bail
+#
+
+#
+# Create dataset layout similar to the linux upgrade.
+#
+TMPDIR=$(mktemp -d -p "/tmp" -t delphix.XXXXXXX)
+FSNAME=$(basename "$TMPDIR")
+zfs create -o canmount=off -o mountpoint=none "$RPOOL/ROOT" ||
+	die "failed to create $RPOOL/ROOT"
+zfs create -o canmount=noauto -o mountpoint=/ "$RPOOL/ROOT/$FSNAME" ||
+	die "failed to create linux root dataset $RPOOL/ROOT/$FSNAME"
+
+#
+# Temporarily set the mountpoint to point to a temporary
+# root directory, and unpack our cpio archive to it.
+#
+TMP_ROOT="$TMPDIR/root"
+zfs set mountpoint="$TMP_ROOT" "$RPOOL/ROOT/$FSNAME" ||
+	die "failed to set temporary mount $TMP_ROOT for new root dataset"
+zfs mount "$RPOOL/ROOT/$FSNAME" ||
+	die "failed to mount $RPOOL/ROOT/$FSNAME in temporary dir $TMP_ROOT"
+(
+	cd "$TMP_ROOT"
+	cpio -imu
+) <"$ARCHIVE_DIR/os-root.cpio" 2>&1 ||
+	die "failed to unpack os-root.cpio"
+
+#
+# WIP: Add here any operations that generate files from illumos,
+#	that we may want to carry over and use in Linux. Examples
+#	include networking interface configuration.
+#
+
+#
+# Set things up for the FreeBSD bootloader to provide an option for
+# booting into the Linux environment This happens in two steps:
+# [1] We place vmlinuz and initrd from our migration image into
+#     the /boot directory of the current system, so the bootloader
+#     can load them.
+# [2] Add a new option in the bootloader's menu for Linux. This is
+#     done by appending the configuration of the new option in our
+#     current menu file.
+#
+# Note: We reverse sort below based on a vmlinuz & initrd's name
+# to get the latest version of them. In reality, there is always
+# only one version but in the case that there is an issue in
+# how we construct the images we always want to get the latest.
+#
+VMLINUZ=$(find "$TMP_ROOT/boot/vmlinuz-"* | sort -r | head -n 1)
+INITRD_IMG=$(find "$TMP_ROOT/boot/initrd.img-"* | sort -r | head -n 1)
+cp "$VMLINUZ" /boot ||
+	die "failed to copy $VMLINUZ to /boot"
+cp "$INITRD_IMG" /boot ||
+	die "faield to copy $INITRD_IMG to /boot"
+
+#
+# This command loads the Linux Kernel Compressed Executable in memory
+# from the OK prompt of the FreeBSD bootloader.
+#
+# - We specify the root filesystem type to be ZFS and its root dataset
+#   the one that we just created for the migration image.
+#
+# - We set the console parameter during load twice. Once for each
+#   console technology:
+#      tty0 - Makes kernel messages appear in the first virtual
+#             terminal.
+#      ttyS0 - Makes kernel messages appear in the frst serial
+#             port. The 115200n8 part means the serial connection
+#             is made at 115200 baud 8n1.
+#
+# - We specify zfsforce=1 because otherwise we would be failing at
+#   pool import because of ZFS's hostid check.
+#
+# Note that we use an array of strings instead of one whole string
+# that we break to multiple lines in order to divide the arguments
+# in logical pieces while ensuring that their quotes are escaped
+# correctly and in accordance with our linters/checkstyles. This
+# should be taken into account for all cases of string arrays for
+# the rest of this file that have to do with adding commands in the
+# bootloader configuration.
+#
+LOAD_VMLINUZ_OK_ARG=(
+	"/boot/$(basename "$VMLINUZ")"
+	"root=ZFS=$RPOOL/ROOT/$FSNAME"
+	'console=tty0 console=ttyS0,115200n8'
+	'zfsforce=1'
+)
+LOAD_VMLINUZ_OK_CMD="load ${LOAD_VMLINUZ_OK_ARG[*]}"
+
+#
+# This command loads the initial RAM disk as the initial root filesystem
+# which is needed as part of the booting process.
+#
+LOAD_INITRD_OK_CMD="load -t rootfs /boot/$(basename "$INITRD_IMG")"
+
+#
+# This is the command to be issued whenever our new option in the
+# bootloader menu is chosen. It is FICL code (a Forth-inspired
+# command language) that is basically read as:
+# 	arg func; arg func; func.
+# In our case we:
+# [1] Evaluate the command to load vmlinuz
+# [2] Evaluate the command to load initrd
+# [3] boot (with the above two loaded)
+#
+MAIN_MENU_FICL=(
+	"s\\\" $LOAD_VMLINUZ_OK_CMD\\\" evaluate"
+	"s\\\" $LOAD_INITRD_OK_CMD\\\" evaluate"
+	boot
+)
+
+#
+# Note: We always have 7 options in our bootloader at any given time
+# in the latest 5.3 version, thus we use the index 8 for the new
+# option below.
+#
+{
+	#
+	# Add non-ansi and ansi version for the name of the option.
+	#
+	echo 'set mainmenu_caption[8]="Boot Delphix on [L]inux"'
+	echo 'set mainansi_caption[8]="Boot Delphix on ^[1mL^[minux version"'
+
+	#
+	# 76 is ascii for capital 'L', see caption above
+	#
+	echo 'set mainmenu_keycode[8]=76'
+
+	#
+	# If someone selects our new option, boot into Linux.
+	#
+	echo 'set mainmenu_command[8]="'"${MAIN_MENU_FICL[*]}"'"'
+} >>/boot/menu.rc.local ||
+	die "failed to update /boot/menu.rc.local"
+
+#
+# Unmount root directory and reset its mountpoint.
+#
+zfs umount "$RPOOL/ROOT/$FSNAME" ||
+	die "couldn't unmount linux root dataset from temporary mountpoint"
+zfs set mountpoint=/ "$RPOOL/ROOT/$FSNAME" ||
+	die "could not reset mountpoint for linux root dataset"
 
 exit 0

--- a/live-build/misc/migration-scripts/dx_execute
+++ b/live-build/misc/migration-scripts/dx_execute
@@ -16,9 +16,73 @@
 #
 
 #
-# [WIP]
-# The existence of this file is checked by dx_unpack, thus we provide
-# it as an empty file until the needed functionality is added.
+# Sets up the FreeBSD bootloader to boot into that Linux image next time
+# we reboot.
 #
+
+set -o pipefail
+
+function die() {
+	report "$(basename "$0"): $*" >&2
+	exit 1
+}
+
+[[ "$(uname -s)" == "SunOS" ]] || die "script can only be used in illumos"
+
+#
+# Undo any existing default timeout commands in the bootloader's menu.
+#
+sed -i '/menu_timeout_command/d' /boot/menu.rc.local
+[[ "$(grep -cF 'menu_timeout_command' /boot/menu.rc.local)" -eq 0 ]] ||
+	die "failed to cleanup previous default command"
+
+#
+# Get the RDS and the current ZFS pool that we're currently using.
+#
+RDS=$(mount | awk '/^\/ /{ print $3 }')
+RPOOL=${RDS%%/*}
+
+#
+# Check that the version to which we are upgrading is compatible with the
+# currently installed version. (Look at version.info to see if we are
+# above the minimum version required. Since we are doing a migration the
+# minimum version should be the latest 5.3.
+#
+# CURRENT_DDS=$(dirname "$(mount | awk '/^\/opt\/delphix /{ print $3 }')")
+# CURRENT_VERSION=$(basename $current_dds)
+#
+# WIP: check if current version is 5.3, if not bail
+#
+
+#
+# Ensure that the expected Linux dataset layout exists.
+#
+[[ $(zfs list -o name -Hr "$RPOOL/ROOT" | wc -l) -eq 2 ]] ||
+	die "could not find the expected linux dataset layout"
+LX_RPOOL_ROOT=$(zfs list -o name -H "$RPOOL/ROOT")
+[[ -n $LX_RPOOL_ROOT ]] || die "could not find Linux ROOT dataset"
+LX_RDS=$(zfs list -o name -Hr "$RPOOL/ROOT" | tail -n 1)
+
+#
+# Ensure that the expected bootloader fields are there.
+#
+[[ "$(grep -cF 'mainmenu_caption[8]' /boot/menu.rc.local)" -eq 1 ]] ||
+	die "there is no caption for the Linux option in the bootloader menu"
+[[ "$(grep -cF 'mainmenu_caption[8]' /boot/menu.rc.local)" -eq 1 ]] ||
+	die "there is no keycode for the Linux option in the bootloader menu"
+[[ "$(grep -cF 'mainmenu_command[8]' /boot/menu.rc.local)" -eq 1 ]] ||
+	die "there is no command for the Linux option in the bootloader menu"
+[[ "$(grep -c "$LX_RDS" /boot/menu.rc.local)" -eq 1 ]] ||
+	die "the expected Linux RDS ($LX_RDS) was either not found or has" \
+		"been specified more than once in the bootloader's menu file"
+
+#
+# Read the command from option 8 which should be the one that boots
+# into Linux. Then make it so that the same command runs whenever we
+# hit the timer of the FreeBSD bootloader menu.
+#
+MAIN_MENU_LINUX_CMD=$(grep -F 'mainmenu_command[8]' /boot/menu.rc.local |
+	cut -d = -f 2-)
+echo "set menu_timeout_command=$MAIN_MENU_LINUX_CMD" >>/boot/menu.rc.local
 
 exit 0

--- a/scripts/docker-run.sh
+++ b/scripts/docker-run.sh
@@ -54,8 +54,8 @@ $DOCKER_RUN --rm \
 	--env APPLIANCE_PASSWORD \
 	--env AWS_ACCESS_KEY_ID \
 	--env AWS_SECRET_ACCESS_KEY \
-	--env DLPX_KEY_URL \
-	--env DLPX_SIGNING_LOGIN \
+	--env DELPHIX_SIGNATURE_URL \
+	--env DELPHIX_SIGNATURE_TOKEN \
 	--volume "$TOP:/opt/appliance-build" \
 	--workdir "/opt/appliance-build" \
 	appliance-build "$@"


### PR DESCRIPTION
LX-1551 dx_apply for migration
    LX-1553 dx_execute for migration

    This patch introduces the next 2 migration scripts:
    dx_apply and dx_execute.

    dx_apply: creates the dataset hierarchy expected by linux upgrade
    and unpacks the migration image within it. It also adds a new
    entry in the FreeBSD bootloader so a VM can optionally boot from
    Linux. Note that the script has a few WIP comments that are there
    for 2 WIP issues. The first one is the fact that we can't do any
    checks about running on the 5.3 release because of the feature
    incompatibility of ZoL and our illumos pools (this is tracked by
    LX-1633). The other one is a placeholder for the point of execution
    where the migration scripts will run.

    dx_execute: checks that dx_apply has left around all the expected
    files and info and configures the bootloader to boot into Linux
    next time the system boots.

    Side-note - This patch also fixes issue #170.

    Testing:

    In a DRYRUN-5.3.2.0 VM:
    ```
    $ sudo /opt/delphix/server/bin/upgrade/dx_unpack internal-qa.migration.tar.gz
    Progress increment: 17:52:10:272024270+0000, 10, Extracting upgrade image
    17:52:10:274636821:+0000: Unpacking internal-qa.migration.tar.gz ...

    18:02:32:771501160:+0000: done.
    Progress increment: 18:02:32:774283991+0000, 40,  verifying format
    Progress increment: 18:02:32:802230044+0000, 50,  verifying signature
    18:02:32:804885537:+0000: Verify signature ... Verified OK
    Progress increment: 18:02:32:940595417+0000, 70, Verifying integrity of upgrade image
    18:02:32:943585708:+0000: Verifying contents of ./dx_apply ... ./dx_apply: OK
    18:02:32:959290157:+0000: Verifying contents of ./dx_execute ... ./dx_execute: OK
    18:02:32:973580872:+0000: Verifying contents of ./dx_prepare ... ./dx_prepare: OK
    18:02:32:988391332:+0000: Verifying contents of ./dx_verify ... ./dx_verify: OK
    18:02:33:005307726:+0000: Verifying contents of ./os-root.cpio ... ./os-root.cpio: OK
    18:04:28:832789838:+0000: Verifying contents of ./os-root.hashes ... ./os-root.hashes: OK
    18:04:28:970944902:+0000: Verifying contents of ./version.info ... ./version.info: OK
    Progress increment: 18:04:28:986276858+0000, 80, Verifying integrity of upgrade image done
    Progress increment: 18:04:29:062561886+0000, 90, preparing upgrade image
    Progress increment: 18:04:29:078086553+0000, 100, unpacking successful

    $ ls /var/dlpx-update/latest/
    dx_apply  dx_execute  dx_prepare  dx_verify  hashes  hashes.sig.5.3  os-root.cpio  os-root.hashes  version.info

    $ sudo /var/dlpx-update/latest/dx_apply /var/dlpx-update/latest/
    28115061 blocks

    $ zfs list
    NAME                                                      USED  AVAIL  REFER  MOUNTPOINT
    rpool                                                    42.7G   102G  43.5K  /rpool
    rpool/ROOT                                               9.36G   102G    23K  none
    rpool/ROOT/delphix.C3zxml7                               9.36G   102G  9.36G  /
    ...

    $ ls /boot/
    ...  initrd.img-4.15.0-42-generic ...
    ... vmlinuz-4.15.0-42-generic ...

    $ tail /boot/menu.rc.local
    set dversionsmenu_caption[3]="boot archive recovery"
    set dv_ba[3]="-B dlpx_version=5.3.2.0,dlpx_ds=rpool/versions/5.3.2018.11.21/dlpx/5.3.2.0,dlpx_support=true"
    set dversionsmenu_command[3]="s\"  set currdev=zfs:rpool/versions/5.3.2018.11.21/support:\" evaluate s\" set  boot-args=\${dv_ba[3]}\" evaluate boot"
    set mainmenu_caption[8]="Boot Delphix on [L]inux"
    set mainansi_caption[8]="Boot Delphix on ^[1mL^[minux version"
    set mainmenu_keycode[8]=76
    set mainmenu_command[8]="s\" load /boot/vmlinuz-4.15.0-42-generic root=ZFS=rpool/ROOT/delphix.C3zxml7 console=tty0 console=ttyS0,115200n8 zfsforce=1\" evaluate s\" load -t rootfs /boot/initrd.img-4.15.0-42-generic\" evaluate boot"

    $ sudo /var/dlpx-update/latest/dx_execute
    $

    $ tail /boot/menu.rc.local
    set dversionsmenu_caption[3]="boot archive recovery"
    set dv_ba[3]="-B dlpx_version=5.3.2.0,dlpx_ds=rpool/versions/5.3.2018.11.21/dlpx/5.3.2.0,dlpx_support=true"
    set dversionsmenu_command[3]="s\"  set currdev=zfs:rpool/versions/5.3.2018.11.21/support:\" evaluate s\" set  boot-args=\${dv_ba[3]}\" evaluate boot"
    set mainmenu_caption[8]="Boot Delphix on [L]inux"
    set mainansi_caption[8]="Boot Delphix on ^[1mL^[minux version"
    set mainmenu_keycode[8]=76
    set mainmenu_command[8]="s\" load /boot/vmlinuz-4.15.0-42-generic root=ZFS=rpool/ROOT/delphix.C3zxml7 console=tty0 console=ttyS0,115200n8 zfsforce=1\" evaluate s\" load -t rootfs /boot/initrd.img-4.15.0-42-generic\" evaluate boot"
    set menu_timeout_command="s\" load /boot/vmlinuz-4.15.0-42-generic root=ZFS=rpool/ROOT/delphix.C3zxml7 console=tty0 console

    $ sudo reboot

    <....sshing back in after some time ...>

    $ uname -a
        Linux localhost 4.15.0-42-generic #45-Ubuntu SMP Thu Nov 15 19:32:57 UTC 2018 x86_64 x86_64 x86_64 GNU/Linux
    ```

    After rebooting the VM ~3 times from within Linux, we get into the recovery
    environment:
    ```
    Please enter a number  [1]:
                    Welcome to the Delphix Server 5.3.2.0 Installation Menu

            1  Shell
            2  Terminal type (currently sun-color)
            3  Reboot
    ```

ab-pre-push (pending):
http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/335/flowGraphTable/