### PR TITLE
Reload and restart delphix-platform during upgrade

### DIFF
--- a/live-build/misc/upgrade-scripts/upgrade
+++ b/live-build/misc/upgrade-scripts/upgrade
@@ -93,8 +93,12 @@ function upgrade_in_place() {
 		die "'$IMAGE_PATH/execute' failed in '$CONTAINER'"
 
 	"$IMAGE_PATH/upgrade-container" run "$CONTAINER" \
-		/bin/systemctl start delphix-platform ||
-		die "'systemctl start delphix-platform' failed in '$CONTAINER'"
+		/bin/systemctl reload delphix-platform ||
+		die "'systemctl reload delphix-platform' failed in '$CONTAINER'"
+
+	"$IMAGE_PATH/upgrade-container" run "$CONTAINER" \
+		/bin/systemctl restart delphix-platform ||
+		die "'systemctl restart delphix-platform' failed in '$CONTAINER'"
 
 	if [[ "$DLPX_UPGRADE_SKIP_VERIFY" != "true" ]]; then
 		"$IMAGE_PATH/upgrade-container" run "$CONTAINER" \
@@ -143,8 +147,12 @@ function upgrade_not_in_place() {
 		die "'$IMAGE_PATH/execute' failed in '$CONTAINER'"
 
 	"$IMAGE_PATH/upgrade-container" run "$CONTAINER" \
-		/bin/systemctl start delphix-platform ||
-		die "'systemctl start delphix-platform' failed in '$CONTAINER'"
+		/bin/systemctl reload delphix-platform ||
+		die "'systemctl reload delphix-platform' failed in '$CONTAINER'"
+
+	"$IMAGE_PATH/upgrade-container" run "$CONTAINER" \
+		/bin/systemctl restart delphix-platform ||
+		die "'systemctl restart delphix-platform' failed in '$CONTAINER'"
 
 	if [[ "$DLPX_UPGRADE_SKIP_VERIFY" != "true" ]]; then
 		"$IMAGE_PATH/upgrade-container" run "$CONTAINER" \


### PR DESCRIPTION
This updates the upgrade logic to account for some recent changes to the
delphix-platform service. Now, we need to reload the service to ensure
the service will do useful work the next time it runs. Additionally, we
need to restart the service rather than start the service; otherwise, if
the service is already running (it should be), starting the service is
basically a noop.