### PR TITLE
Migrate configuration prior to running "verify-impl"

### DIFF
--- a/live-build/misc/upgrade-scripts/upgrade
+++ b/live-build/misc/upgrade-scripts/upgrade
@@ -150,12 +150,11 @@ function upgrade_not_in_place() {
 		die "'$IMAGE_PATH/execute' failed in '$CONTAINER'"
 
 	"$IMAGE_PATH/upgrade-container" run "$CONTAINER" \
-		/bin/systemctl reload delphix-platform ||
-		die "'systemctl reload delphix-platform' failed in '$CONTAINER'"
+		/bin/systemctl start delphix-platform ||
+		die "'systemctl start delphix-platform' failed in '$CONTAINER'"
 
-	"$IMAGE_PATH/upgrade-container" run "$CONTAINER" \
-		/bin/systemctl restart delphix-platform ||
-		die "'systemctl restart delphix-platform' failed in '$CONTAINER'"
+	"$IMAGE_PATH/upgrade-container" migrate-configuration "$CONTAINER" ||
+		die "failed to migrate configuration for '$CONTAINER'"
 
 	if [[ "$DLPX_UPGRADE_SKIP_VERIFY" != "true" ]]; then
 		"$IMAGE_PATH/upgrade-container" run "$CONTAINER" \

--- a/live-build/misc/upgrade-scripts/upgrade-container
+++ b/live-build/misc/upgrade-scripts/upgrade-container
@@ -301,6 +301,68 @@ function get_bootloader_devices() {
 		sed 's/[0-9]*$//'
 }
 
+function convert_to_bootfs_cleanup() {
+	for dir in /proc /sys /dev; do
+		umount -R "/var/lib/machines/${CONTAINER}${dir}" ||
+			warn "'umount -R' of '$dir' failed"
+	done
+}
+
+#
+# The purpose of this function is to convert an existing upgrade
+# container (specified by the $CONTAINER global variable) into the next
+# boot filesystem used by the appliance; i.e. after calling this
+# function, the container's root filesystem will be used as the
+# appliance's root filesystem, the next time the appliance boots.
+#
+# This is done by updating the appliance's bootloader (i.e. grub) to
+# point to the container's filesystem, along with setting the mountpoint
+# of the filesystem to be "/" instead of "/var/lib/machines/$CONTAINER".
+# This effectively removes the container, since systemd-nspawn only
+# looks in /var/lib/machines, so it'll no longer find the container
+# after the mountpoint changes.
+#
+function convert_to_bootfs() {
+	trap convert_to_bootfs_cleanup EXIT
+
+	mount --make-slave "/var/lib/machines/$CONTAINER" ||
+		die "'mount --make-slave /var/lib/machines/$CONTAINER' failed"
+
+	for dir in /proc /sys /dev; do
+		mount --rbind "$dir" "/var/lib/machines/${CONTAINER}${dir}" ||
+			die "'mount --rbind' of '$dir' failed"
+		mount --make-rslave "/var/lib/machines/${CONTAINER}${dir}" ||
+			die "'mount --make-rslave' of '$dir' failed"
+	done
+
+	chroot "/var/lib/machines/$CONTAINER" update-grub ||
+		die "'update-grub' failed in '$CONTAINER'"
+
+	for dev in $(get_bootloader_devices); do
+		[[ -e "/dev/$dev" ]] ||
+			die "bootloader device '/dev/$dev' not found"
+
+		[[ -b "/dev/$dev" ]] ||
+			die "bootloader device '/dev/$dev' not block device"
+
+		chroot "/var/lib/machines/$CONTAINER" \
+			grub-install "/dev/$dev" ||
+			die "'grub-install /dev/$dev' failed in '$CONTAINER'"
+	done
+
+	convert_to_bootfs_cleanup
+	trap - EXIT
+
+	zfs umount "rpool/ROOT/$CONTAINER" ||
+		die "'zfs umount rpool/ROOT/$CONTAINER' failed"
+
+	zfs set canmount=noauto "rpool/ROOT/$CONTAINER" ||
+		die "'zfs set canmount=noauto rpool/ROOT/$CONTAINER' failed"
+
+	zfs set mountpoint=/ "rpool/ROOT/$CONTAINER" ||
+		die "'zfs set mountpoint=/ rpool/ROOT/$CONTAINER' failed"
+}
+
 function migrate_password_for_user() {
 	local user="$1"
 	local password
@@ -336,40 +398,7 @@ function migrate_directory() {
 	fi
 }
 
-function convert_to_bootfs_cleanup() {
-	for dir in /proc /sys /dev; do
-		umount -R "/var/lib/machines/${CONTAINER}${dir}" ||
-			warn "'umount -R' of '$dir' failed"
-	done
-}
-
-#
-# The purpose of this function is to convert an existing upgrade
-# container (specified by the $CONTAINER global variable) into the next
-# boot filesystem used by the appliance; i.e. after calling this
-# function, the container's root filesystem will be used as the
-# appliance's root filesystem, the next time the appliance boots.
-#
-# This is done by updating the appliance's bootloader (i.e. grub) to
-# point to the container's filesystem, along with setting the mountpoint
-# of the filesystem to be "/" instead of "/var/lib/machines/$CONTAINER".
-# This effectively removes the container, since systemd-nspawn only
-# looks in /var/lib/machines, so it'll no longer find the container
-# after the mountpoint changes.
-#
-function convert_to_bootfs() {
-	trap convert_to_bootfs_cleanup EXIT
-
-	mount --make-slave "/var/lib/machines/$CONTAINER" ||
-		die "'mount --make-slave /var/lib/machines/$CONTAINER' failed"
-
-	for dir in /proc /sys /dev; do
-		mount --rbind "$dir" "/var/lib/machines/${CONTAINER}${dir}" ||
-			die "'mount --rbind' of '$dir' failed"
-		mount --make-rslave "/var/lib/machines/${CONTAINER}${dir}" ||
-			die "'mount --make-rslave' of '$dir' failed"
-	done
-
+function migrate_configuration() {
 	#
 	# When performing a not-in-place upgrade, the root and delphix
 	# users will not have any password by default. Thus, we need to
@@ -469,33 +498,6 @@ function convert_to_bootfs() {
 		/etc/systemd/system/delphix-mgmt.service.d/override.conf
 		/etc/systemd/system/delphix-postgres@.service.d/override.conf
 	EOF
-
-	chroot "/var/lib/machines/$CONTAINER" update-grub ||
-		die "'update-grub' failed in '$CONTAINER'"
-
-	for dev in $(get_bootloader_devices); do
-		[[ -e "/dev/$dev" ]] ||
-			die "bootloader device '/dev/$dev' not found"
-
-		[[ -b "/dev/$dev" ]] ||
-			die "bootloader device '/dev/$dev' not block device"
-
-		chroot "/var/lib/machines/$CONTAINER" \
-			grub-install "/dev/$dev" ||
-			die "'grub-install /dev/$dev' failed in '$CONTAINER'"
-	done
-
-	convert_to_bootfs_cleanup
-	trap - EXIT
-
-	zfs umount "rpool/ROOT/$CONTAINER" ||
-		die "'zfs umount rpool/ROOT/$CONTAINER' failed"
-
-	zfs set canmount=noauto "rpool/ROOT/$CONTAINER" ||
-		die "'zfs set canmount=noauto rpool/ROOT/$CONTAINER' failed"
-
-	zfs set mountpoint=/ "rpool/ROOT/$CONTAINER" ||
-		die "'zfs set mountpoint=/ rpool/ROOT/$CONTAINER' failed"
 }
 
 function usage() {
@@ -511,6 +513,7 @@ function usage() {
 	echo "$PREFIX_SPACES destroy <container>"
 	echo "$PREFIX_SPACES run <container> <command>"
 	echo "$PREFIX_SPACES convert-to-bootfs <container>"
+	echo "$PREFIX_SPACES migrate-configuration <container>"
 
 	exit 2
 }
@@ -566,6 +569,12 @@ convert-to-bootfs)
 	[[ $# -gt 2 ]] && usage "too many arguments specified"
 	CONTAINER="$2"
 	convert_to_bootfs
+	;;
+migrate-configuration)
+	[[ $# -lt 2 ]] && usage "too few arguments specified"
+	[[ $# -gt 2 ]] && usage "too many arguments specified"
+	CONTAINER="$2"
+	migrate_configuration
 	;;
 *)
 	usage "invalid option specified: '$1'"


### PR DESCRIPTION
We need to ensure the correct configuration is in place, prior to
executing the upgrade verification logic (i.e. prior to running
"verify-impl"). This change updates the "upgrade" script to do this.
Additionally, this only applies to "not-in-place" upgrades, since we
don't do any configuration migration for "in-place" upgrades.