### PR TITLE
Fix recent regression in "execute" script

### DIFF
--- a/live-build/misc/upgrade-scripts/execute
+++ b/live-build/misc/upgrade-scripts/execute
@@ -48,7 +48,8 @@ done
 # Thus, when we can't determine the installed version of delphix-entire,
 # we assume we're doing a not-in-place upgrade, and skip this check.
 #
-[[ -n "$(get_installed_version)" ]] && verify_upgrade_is_allowed
+INSTALLED_VERSION=$(get_installed_version)
+[[ -n "$INSTALLED_VERSION" ]] && verify_upgrade_is_allowed
 
 if [[ -f /etc/apt/sources.list ]]; then
 	mv /etc/apt/sources.list /etc/apt/sources.list.orig ||
@@ -61,6 +62,8 @@ EOF
 	die "failed to configure apt sources"
 
 apt_get update || die "failed to update apt sources"
+
+source_version_information
 apt_get install -y "delphix-entire=$VERSION" ||
 	die "upgrade failed; from '$INSTALLED_VERSION' to '$VERSION'"
 


### PR DESCRIPTION
The following commit broke the "execute" script:

    commit e3ea5c8dc820ce276553c16ba3ba506540495337
    Author: Prakash Surya <prakash.surya@delphix.com>
    Date:   Thu Dec 13 10:15:40 2018 -0800

        Enforce version.info requirements in upgrade scripts

As an example, running "upgrade" resulted in this error:

    E: Version '' for 'delphix-entire' was not found
    execute: upgrade failed; from '' to ''
    upgrade: '/var/dlpx-update/2018.12.13.7/execute' failed in 'delphix.IPS0gAD'

The problem is we use the "INSTALLED_VERSION" and "VERSION" variables in
the "execute" script, but that commit removed the code that was
responsible for setting those variables. This change resolves the issue
by adding code to set these variables prior to them being used.