### PR TITLE
LX-1337 Allow app-gate stack to run in a chroot (systemd-nspawn) environment

### DIFF
--- a/upgrade/upgrade-scripts/upgrade
+++ b/upgrade/upgrade-scripts/upgrade
@@ -113,8 +113,11 @@ function upgrade_in_place() {
 
 	if [[ "$DLPX_UPGRADE_SKIP_VERIFY" != "true" ]]; then
 		"$IMAGE_PATH/upgrade-container" run "$CONTAINER" \
-			"$IMAGE_PATH/verify-impl" "$@" ||
-			die "'$IMAGE_PATH/verify-impl' '$*' failed in '$CONTAINER'"
+			"$IMAGE_PATH/verify-jar" "$@" ||
+			die "'$IMAGE_PATH/verify-jar' '$*' failed in '$CONTAINER'"
+		"$IMAGE_PATH/upgrade-container" run "$CONTAINER" \
+			"$IMAGE_PATH/verify-stack" "$@" ||
+			die "'$IMAGE_PATH/verify-stack' '$*' failed in '$CONTAINER'"
 	fi
 
 	"$IMAGE_PATH/execute" -p "$(get_platform)" ||
@@ -180,8 +183,8 @@ function upgrade_not_in_place() {
 
 	if [[ "$DLPX_UPGRADE_SKIP_VERIFY" != "true" ]]; then
 		"$IMAGE_PATH/upgrade-container" run "$CONTAINER" \
-			"$IMAGE_PATH/verify-impl" "$@" ||
-			die "'$IMAGE_PATH/verify-impl' '$*' failed in '$CONTAINER'"
+			"$IMAGE_PATH/verify-jar" "$@" ||
+			die "'$IMAGE_PATH/verify-jar' '$*' failed in '$CONTAINER'"
 	fi
 
 	"$IMAGE_PATH/upgrade-container" stop "$CONTAINER" ||

--- a/upgrade/upgrade-scripts/verify
+++ b/upgrade/upgrade-scripts/verify
@@ -41,6 +41,15 @@ function cleanup() {
 	#
 	[[ -z "$CONTAINER" ]] && return
 
+	#
+	# Collect logs within container if it's running.
+	#
+	if [[ "$(machinectl list | grep -q "${CONTAINER}")" -eq 0 ]]; then
+		report_progress 75 "Collecting container logs into '${LOG_DIRECTORY}/${CONTAINER}'."
+		"$IMAGE_PATH/upgrade-container" run "$CONTAINER" "/opt/delphix/server/bin/support_info" \
+			-o "${LOG_DIRECTORY}/${CONTAINER}" -t "log dropbox"
+	fi
+
 	if [[ "$rc" == "0" || "$DLPX_DEBUG" != "true" ]]; then
 		report_progress 80 "Performing upgrade verification cleanup"
 
@@ -68,6 +77,9 @@ function cleanup() {
 
 trap cleanup EXIT
 
+VERSION=$(get_installed_version)
+source_version_information
+
 report_progress 0 "Creating upgrade verification container"
 CONTAINER=$("$IMAGE_PATH/upgrade-container" create in-place)
 [[ -n "$CONTAINER" ]] || die "failed to create container"
@@ -83,8 +95,21 @@ report_progress 40 "Performing package upgrade verification"
 
 report_progress 60 "Performing application upgrade verification"
 "$IMAGE_PATH/upgrade-container" run "$CONTAINER" \
-	"$IMAGE_PATH/verify-impl" "$@" ||
-	die "'$IMAGE_PATH/verify-impl' '$*' failed in '$CONTAINER'"
+	"$IMAGE_PATH/verify-jar" "$@" ||
+	die "'$IMAGE_PATH/verify-jar' '$*' failed in '$CONTAINER'"
+
+#
+# We skip stack startup verification if upgrade is a reboot-required upgrade
+# (i.e. 'current version' > 'minimum reboot optional version') because reboot-required upgrade
+# implies that stack is dependent on bits that are available post-reboot, so starting a
+# stack pre-reboot may result in dependency failure.
+#
+if compare_versions "$VERSION" "ge" "${MINIMUM_REBOOT_OPTIONAL_VERSION}"; then
+	report_progress 70 "Performing post-upgrade application startup upgrade verification"
+	"$IMAGE_PATH/upgrade-container" run "$CONTAINER" \
+		"$IMAGE_PATH/verify-stack" "$@" ||
+		die "'$IMAGE_PATH/verify-stack' '$*' failed in '$CONTAINER'"
+fi
 
 #
 # The cleanup logic will be run on EXIT, so rather than reporting 100

--- a/upgrade/upgrade-scripts/verify-jar
+++ b/upgrade/upgrade-scripts/verify-jar
@@ -26,13 +26,24 @@ function usage() {
 	exit 2
 }
 
-function run_support_info() {
+function verify_jar_verify_cleanup() {
 	local rc="$?"
 
-	/opt/delphix/server/bin/support_info \
-		-o "${LOG_DIRECTORY}/${CONTAINER}" \
-		-t "log dropbox" || die "Failed to collect verify logs."
+	#
+	# This name is used by the "upgrade-verify.jar" just executed, so we
+	# cannot change this value without also modifying that JAR.
+	#
+	MDS_SNAPNAME="MDS-CLONE-upgradeverify"
 
+	if /opt/delphix/server/bin/dx_manage_pg isrunning -s ${MDS_SNAPNAME}; then
+		/opt/delphix/server/bin/dx_manage_pg stop -s "${MDS_SNAPNAME}" ||
+			die "failed to stop postgres for snapshot '${MDS_SNAPNAME}'."
+	fi
+
+	if zfs list "${MDS_SNAPNAME}" &>/dev/null; then
+		/opt/delphix/server/bin/dx_manage_pg cleanup -s "${MDS_SNAPNAME}" ||
+			die "failed to cleanup postgres for snapshot '${MDS_SNAPNAME}'."
+	fi
 	return "$rc"
 }
 
@@ -55,16 +66,7 @@ if $opt_d; then
 	VERIFY_LIVE_MDS_OPT="-disableConsistentMdsZfsDataUtil"
 fi
 
-#
-# We use this directory to store the upgrade verification logs of this
-# container. This directory is accessible from both the container, and
-# the host. This allows the software running on the host to easily
-# access the logs after the verification is performed.
-#
-mkdir -p "${LOG_DIRECTORY}/${CONTAINER}" ||
-	die "failed to create directory: '${LOG_DIRECTORY}/${CONTAINER}'"
-
-trap run_support_info EXIT
+trap verify_jar_verify_cleanup EXIT
 
 /usr/bin/java \
 	-Dlog.dir=/var/delphix/server/upgrade-verify \
@@ -78,17 +80,5 @@ trap run_support_info EXIT
 	-pl 60 -ph 80 \
 	$VERIFY_LIVE_MDS_OPT ||
 	die "'upgrade-verify.jar' failed in verification container"
-
-#
-# This name is used by the "upgrade-verify.jar" just executed, so we
-# cannot change this value without also modifying that JAR.
-#
-MDS_SNAPNAME="MDS-CLONE-upgradeverify"
-
-/opt/delphix/server/bin/dx_manage_pg stop -s "$MDS_SNAPNAME" ||
-	die "failed to stop postgres"
-
-/opt/delphix/server/bin/dx_manage_pg cleanup -s "$MDS_SNAPNAME" ||
-	die "failed to cleanup postgres"
 
 exit 0

--- a/upgrade/upgrade-scripts/verify-stack
+++ b/upgrade/upgrade-scripts/verify-stack
@@ -1,0 +1,64 @@
+#!/bin/bash
+#
+# Copyright 2018 Delphix
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+. "${BASH_SOURCE%/*}/common.sh"
+
+STACK_STARTUP_MDS_SNAPNAME="MDS-CLONE-stack-startup-verify"
+
+function stack_startup_verify_cleanup() {
+	local rc="$?"
+
+	if /opt/delphix/server/bin/dx_manage_pg isrunning -s ${STACK_STARTUP_MDS_SNAPNAME}; then
+		/opt/delphix/server/bin/dx_manage_pg stop -s "${STACK_STARTUP_MDS_SNAPNAME}" ||
+			die "failed to stop postgres for snapshot '${STACK_STARTUP_MDS_SNAPNAME}'."
+	fi
+
+	if zfs list | grep -q ${STACK_STARTUP_MDS_SNAPNAME}; then
+		/opt/delphix/server/bin/dx_manage_pg cleanup -s "${STACK_STARTUP_MDS_SNAPNAME}" ||
+			die "failed to cleanup postgres for snapshot '${STACK_STARTUP_MDS_SNAPNAME}'."
+	fi
+
+	return "$rc"
+}
+
+trap stack_startup_verify_cleanup EXIT
+
+#
+# Make sure delphix-mgmt and delphix-postgres aren't running within container.
+#
+IS_ACTIVE_MGMT=$(systemctl is-active delphix-mgmt)
+[[ "${IS_ACTIVE_MGMT}" == "inactive" ]] ||
+	die "delphix-mgmt service expected to be 'inactive', found to be '${IS_ACTIVE_MGMT}'"
+IS_ACTIVE_POSTGRES=$(systemctl is-active delphix-postgres@default)
+[[ "${IS_ACTIVE_POSTGRES}" == "inactive" ]] ||
+	die "delphix-postgres@default service expected to be 'inactive', found to be '${IS_ACTIVE_POSTGRES}'"
+
+#
+# Create a copy of MDS and start the postgres service.
+#
+/opt/delphix/server/bin/dx_manage_pg clone -s "${STACK_STARTUP_MDS_SNAPNAME}" -l ||
+	die "failed to clone postgres"
+/opt/delphix/server/bin/dx_manage_pg start -s "${STACK_STARTUP_MDS_SNAPNAME}" -p 5432 ||
+	die "failed to start postgres"
+
+#
+# Start management stack up to post-upgrade logic.
+#
+/opt/delphix/server/bin/start_mgmt_server_jvm -f /var/run/delphix-mgmt.pid ||
+	die "Stack startup verification failed."
+
+exit 0


### PR DESCRIPTION
### Changes

Adds stack startup verification logic.

* The stack startup verification logic will run only if it's a reboot required upgrade (i.e. when current version is less than `MINIMUM_REBOOT_OPTIONAL_VERSION`. Once a container packages are upgraded to the latest version, we don't have a way to get the previous version to compare against `MINIMUM_REBOOT_OPTIONAL_VERSION`. So I simply save the pre-upgrade version to `${IMAGE_PATH}/${UPGRADE_VERSION_FILE_NAME}` before running `execute` script and read the content before verifying.

* In order to run stack within a container, we need have a copy of MDS instance. In order to do so, we leverage `dx_manage_pg.sh` script to make a copy of MDS, start and stop the instance. Once MDS clone is prepared, we need to create new links to `/var/delphix/server/db` and `/var/delphix/server/mds_external` since stack depends on these location. We are also leveraging `start_mgmt_server_jvm` script to run management stack. This script will return non-zero exit status if it fails to start. 

