### PR TITLE
Make migration image useable by UpgradeManager

### DIFF
--- a/live-build/misc/live-build-hooks/90-linux-migration-artifact.binary
+++ b/live-build/misc/live-build-hooks/90-linux-migration-artifact.binary
@@ -94,11 +94,15 @@ cp migration-scripts/* $DEPOT_DIRECTORY
 #
 {
 	#
-	# Note that both the following fields are bogus and supplied
+	# Note that both the following field is bogus and supplied
 	# solely for making dx_unpack happy.
 	#
-	echo "DLPX_DATE=bogus"
 	echo "DLPX_OS_VERSION=Linux"
+
+	#
+	# UpgradeManager expects a valid date for DLPX_DATE.
+	#
+	echo "DLPX_DATE=$(date '+%Y.%m.%d.%H.%M.%S')"
 
 	#
 	# DLPX_MIN_VERSION is specified for ensuring that we are

--- a/live-build/misc/migration-scripts/dx_apply
+++ b/live-build/misc/migration-scripts/dx_apply
@@ -35,6 +35,10 @@ function usage() {
 	exit 2
 }
 
+function report_progress_inc() {
+	echo "Progress increment: $(date +%T:%N%z), $1, $2"
+}
+
 [[ "$(uname -s)" == "SunOS" ]] || die "script can only be used in illumos"
 
 while getopts ':h' opt; do
@@ -85,6 +89,8 @@ sed -i '/set mainmenu_keycode\[8\]/d' /boot/menu.rc.local
 sed -i '/set mainmenu_command\[8\]/d' /boot/menu.rc.local
 [[ "$(grep -cF 'mainmenu_command[8]' /boot/menu.rc.local)" -eq 0 ]] ||
 	die "failed to cleanup mainmenu_command from previous run"
+
+report_progress_inc 20
 
 #
 # Check that the version to which we are upgrading is compatible with the
@@ -238,5 +244,7 @@ zfs umount "$RPOOL/ROOT/$FSNAME" ||
 	die "couldn't unmount linux root dataset from temporary mountpoint"
 zfs set mountpoint=/ "$RPOOL/ROOT/$FSNAME" ||
 	die "could not reset mountpoint for linux root dataset"
+
+report_progress_inc 100
 
 exit 0

--- a/live-build/misc/migration-scripts/dx_execute
+++ b/live-build/misc/migration-scripts/dx_execute
@@ -27,6 +27,27 @@ function die() {
 	exit 1
 }
 
+function usage() {
+	[[ -n "$1" ]] && echo "$1"
+	cat <<EOM
+Usage:
+  $(basename "$0") [-s]"
+    Reset system to the Linux version that has been previously installed using
+    dx_apply.
+      -s Shutdown (instead of reboot) after upgrade.
+EOM
+	exit 2
+}
+
+opt_s=false
+while getopts :hs c; do
+	case "$c" in
+	\?) usage "Invalid option: -$OPTARG." ;;
+	h) usage ;;
+	s) eval "opt_$c=true" ;;
+	esac
+done
+
 [[ "$(uname -s)" == "SunOS" ]] || die "script can only be used in illumos"
 
 #
@@ -84,5 +105,17 @@ LX_RDS=$(zfs list -o name -Hr "$RPOOL/ROOT" | tail -n 1)
 MAIN_MENU_LINUX_CMD=$(grep -F 'mainmenu_command[8]' /boot/menu.rc.local |
 	cut -d = -f 2-)
 echo "set menu_timeout_command=$MAIN_MENU_LINUX_CMD" >>/boot/menu.rc.local
+
+# Constants used by the uadmin syscall.
+A_SHUTDOWN=2
+AD_POWEROFF=6
+AD_BOOT=1
+
+# reboot or shutdown
+if $opt_s; then
+	uadmin $A_SHUTDOWN $AD_POWEROFF
+else
+	uadmin $A_SHUTDOWN $AD_BOOT
+fi
 
 exit 0

--- a/live-build/misc/migration-scripts/dx_verify
+++ b/live-build/misc/migration-scripts/dx_verify
@@ -21,4 +21,10 @@
 # it as an empty file until the needed functionality is added.
 #
 
+function report_progress_inc() {
+	echo "Progress increment: $(date +%T:%N%z), $1, $2"
+}
+
+report_progress_inc 100
+
 exit 0


### PR DESCRIPTION
This follows up on https://github.com/delphix/appliance-build/pull/167 and makes those scripts consumable by UpgradeManager.
The following changes had to be made:
- Add progress report to `dx_apply` and `dx_verify`
- Add a valid date field to `version.info`
- Reboot the system at the end of `dx_execute`

## TESTING
1. Run a 5.3 system through initial setup (Using `DRYRUN-migration-5.2.3.0` image)
1. Download migration image from S3 into /var/dlpx-update/upload
2. Remove `rpool/update` quota (`zfs set quota=none rpool/update`) as the migration image is very large and fails to unpack otherwise.
3. Run `dx_unpack` on the migration image
4. Go into the UI and click "Verify Upgrade" -- PASS.
5. Go into the UI and click "Apply Upgrade" -- This will apply the image and reboot into Linux. Note that domain0 is currently not importable in RW mode due to missing ZFS features.
