### PR TITLE
LX-1664 Verify jar results json file is not present in /var/delphix/dropbox/ in Linux

### DIFF
--- a/live-build/misc/upgrade-scripts/verify-impl
+++ b/live-build/misc/upgrade-scripts/verify-impl
@@ -38,7 +38,7 @@ function cleanup() {
 		die "Failed to remove verify log directory ${UPDATE_VERIFY_LOG_DIR}."
 	mkdir -p "${UPDATE_VERIFY_LOG_DIR}/${CONTAINER}" ||
 		die "Failed to create verify log directory ${UPDATE_VERIFY_LOG_DIR}/${CONTAINER}."
-	${SUPPORT_INFO_SCRIPT} -o "${UPDATE_VERIFY_LOG_DIR}/${CONTAINER}" -t "log dropbox" ||
+	${SUPPORT_INFO_SCRIPT} -s -o "${UPDATE_VERIFY_LOG_DIR}/${CONTAINER}" -t "log dropbox" ||
 		die "Failed to collect verify logs."
 
 	return "$rc"


### PR DESCRIPTION
The verify.jar results were purged when container logs were collected because support_info script by default cleans up the dropbox directory. I made a change to support_info script to skip the cleanup if `-s` flag is provided. The change here simply consumes the flag.