### PR TITLE
Don't use "dropbox" for upgrade-verify's JSON file

### DIFF
--- a/live-build/misc/upgrade-scripts/common.sh
+++ b/live-build/misc/upgrade-scripts/common.sh
@@ -15,12 +15,6 @@
 # limitations under the License.
 #
 
-# shellcheck disable=SC2034
-UPDATE_DIR=${UPDATE_DIR:-"/var/dlpx-update"}
-UPDATE_VERIFY_LOG_DIR=${UPDATE_DIR}/verify-logs
-SUPPORT_INFO_SCRIPT=${SUPPORT_INFO_SCRIPT:-"/opt/delphix/server/bin/support_info"}
-DROPBOX_DIR=${DROPBOX_DIR:-"/var/delphix/dropbox"}
-
 function die() {
 	echo "$(basename "$0"): $*" >&2
 	exit 1

--- a/live-build/misc/upgrade-scripts/common.sh
+++ b/live-build/misc/upgrade-scripts/common.sh
@@ -15,6 +15,9 @@
 # limitations under the License.
 #
 
+# shellcheck disable=SC2034
+LOG_DIRECTORY="/var/log/delphix-upgrade"
+
 function die() {
 	echo "$(basename "$0"): $*" >&2
 	exit 1

--- a/live-build/misc/upgrade-scripts/upgrade-container
+++ b/live-build/misc/upgrade-scripts/upgrade-container
@@ -235,6 +235,21 @@ function create_upgrade_container() {
 	fi
 
 	#
+	# Lastly, we create the log directory and bind mount this into
+	# the container. This is meant as a way for software running in
+	# the container, to share files with software running on the
+	# host; e.g. during upgrade verify, this directory can be used
+	# to store logs, such that they persist after the container is
+	# destroyed.
+	#
+	mkdir -p "$LOG_DIRECTORY" ||
+		die "failed to create directory: '$LOG_DIRECTORY'"
+	cat >>"/etc/systemd/nspawn/$CONTAINER.nspawn" <<-EOF ||
+		Bind=$LOG_DIRECTORY
+	EOF
+		die "failed to add '$LOG_DIRECTORY' to container config file"
+
+	#
 	# We want to enable all available capabilities to the container
 	# that we will use to run the ugprade verification. Ideally, we
 	# would accomplish this by using "CAPABILITY=all" in the

--- a/live-build/misc/upgrade-scripts/upgrade-container
+++ b/live-build/misc/upgrade-scripts/upgrade-container
@@ -235,18 +235,6 @@ function create_upgrade_container() {
 	fi
 
 	#
-	# Lastly, we expose the host's DROPBOX_DIR to the container, so
-	# that this directory can be used from within the container, to
-	# store files that need to be preserved after the container is
-	# destroyed; e.g. logs of the upgrade verification java process
-	# are stored here (by default).
-	#
-	cat >>"/etc/systemd/nspawn/$CONTAINER.nspawn" <<-EOF ||
-		Bind=$DROPBOX_DIR
-	EOF
-		die "failed to add '$DROPBOX_DIR' to container config file"
-
-	#
 	# We want to enable all available capabilities to the container
 	# that we will use to run the ugprade verification. Ideally, we
 	# would accomplish this by using "CAPABILITY=all" in the

--- a/live-build/misc/upgrade-scripts/verify-impl
+++ b/live-build/misc/upgrade-scripts/verify-impl
@@ -17,8 +17,17 @@
 
 . "${BASH_SOURCE%/*}/common.sh"
 
+IMAGE_PATH=$(get_image_path)
+[[ -n "$IMAGE_PATH" ]] || die "failed to determine image path"
+
 IMAGE_VERSION=$(get_image_version)
 [[ -n "$IMAGE_VERSION" ]] || die "failed to determine image version"
+
+UPDATE_DIR="$(dirname "$IMAGE_PATH")"
+[[ -n "$UPDATE_DIR" ]] || die "failed to determine update directory"
+
+LOG_DIR="${UPDATE_DIR}/verify-logs"
+LOG_SCRIPT="/opt/delphix/server/bin/support_info"
 
 function usage() {
 	echo "$(basename "$0"): $*" >&2
@@ -26,19 +35,10 @@ function usage() {
 	exit 2
 }
 
-function cleanup() {
+function run_support_info_script() {
 	local rc="$?"
 
-	#
-	# Persist container logs by saving to the container's host.
-	# Delete and create verify log destination directory to save only one copy of log to limit
-	# space usage.
-	#
-	rm -rf "${UPDATE_VERIFY_LOG_DIR:?}" ||
-		die "Failed to remove verify log directory ${UPDATE_VERIFY_LOG_DIR}."
-	mkdir -p "${UPDATE_VERIFY_LOG_DIR}/${CONTAINER}" ||
-		die "Failed to create verify log directory ${UPDATE_VERIFY_LOG_DIR}/${CONTAINER}."
-	${SUPPORT_INFO_SCRIPT} -o "${UPDATE_VERIFY_LOG_DIR}/${CONTAINER}" -t "log dropbox" ||
+	"${LOG_SCRIPT}" -o "${LOG_DIR}/${CONTAINER}" -t "log dropbox" ||
 		die "Failed to collect verify logs."
 
 	return "$rc"
@@ -63,14 +63,30 @@ if $opt_d; then
 	VERIFY_LIVE_MDS_OPT="-disableConsistentMdsZfsDataUtil"
 fi
 
-trap cleanup EXIT
+#
+# We use this directory to store the upgrade verification logs of this
+# container. This directory is accessible from both the container, and
+# the host. This allows the software running on the host to easily
+# access the logs after the verification is performed.
+#
+# Additionally, we only want to save the logs for one verification
+# invocation at any given time; mostly to avoid these logs from
+# consuming storage unnecessarily. Thus, we delete the existing
+# directory first, and then recreate an empty directory.
+#
+rm -rf "${LOG_DIR:?}" ||
+	die "failed to remove directory: '${LOG_DIR}'"
+mkdir -p "${LOG_DIR}/${CONTAINER}" ||
+	die "failed to create directory: '${LOG_DIR}/${CONTAINER}'"
+
+trap run_support_info_script EXIT
 
 /usr/bin/java \
 	-Dlog.dir=/var/delphix/server/upgrade-verify \
 	-Dmdsverify=true \
 	$VERIFY_DEBUG_OPT \
 	-jar /opt/delphix/server/lib/exec/upgrade-verify/upgrade-verify.jar \
-	-d "${opt_o:-$DROPBOX_DIR/upgrade_verify_report.json}" \
+	-d "${opt_o:-${LOG_DIR}/${CONTAINER}/upgrade_verify_report.json}" \
 	-f "${opt_f:-1}" \
 	-l "${opt_l:-en-US}" \
 	-v "$IMAGE_VERSION" \

--- a/live-build/misc/upgrade-scripts/verify-impl
+++ b/live-build/misc/upgrade-scripts/verify-impl
@@ -17,17 +17,8 @@
 
 . "${BASH_SOURCE%/*}/common.sh"
 
-IMAGE_PATH=$(get_image_path)
-[[ -n "$IMAGE_PATH" ]] || die "failed to determine image path"
-
 IMAGE_VERSION=$(get_image_version)
 [[ -n "$IMAGE_VERSION" ]] || die "failed to determine image version"
-
-UPDATE_DIR="$(dirname "$IMAGE_PATH")"
-[[ -n "$UPDATE_DIR" ]] || die "failed to determine update directory"
-
-LOG_DIR="${UPDATE_DIR}/verify-logs"
-LOG_SCRIPT="/opt/delphix/server/bin/support_info"
 
 function usage() {
 	echo "$(basename "$0"): $*" >&2
@@ -35,11 +26,12 @@ function usage() {
 	exit 2
 }
 
-function run_support_info_script() {
+function run_support_info() {
 	local rc="$?"
 
-	"${LOG_SCRIPT}" -o "${LOG_DIR}/${CONTAINER}" -t "log dropbox" ||
-		die "Failed to collect verify logs."
+	/opt/delphix/server/bin/support_info \
+		-o "${LOG_DIRECTORY}/${CONTAINER}" \
+		-t "log dropbox" || die "Failed to collect verify logs."
 
 	return "$rc"
 }
@@ -69,24 +61,17 @@ fi
 # the host. This allows the software running on the host to easily
 # access the logs after the verification is performed.
 #
-# Additionally, we only want to save the logs for one verification
-# invocation at any given time; mostly to avoid these logs from
-# consuming storage unnecessarily. Thus, we delete the existing
-# directory first, and then recreate an empty directory.
-#
-rm -rf "${LOG_DIR:?}" ||
-	die "failed to remove directory: '${LOG_DIR}'"
-mkdir -p "${LOG_DIR}/${CONTAINER}" ||
-	die "failed to create directory: '${LOG_DIR}/${CONTAINER}'"
+mkdir -p "${LOG_DIRECTORY}/${CONTAINER}" ||
+	die "failed to create directory: '${LOG_DIRECTORY}/${CONTAINER}'"
 
-trap run_support_info_script EXIT
+trap run_support_info EXIT
 
 /usr/bin/java \
 	-Dlog.dir=/var/delphix/server/upgrade-verify \
 	-Dmdsverify=true \
 	$VERIFY_DEBUG_OPT \
 	-jar /opt/delphix/server/lib/exec/upgrade-verify/upgrade-verify.jar \
-	-d "${opt_o:-${LOG_DIR}/${CONTAINER}/upgrade_verify_report.json}" \
+	-d "${opt_o:-${LOG_DIRECTORY}/${CONTAINER}/upgrade_verify.json}" \
 	-f "${opt_f:-1}" \
 	-l "${opt_l:-en-US}" \
 	-v "$IMAGE_VERSION" \


### PR DESCRIPTION
This change modifies where the upgrade-verify's JSON file will be
stored, from "/var/delphix/dropbox" to "/var/dlpx-update/verify-logs".

Since we already use "/var/dlpx-update/verify-logs" for storing the
support_info script's output, it makes sense to also use this directory
to store upgrade-verify's JSON file. This simplifies the container's
configuration, since we no longer need to bind mount the host's
"/var/delphix/dropbox" directory into the container.