### PR TITLE
Revert "Use zfs-mount.service to mount datasets in container"

### DIFF
--- a/live-build/misc/upgrade-scripts/upgrade-container
+++ b/live-build/misc/upgrade-scripts/upgrade-container
@@ -205,6 +205,21 @@ function create_upgrade_container() {
 	done
 
 	#
+	# Since UPDATE_DIR is stored on a seperate ZFS filesystem than
+	# the root filesysytem, we need to explicitly make this
+	# directory available inside of the upgrade container,
+	# which is what we're doing here.
+	#
+	# We need UPDATE_DIR to be available inside of the container so
+	# that we can use the APT repository that it contains to upgrade
+	# the packages inside the container, and verify that process.
+	#
+	cat >>"/etc/systemd/nspawn/$CONTAINER.nspawn" <<-EOF ||
+		Bind=$UPDATE_DIR
+	EOF
+		die "failed to add '$UPDATE_DIR' to container config file"
+
+	#
 	# We also need to make "/domain0" available from within the
 	# container, since that's required by the "upgrade-verify" JAR
 	# that's run later. This allows the Virtualization upgrade


### PR DESCRIPTION
This reverts commit 20573a5d4ca5abe537c5f232b5ecf920a58286a0.

The change being reverted breaks not-in-place upgrade. This is due to
how we "debootstrap + start" the upgrade container, prior to installing
the delphix-entire package (and all of it's dependencies).

As a result, when the container is first started, the "zfs-mount"
service will not exist, and thus the "/var/dlpx-update" directory is not
automatically mounted. Then, because this directory isn't mounted, the
upgrade image required to execute the upgrade and install delphix-entire
is not accessible from the container.

The solution is to simply revert the breakage, and continue to rely on
systemd-nspawn to mount this container, since this works even when
delphix-entire is not installed in the container.