### PR TITLE
Add UPDATE_DIR definition back to common.sh

### DIFF
--- a/live-build/misc/upgrade-scripts/common.sh
+++ b/live-build/misc/upgrade-scripts/common.sh
@@ -16,6 +16,7 @@
 #
 
 # shellcheck disable=SC2034
+UPDATE_DIR="/var/dlpx-update"
 LOG_DIRECTORY="/var/log/delphix-upgrade"
 
 function die() {


### PR DESCRIPTION
In commit 4bf0452d6018681f20680d2d71ea4d2a1554240d we incorrectly
removed the UPDATE_DIR variable from common.sh; as a result,
not-in-place upgrades are broken without this change.