### PR TITLE
Use a dedicated dataset for GRUB configuration

### DIFF
--- a/live-build/misc/live-build-hooks/90-raw-disk-image.binary
+++ b/live-build/misc/live-build-hooks/90-raw-disk-image.binary
@@ -133,6 +133,28 @@ zfs create \
 	"rpool/ROOT/$FSNAME/data"
 
 #
+# Initialize the grub dataset. This dataset will be used to contain all
+# of the grub-specific files; this includes the "grub.cfg" file, along
+# with the files created when running "grub-install".
+#
+# We maintain a seperate dataset for grub, so that we can maintain it
+# differently than how we maintain and version the root filesystems.
+# This allows us to have a single configuration for the bootloader,
+# spanning all of the root filesystems that may be present on the
+# system; rather than trying to have a configuration on each root
+# filesystem, and trying to keep them all consistent with each other.
+#
+# Additionally, we use the "legacy" mountpoint so we can carefully
+# control when this dataset is mounted, to help ensure the dataset isn't
+# modified unexpectedly. Thus, we mount it on-demand when we need to
+# make changes to it, and then quickly unmount it.
+#
+zfs create \
+	-o compression=on \
+	-o mountpoint=legacy \
+	rpool/grub
+
+#
 # Initialize the crashdump dataset. This is used to store core files
 # from processes that have crashed. Since we don't have control on how
 # many of these core files accumulate, we set a reasonable quota (25% of
@@ -187,8 +209,14 @@ for dir in /dev /proc /sys; do
 	mount --make-rslave "${DIRECTORY}${dir}"
 done
 
-chroot "$DIRECTORY" grub-install "/dev/$LOOPNAME"
-chroot "$DIRECTORY" update-grub
+#
+# We need to use the dedicated grub dataset when running "grub-install"
+# and "grub-mkconfig", so we need to mount this dataset first.
+#
+chroot "$DIRECTORY" mount -t zfs rpool/grub /mnt
+chroot "$DIRECTORY" grub-install --root-directory=/mnt "/dev/$LOOPNAME"
+chroot "$DIRECTORY" grub-mkconfig -o /mnt/boot/grub/grub.cfg
+chroot "$DIRECTORY" umount /mnt
 
 for dir in /dev /proc /sys; do
 	umount -R "${DIRECTORY}${dir}"

--- a/live-build/misc/upgrade-scripts/upgrade-container
+++ b/live-build/misc/upgrade-scripts/upgrade-container
@@ -381,6 +381,9 @@ function get_bootloader_devices() {
 }
 
 function convert_to_bootfs_cleanup() {
+	umount "/var/lib/machines/$CONTAINER/mnt" ||
+		warn "'umount' of '/var/lib/machines/$CONTAINER/mnt' failed"
+
 	for dir in /proc /sys /dev; do
 		umount -R "/var/lib/machines/${CONTAINER}${dir}" ||
 			warn "'umount -R' of '$dir' failed"
@@ -414,8 +417,8 @@ function convert_to_bootfs() {
 			die "'mount --make-rslave' of '$dir' failed"
 	done
 
-	chroot "/var/lib/machines/$CONTAINER" update-grub ||
-		die "'update-grub' failed in '$CONTAINER'"
+	mount -t zfs rpool/grub "/var/lib/machines/$CONTAINER/mnt" ||
+		die "'mount -t zfs rpool/grub' failed for '$CONTAINER'"
 
 	for dev in $(get_bootloader_devices); do
 		[[ -e "/dev/$dev" ]] ||
@@ -425,9 +428,13 @@ function convert_to_bootfs() {
 			die "bootloader device '/dev/$dev' not block device"
 
 		chroot "/var/lib/machines/$CONTAINER" \
-			grub-install "/dev/$dev" ||
-			die "'grub-install /dev/$dev' failed in '$CONTAINER'"
+			grub-install --root-directory=/mnt "/dev/$dev" ||
+			die "'grub-install' for '$dev' failed in '$CONTAINER'"
 	done
+
+	chroot "/var/lib/machines/$CONTAINER" \
+		grub-mkconfig -o /mnt/boot/grub/grub.cfg ||
+		die "'grub-mkconfig' failed in '$CONTAINER'"
 
 	convert_to_bootfs_cleanup
 	trap - EXIT


### PR DESCRIPTION
Use a dedicated/seperate dataset for grub, so that we can maintain it
differently than how we maintain and version the root filesystems. This
allows us to have a single configuration for the bootloader, spanning
all of the root filesystems that may be present on the system; rather
than trying to have a configuration on each root filesystem, and trying
to keep them all consistent with each other.