### PR TITLE
Only copy OVA when building for ESX

### DIFF
--- a/scripts/run-live-build.sh
+++ b/scripts/run-live-build.sh
@@ -120,6 +120,18 @@ if [[ ! -f binary/SHA256SUMS ]]; then
 	exit 1
 fi
 
+case $APPLIANCE_PLATFORM in
+aws) vm_artifact_ext=vmdk ;;
+azure) vm_artifact_ext=vhdx ;;
+esx) vm_artifact_ext=ova ;;
+gcp) vm_artifact_ext=gcp.tar.gz ;;
+kvm) vm_artifact_ext=qcow2 ;;
+*)
+	echo "Invalid platform"
+	exit 1
+	;;
+esac
+
 #
 # After running the build successfully, it should have produced various
 # virtual machine artifacts. We move these artifacts into a specific
@@ -127,7 +139,7 @@ fi
 # user (e.g. other software); this is most useful when multiple variants
 # are built via a single call to "make" (e.g. using the "all" target).
 #
-for ext in ova qcow2 debs.tar.gz migration.tar.gz gcp.tar.gz vhdx vmdk; do
+for ext in debs.tar.gz migration.tar.gz $vm_artifact_ext; do
 	if [[ -f "$ARTIFACT_NAME.$ext" ]]; then
 		mv "$ARTIFACT_NAME.$ext" "$TOP/live-build/build/artifacts/"
 	fi


### PR DESCRIPTION
When we build an OVA for ESX, we first build a VMDK, and then convert
that into an OVA. We end up moving both artifacts to the artifacts/
directory, and thus we end up uploading both, but we really only need
the OVA.