### PR TITLE
Bump bors timeout to align with Jenkins timeout

### DIFF
--- a/bors.toml
+++ b/bors.toml
@@ -1,4 +1,10 @@
-timeout-sec = 21600
+#
+# The automation associated with the "jenkins/appliance-build" commit
+# status uses a timeout of 12 hours. Thus, the bors timeout should match
+# that. We then add an additional hour to the bors timeout, to account
+# for the time it may take for the automation to start its testing.
+#
+timeout-sec = 46800
 
 pr_status = [
   "license/cla"


### PR DESCRIPTION
For our Jenkins job that executes the build, we use a 12 hour timeout.
Thus, we should align the timeout we use for bors to align with that, so
bors doesn't result in a timeout while the build is still in progress.