### PR TITLE
LX-1747 /var/delphix dataset should be migrated to Linux

### DIFF
--- a/live-build/misc/migration-scripts/dx_apply
+++ b/live-build/misc/migration-scripts/dx_apply
@@ -154,12 +154,18 @@ mount -F zfs "$RPOOL/ROOT/$FSNAME/data" "$TMP_ROOT/var/delphix"
 (
 	cd "$TMP_ROOT"
 	cpio -imu
-	cat <<-EOF >"/etc/fstab"
-		$RPOOL/ROOT/$FSNAME/home /export/home zfs defaults 0 0
-		$RPOOL/ROOT/$FSNAME/data /var/delphix zfs defaults 0 0
-	EOF
 ) <"$ARCHIVE_DIR/os-root.cpio" 2>&1 ||
 	die "failed to unpack os-root.cpio"
+
+#
+# /export/home and /var/delphix datasets are not mounted automatically.
+# On Illumos this kind of mounting logic was performed by dxinit and svc-boot.
+# On Linux /etc/fstab is used instead.
+#
+cat <<-EOF >"$TMP_ROOT/etc/fstab" || die "Failed to setup /etc/fstab"
+	$RPOOL/ROOT/$FSNAME/home /export/home zfs defaults 0 0
+	$RPOOL/ROOT/$FSNAME/data /var/delphix zfs defaults 0 0
+EOF
 
 #
 # WIP: Add here any operations that generate files from illumos,
@@ -269,8 +275,25 @@ MAIN_MENU_FICL=(
 } >>/boot/menu.rc.local ||
 	die "failed to update /boot/menu.rc.local"
 
-umount "$TMP_ROOT/var/delphix" ||
-	die "couldn't unmount linux directory $TMP_ROOT/var/delphix"
+#
+# Note that the new /var/delphix should not contain any useful data as it will
+# be replaced by a clone of the current /var/delphix dataset in dx_execute.
+# We do not clone the current /var/delphix right away as the clone will be
+# outdated by the time dx_execute is called. Before deleting the dataset we
+# first verify that it doesn't contain anything useful.
+#
+(
+	cd "$TMP_ROOT/var/delphix" || die "failed to cd into $TMP_ROOT/var/delphix"
+	# We only expect to find:
+	#  ./dropbox
+	[[ $(find . -mindepth 1 | wc -l) -eq 1 ]] ||
+		die "linux dataset for /var/delphix contains unexpected files"
+	[[ -d dropbox ]] ||
+		die "linux dataset for /var/delphix should contain directory dropbox"
+) || die "verification of /var/delphix failed"
+
+zfs destroy "$RPOOL/ROOT/$FSNAME/data" ||
+	die "failed to destroy linux dataset $RPOOL/ROOT/$FSNAME/data"
 umount "$TMP_ROOT/export/home" ||
 	die "couldn't unmount linux dataset $TMP_ROOT/export/home"
 

--- a/live-build/misc/migration-scripts/dx_execute
+++ b/live-build/misc/migration-scripts/dx_execute
@@ -23,7 +23,7 @@
 set -o pipefail
 
 function die() {
-	report "$(basename "$0"): $*" >&2
+	echo "$(basename "$0"): $*" >&2
 	exit 1
 }
 
@@ -77,8 +77,9 @@ RPOOL=${RDS%%/*}
 
 #
 # Ensure that the expected Linux dataset layout exists.
+# Note that this excludes the "data" dataset which was destroyed in dx_apply.
 #
-[[ $(zfs list -o name -Hr "$RPOOL/ROOT" | wc -l) -eq 5 ]] ||
+[[ $(zfs list -o name -Hr "$RPOOL/ROOT" | wc -l) -eq 4 ]] ||
 	die "could not find the expected linux dataset layout"
 LX_RDS_PARENT=$(zfs list -o name -H -d 1 "$RPOOL/ROOT" | tail -n 1)
 [[ -n $LX_RDS_PARENT ]] || die "could not find Linux RDS parent dataset"
@@ -96,6 +97,20 @@ LX_RDS="$LX_RDS_PARENT/root"
 [[ "$(grep -c "$LX_RDS" /boot/menu.rc.local)" -eq 1 ]] ||
 	die "the expected Linux RDS ($LX_RDS) was either not found or has" \
 		"been specified more than once in the bootloader's menu file"
+
+#
+# Create linux /var/delphix dataset from a clone of the current
+# /var/delphix dataset.
+#
+LX_VAR_DLPX="$LX_RDS_PARENT/data"
+LX_CONTAINER="${LX_RDS_PARENT##*/}"
+CUR_VAR_DLPX=$(zfs list -Ho name /var/delphix)
+[[ -n $CUR_VAR_DLPX ]] || die "could not determine current /var/delphix dataset"
+zfs list "$CUR_VAR_DLPX" >/dev/null 2>&1 ||
+	die "'$CUR_VAR_DLPX' is not a valid zfs dataset"
+zfs snapshot "${CUR_VAR_DLPX}@${LX_CONTAINER}"
+zfs clone -o compression=on -o mountpoint=legacy \
+	"${CUR_VAR_DLPX}@${LX_CONTAINER}" "$LX_VAR_DLPX"
 
 #
 # Read the command from option 8 which should be the one that boots


### PR DESCRIPTION
`/var/delphix` contains some Delphix configuration and useful debug logs, so we want to carry that directory over into Linux. Note that we do that in `dx_execute` since that's when the stack is quiesced.

There's also a side fix to the code that edits `/etc/fstab` as it didn't seem to work consistently.

## TESTING

 - ab-pre-push: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/503/
 - verify that  `/var/delphix` was carried over after rebooting into Linux:
```
delphix@localhost:/var/delphix$ df .
Filesystem                      1K-blocks  Used Available Use% Mounted on
rpool/ROOT/delphix.WhJtaCV/data 116131072  4864 116126208   1% /var/delphix
delphix@localhost:/var/delphix$ zfs get origin rpool/ROOT/delphix.WhJtaCV/data
NAME                             PROPERTY  VALUE                                                                   SOURCE
rpool/ROOT/delphix.WhJtaCV/data  origin    rpool/versions/5.3.2019.02.12/dlpx/5.3.3.0/running/var@delphix.WhJtaCV  -
```