### PR TITLE
Refactor signature generation for migration to ease debugging

### DIFF
--- a/live-build/config/hooks/90-linux-migration-artifact.binary
+++ b/live-build/config/hooks/90-linux-migration-artifact.binary
@@ -149,14 +149,24 @@ if [[ -n "${DELPHIX_SIGNATURE_TOKEN:-}" ]] && [[ -n "${DELPHIX_SIGNATURE_URL:-}"
 	#
 	VERSION="5.3"
 	SIGN_URL="$DELPHIX_SIGNATURE_URL/upgrade/keyVersion/$VERSION/sign"
+	(
+		cd $DEPOT_DIRECTORY
 
-	set -o pipefail
-	curl -s -f -H "Content-Type: application/json" \
-		-u "$DELPHIX_SIGNATURE_TOKEN" "$SIGN_URL" -d @- <<-EOF |
-			{"data": "$(base64 -w 0 $DEPOT_DIRECTORY/hashes)"}
-		EOF
-		jq -r .signature |
-		base64 -d >$DEPOT_DIRECTORY/hashes.sig.$VERSION
+		# Encode payload for signature request
+		base64 -w 0 hashes >hashes64
+		echo "{\"data\": \"$(cat hashes64)\"}" >hashes64.payload
+
+		# Request signature
+		curl -s -f -H "Content-Type: application/json" \
+			-u "$DELPHIX_SIGNATURE_TOKEN" "$SIGN_URL" -d @hashes64.payload >hashes.response
+
+		# Decode generated signature
+		jq -r .signature <hashes.response >sig.encoded
+		base64 -d sig.encoded >hashes.sig.$VERSION
+
+		# Remove intermediate files
+		rm hashes64 hashes64.payload hashes.response sig.encoded
+	)
 fi
 
 #


### PR DESCRIPTION
# Commit:

We recently had a failure where the logs looked like this:
```
00:28:45 + set -o pipefail
00:28:45 + jq -r .signature
00:28:45 + curl -s -f -H 'Content-Type: application/json' -u **** ****/upgrade/keyVersion/5.3/sign -d @-
00:28:45 + base64 -d
00:28:45 ++ base64 -w 0 depot/hashes
00:29:12 E: config/hooks/90-linux-migration-artifact.binary failed (exit non-zero). You should check for errors.
00:29:12 P: Begin unmounting filesystems...
00:29:12 P: Saving caches...
00:29:12 Reading package lists...
00:29:12 Building dependency tree...
00:29:12 Reading state information...
00:29:12 + kill -9 1037
00:29:12 + [[ ! -f binary/SHA256SUMS ]]
00:29:12 + exit 1
```

It is hard to tell exactly what went wrong because the
specific shell statement in questions is a long pipe of
commands.

This patch refactors that pipe, separating those commands
and generating a few intermediate files.

# Testing Done:

ab-precommit: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/570/flowGraphTable/

Used the pre-push number from the above link for the script below:
```
$ ~pzakharov/get-migration-image s3://dev-de-images/builds/jenkins-selfservice/devops-gate/master/appliance-build/master/pre-push/468
<... bunch of output cropped ...>
+ sudo /opt/delphix/server/bin/upgrade/dx_unpack /var/dlpx-update/upload/internal-qa-esx.migration.tar.gz
Progress increment: 19:27:49:245607391+0000, 10, Extracting upgrade image
19:27:49:249466757:+0000: Unpacking /var/dlpx-update/upload/internal-qa-esx.migration.tar.gz ...
19:37:33:362976399:+0000: done.
Progress increment: 19:37:33:369669796+0000, 40,  verifying format
Progress increment: 19:37:33:599751086+0000, 50,  verifying signature
19:37:33:604338378:+0000: Verify signature ... Verified OK
Progress increment: 19:37:33:769873038+0000, 70, Verifying integrity of upgrade image
19:37:33:774010881:+0000: Verifying contents of ./dx_apply ... ./dx_apply: OK
19:37:33:799354595:+0000: Verifying contents of ./dx_execute ... ./dx_execute: OK
19:37:33:813117103:+0000: Verifying contents of ./dx_prepare ... ./dx_prepare: OK
19:37:33:829331516:+0000: Verifying contents of ./dx_verify ... ./dx_verify: OK
19:37:33:845795725:+0000: Verifying contents of ./os-root.cpio ... ./os-root.cpio: OK
19:39:18:880881955:+0000: Verifying contents of ./os-root.hashes ... ./os-root.hashes: OK
19:39:19:046147663:+0000: Verifying contents of ./version.info ... ./version.info: OK
Progress increment: 19:39:19:059553123+0000, 80, Verifying integrity of upgrade image done
Progress increment: 19:39:19:250327997+0000, 90, preparing upgrade image
Progress increment: 19:39:19:259978382+0000, 100, unpacking successful
```

Logged in as sysadmin and waited for Verify to finish, then clicked "Apply Upgrade".
Lost connection from the UI and ssh'd in the machine that was now running Linux.