### PR TITLE
Add additional cloud-init datasources for internal variants

### DIFF
--- a/live-build/misc/ansible-roles/appliance-build.minimal-internal/tasks/main.yml
+++ b/live-build/misc/ansible-roles/appliance-build.minimal-internal/tasks/main.yml
@@ -19,7 +19,7 @@
     dest: /etc/cloud/cloud.cfg.d/99-delphix-internal.cfg
     mode: 0644
     content: |
-      datasource_list: [ Ec2, None ]
+      datasource_list: [ Azure, Ec2, GCE, None ]
       datasource:
         Ec2:
           timeout: 10


### PR DESCRIPTION
On the internal variants, we have cloud-init configured to read EC2
userdata, which we use to set up SSH keys on newly-provisioned VMs in
EC2. We should also allow cloud-init to read userdata from GCP, so that
we can set up SSH keys on internal Delphix engines there too. The
devops-gate has a workaround in place such that reading userdata from
Azure isn't strictly necessary, but we might as well add it while we are
at it so that that workaround can be removed.