### PR TITLE
Add additional cloud-init datasources for internal variants (revert)

### DIFF
--- a/live-build/misc/ansible-roles/appliance-build.minimal-internal/tasks/main.yml
+++ b/live-build/misc/ansible-roles/appliance-build.minimal-internal/tasks/main.yml
@@ -19,7 +19,7 @@
     dest: /etc/cloud/cloud.cfg.d/99-delphix-internal.cfg
     mode: 0644
     content: |
-      datasource_list: [ Azure, Ec2, GCE, None ]
+      datasource_list: [ Ec2, None ]
       datasource:
         Ec2:
           timeout: 10


### PR DESCRIPTION
The original change broke cloud-init on the ESX. Reverting until we figure out the correct way to make this change.