### PR TITLE
Fix for LX-1784 and LX-1785 MDS

### DIFF
--- a/upgrade/upgrade-scripts/verify-jar
+++ b/upgrade/upgrade-scripts/verify-jar
@@ -40,7 +40,7 @@ function verify_jar_verify_cleanup() {
 			die "failed to stop postgres for snapshot '${MDS_SNAPNAME}'."
 	fi
 
-	if zfs list "${MDS_SNAPNAME}" &>/dev/null; then
+	if zfs list "domain0/${MDS_SNAPNAME}" &>/dev/null; then
 		/opt/delphix/server/bin/dx_manage_pg cleanup -s "${MDS_SNAPNAME}" ||
 			die "failed to cleanup postgres for snapshot '${MDS_SNAPNAME}'."
 	fi

--- a/upgrade/upgrade-scripts/verify-stack
+++ b/upgrade/upgrade-scripts/verify-stack
@@ -27,7 +27,7 @@ function stack_startup_verify_cleanup() {
 			die "failed to stop postgres for snapshot '${STACK_STARTUP_MDS_SNAPNAME}'."
 	fi
 
-	if zfs list | grep -q ${STACK_STARTUP_MDS_SNAPNAME}; then
+	if zfs list "domain0/${STACK_STARTUP_MDS_SNAPNAME}" &>/dev/null; then
 		/opt/delphix/server/bin/dx_manage_pg cleanup -s "${STACK_STARTUP_MDS_SNAPNAME}" ||
 			die "failed to cleanup postgres for snapshot '${STACK_STARTUP_MDS_SNAPNAME}'."
 	fi


### PR DESCRIPTION
These two were regressions caused by LX-1337. My apologies.

LX-1784 Upgrade verify fails due to lack of permission
* New scripts, `verify-jar` and `verify-stack` didn't have an execute permission. 

LX-1785 MDS clone isn't cleaned up after verification
* `zfs list <dataset_name>` takes full dataset path, not just part of it, so the snapshot names should appended by `domain0`.

Tested on failed VM.