### PR TITLE
migration: Workaround for LX-1779: remove analytics slices and data

### DIFF
--- a/live-build/misc/migration-scripts/dx_execute
+++ b/live-build/misc/migration-scripts/dx_execute
@@ -123,6 +123,15 @@ touch /var/delphix/migration/perform-migration ||
 	die "failed to create delphix-migration flag file"
 
 #
+# Workaround for LX-1779: Prevent analytics from launching Illumos-specific
+# collectors.
+#
+command="TRUNCATE dlpx_analytics_slice; TRUNCATE analytics_datapoint;"
+echo "Running MDS Command: '$command'"
+/opt/delphix/server/bin/mds_client -- -c "$command" ||
+	die "Failed mds_client command."
+
+#
 # Create linux /var/delphix dataset from a clone of the current
 # /var/delphix dataset.
 #


### PR DESCRIPTION
This workaround is put in place to unblock migration testing, until we figure out how to properly handle migration of analytics.

## TESTING
* ab-pre-push (build only) http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/656/
* blackbox-chained to perform migration: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/blackbox-chained/21/
* Verified that the stack comes up after migration without hitting this bug.