### PR TITLE
Build zfs gate during instance creation to remove developer overhead

### DIFF
--- a/live-build/config/hooks/82-upgrade-repository.binary
+++ b/live-build/config/hooks/82-upgrade-repository.binary
@@ -24,6 +24,7 @@
 #
 
 set -o pipefail
+set +o nounset
 
 #
 # Sanity check to make sure we haven't installed multiple kernel versions.

--- a/live-build/misc/ansible-roles/appliance-build.zfsonlinux-development/tasks/main.yml
+++ b/live-build/misc/ansible-roles/appliance-build.zfsonlinux-development/tasks/main.yml
@@ -65,6 +65,39 @@
     accept_hostkey: yes
     update: no
 
+- shell: ls /lib/modules
+  register: kernel_versions
+
+- shell: |
+    CONFIG_OPTS=" \
+    --build=x86_64-linux-gnu \
+    --prefix=/usr \
+    --includedir=/usr/include \
+    --mandir=/usr/share/man \
+    --infodir=/usr/share/info \
+    --sysconfdir=/etc \
+    --localstatedir=/var \
+    --libdir=/usr/lib/x86_64-linux-gnu \
+    --libexecdir=/usr/lib/x86_64-linux-gnu \
+    --disable-maintainer-mode \
+    --bindir=/usr/bin \
+    --sbindir=/sbin \
+    --libdir=/lib \
+    --with-python=3 \
+    --with-udevdir=/lib/udev \
+    --with-systemdunitdir=/lib/systemd/system \
+    --with-systemdpresetdir=/lib/systemd/system-preset \
+    --with-linux=/lib/modules/{{ kernel_versions.stdout_lines[0] }}/build \
+    --with-linux-obj=/lib/modules/{{ kernel_versions.stdout_lines[0] }}/build"
+    cd /export/home/delphix/zfs
+    sh autogen.sh
+
+    ./configure $CONFIG_OPTS --enable-debug --enable-debuginfo
+
+    make -j$(nproc)
+  args:
+    executable: /bin/bash
+
 - file:
     path: "/export/home/delphix/zfs"
     owner: "delphix"


### PR DESCRIPTION
This is still a rough draft of the proposed functionality, but by running through a zfs build before the instance finishes being created, we can save developer time by preventing 20+ minute waits while the zfs repo does an initial build. We could extend this to other repos (virtualization, particularly) as well. I mostly wanted to get this draft up to solicit comments on the concept and the approach.