### PR TITLE
Add openjdk to the dcenter build.

### DIFF
--- a/live-build/misc/ansible-roles/appliance-build.dcenter/tasks/main.yml
+++ b/live-build/misc/ansible-roles/appliance-build.dcenter/tasks/main.yml
@@ -27,6 +27,7 @@
     - libldap2-dev
     - libsasl2-dev
     - nfs-kernel-server
+    - openjdk-8-jre-headless
     - python-ldap
     - python-paramiko
     - python-pip


### PR DESCRIPTION
At delphix we use Jenkins to automate and monitor common tasks. One way of
handling tasks that involve remote servers is to use them as Jenkins agents,
which requires that the agents be running the same version of Java as the
Jenkins masters, which is currently java 8. For this change, I install Java 8
on all new dcenter servers so that Jenkins can work with them.

## TESTING

I installed this on the currently running dcenter and am using it as a Jenkins
agent.