### PR TITLE
LX-1552 need a dx_verify for migration

### DIFF
--- a/live-build/misc/migration-scripts/dx_verify
+++ b/live-build/misc/migration-scripts/dx_verify
@@ -14,17 +14,128 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+export MDS_SNAPNAME="MDS-CLONE-upgradeverify"
 
-#
-# [WIP]
-# The existence of this file is checked by dx_unpack, thus we provide
-# it as an empty file until the needed functionality is added.
-#
+DEBUG=false
+
+UPGRADE_VERIFY_PATH=/opt/delphix/server/lib/exec/upgrade-verify
+UPGRADE_VERIFY_JAR=$UPGRADE_VERIFY_PATH/upgrade-verify.jar
+LOG_DIR=/var/delphix/server/upgrade-verify
+MGMT_FMRI=svc:/system/delphix/mgmt:default
+BINDIR=/opt/delphix/server/bin
+DX_MANAGE_PG=$BINDIR/dx_manage_pg
+
+function usage() {
+	echo "usage: $(basename "$0") -v <version> -o <report file> -f <report file format> -l <report file locale>"
+	echo "  -v <version>: The Delphix version number we're upgrading to"
+	echo "  -o <report file>: The output file verification should generate containing an upgrade verification report"
+	echo "  -f <report file format>: The format of the upgrade verification report to generate"
+	echo "  -l <report file locale>: The locale the upgrade verification report should target"
+	echo "  -d: Disable Consistent MDS ZFS Data Utility feature"
+	exit 1
+}
+
+function cleanup() {
+	if ! $DEBUG; then
+		if [ -n "$root" ]; then
+			cleanup_postgres
+			cleanup_datasets
+			#TODO LX-1771 cleanup masking
+		fi
+	fi
+}
+
+function die() {
+	#TODO save MDS logs, if they exist
+	cleanup
+	exit 1
+}
+
+function report() {
+	echo "$(date +%T:%N:%z): $1"
+}
 
 function report_progress_inc() {
 	echo "Progress increment: $(date +%T:%N%z), $1, $2"
 }
 
-report_progress_inc 100
+function mount_datasets() {
+	local version=$1
+	local rds
 
+	rds=$(zfs list -o name -H -d3 rpool/ROOT | grep "delphix.*/root")
+	[[ -n $rds ]] || die "could not find migration dataset for version $version"
+
+	root=$(mktemp -d) || die "unable to create temporary directory"
+	chmod 755 "$root" || die "unable to set permissions for $root"
+	mount -F zfs -o ignoremountpoint "$rds" "$root" || die "unable to mount $rds"
+
+	#TODO dummy files for UpgradeVerify, see LX-1817 and LX-1808
+	touch /var/dlpx-update/"$version"/etc_system_whitelist
+	touch /var/dlpx-update/"$version"/dx_upg_stress_options
+
+	#TODO LX-1771 setup datasets for masking check
+}
+
+function cleanup_datasets() {
+	umount -f "$root"
+	rmdir "$root"
+}
+
+function cleanup_postgres() {
+	"$root$DX_MANAGE_PG" stop -s $MDS_SNAPNAME ||
+		echo "failed to stop postgres"
+	"$root$DX_MANAGE_PG" cleanup -s $MDS_SNAPNAME ||
+		echo "failed to clean up postgres"
+}
+
+function run_upgrade_verify() {
+	local output=$1
+	local format=$2
+	local locale=$3
+	local upgrade_verify_opts
+	$disable_consistent_mds_zfs_data_util &&
+		upgrade_verify_opts="-disableConsistentMdsZfsDataUtil"
+	local progress_low=$4
+	local progress_high=$5
+
+	[[ $(svcprop -p delphix/debug $MGMT_FMRI) == "true" ]] &&
+		delphix_debug="-Ddelphix.debug=true"
+
+	java=/opt/jdk/bin/java
+	jar=$root$UPGRADE_VERIFY_JAR
+
+	$java -Dlog.dir=$LOG_DIR -Dmdsverify=true "$delphix_debug" \
+		-DosMigration=true -jar "$jar" -d "$output" -f "$format" \
+		-l "$locale" -v "$version" -root "$root" "$upgrade_verify_opts" \
+		-droot "$root" -pl "$progress_low" -ph "$progress_high" ||
+		die "upgrade verification failed"
+}
+
+disable_consistent_mds_zfs_data_util=false
+while getopts ':v:o:l:f:d' c; do
+	case "$c" in
+	f) format=$OPTARG ;;
+	l) locale=$OPTARG ;;
+	o) output=$OPTARG ;;
+	v) version=$OPTARG ;;
+	d) disable_consistent_mds_zfs_data_util=true ;;
+	*) usage ;;
+	esac
+done
+
+[[ -n $version ]] || usage
+
+# Where root is or will be mounted. Set in mount_datasets.
+root=
+
+report_progress_inc 0 "preparing for verification"
+mount_datasets "$version"
+report_progress_inc 20 "running upgrade checks"
+run_upgrade_verify "$output" "$format" "$locale" 20 95
+#TODO LX-1808 stress options
+#TODO LX-1771 test_masking
+report_progress_inc 95 "cleaning up post-verification"
+cleanup
+report_progress_inc 100 "done"
 exit 0


### PR DESCRIPTION
**Overview**
This is based very closely on the `dx_verify` for illumos upgrades. The main differences are as follows:
1. Always mount the root dataset since the migration is always a full OS upgrade and we need access to the contents on the migration image
2. Invoke `UpgradeVerify.jar` with a migration option to indicate that it is being run in the context of a migration. 
3. Do some initial dummy file creation for `whitelist` and `stress_options`. 

The remaining work to be done in this script relates to setting up the datasets for and running the masking checks. It's tracked in LX-1771.

**Testing**
+ Run testing automation with chain jenkins job: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/blackbox-chained/43/consoleFull
Reboot into Linux succeeded, all services are fine, was able to log into the GUI. 

 + Tested manually that `dx_verify` can successfully execute `UpgradeVerify.jar` and that a simple verification check can be made to fail and then corrected:
```
sudo zfs set snapdir=visible domain0/group-2
sudo /var/dlpx-update/2019.03.26.18/dx_verify -v 2019.03.26.18 -o /var/tmp/upgradeReport4976452178788760999json -f 2 -l en-US
Progress increment: 23:27:30:296698538+0000, 0, preparing for verification
Progress increment: 23:27:30:345806045+0000, 20, running upgrade checks
Progress increment: 23:27:40:826+0000, 30, 
Progress increment: 23:27:40:828+0000, 41, 
Progress increment: 23:27:40:998+0000, 51, 
Progress increment: 23:27:41:022+0000, 62, 
Progress increment: 23:27:41:043+0000, 73, 
Progress increment: 23:27:41:155+0000, 83, 
Progress increment: 23:27:41:166+0000, 95, 
Progress increment: 23:27:41:167+0000, 95, 
{"reportFormat":2,"flywayResult":"Applied 8 migrations, now at version 020190211","checkResults":[{"uniqueIdentifier":"732390913","bundleID":"upgrade.snapdirs.snapdir.visible","title":"ZFS snapshot directory is visible.","description":"The ZFS snapshot directory for the dataset \"domain0/group-2\" is visible.","response":null,"impact":"Snapsync will fail if the ZFS snapshot directory is not hidden.","action":"Contact Delphix support to hide the ZFS snapshot directory for the dataset(s).","output":"","severity":"CRITICAL"}]}
Progress increment: 23:27:41:461778623+0000, 95, cleaning up post-verification
Progress increment: 23:27:43:319553134+0000, 100, done

sudo zfs set snapdir=hidden domain0/group-2
sudo /var/dlpx-update/2019.03.26.18/dx_verify -v 2019.03.26.18 -o /var/tmp/upgradeReport4976452178788760999json -f 2 -l en-US
Progress increment: 23:27:55:083139815+0000, 0, preparing for verification
Progress increment: 23:27:55:174282938+0000, 20, running upgrade checks
Progress increment: 23:28:05:691+0000, 41, 
Progress increment: 23:28:05:729+0000, 51, 
Progress increment: 23:28:05:816+0000, 62, 
Progress increment: 23:28:05:859+0000, 73, 
Progress increment: 23:28:05:917+0000, 83, 
Progress increment: 23:28:05:919+0000, 95, 
Progress increment: 23:28:05:927+0000, 95, 
{"reportFormat":2,"flywayResult":"Applied 8 migrations, now at version 020190211","checkResults":[]}
Progress increment: 23:28:06:192339527+0000, 95, cleaning up post-verification
Progress increment: 23:28:08:444097245+0000, 100, done
```