### PR TITLE
Support "rollback" for in-place upgrades

### DIFF
--- a/upgrade/upgrade-scripts/execute
+++ b/upgrade/upgrade-scripts/execute
@@ -55,14 +55,55 @@ done
 [[ -z "$platform" ]] && usage "platform must be specified"
 
 #
+# When upgrading the packages on with this script, we want to ensure
+# that only a single process is attempting to do this at any given time.
+# Thus, we add some locking in case multiple processes call this script
+# concurrently; to prevent accidental corruption and/or failures.
+#
+if [[ "$UPGRADE_EXECUTE_LOCKED" != "true" ]]; then
+	exec env UPGRADE_EXECUTE_LOCKED="true" \
+		flock -e "/var/run/delphix-upgrade-execute-lock" "$0" "$@"
+fi
+
+source_version_information
+
+INSTALLED_VERSION=$(get_installed_version)
+
+#
 # It's possible for the delphix-entire package not to be already
 # installed on the root filesystem being upgraded when we're doing a
 # not-in-place upgrade. Thus, when we can't determine the installed
 # version of delphix-entire, we assume we're doing a not-in-place
-# upgrade, and skip this check.
+# upgrade, and skip the version verification and snapshot generation.
 #
-INSTALLED_VERSION=$(get_installed_version)
-[[ -n "$INSTALLED_VERSION" ]] && verify_upgrade_is_allowed
+if [[ -n "$INSTALLED_VERSION" ]]; then
+	verify_upgrade_is_allowed
+
+	ROOTFS_CONTAINER="$(get_mounted_rootfs_container_dataset)"
+	[[ -n "$ROOTFS_CONTAINER" ]] ||
+		die "unable to determine currently mounted rootfs container"
+
+	#
+	# It's possible for this script to be run multiple times,
+	# and each time this script is run, we want to keep a
+	# unique snapshot for each invocation.
+	#
+	# shellcheck disable=SC2002
+	UNIQUE="$(cat /dev/urandom | tr -cd '[:alnum:]' | head -c 7)"
+	[[ -n "$UNIQUE" ]] ||
+		die "failed to generate unique snapshot name suffix"
+
+	#
+	# We need to keep the snapshot names used here in sync with the
+	# logic that retrieves the snapshot name during rollback. Thus,
+	# if we change the snapshot names here, we likely also need to
+	# modify "get_dataset_rollback_snapshot_name()" in "common.sh".
+	#
+	# shellcheck disable=SC2153
+	zfs snapshot -r \
+		"$ROOTFS_CONTAINER@execute-upgrade.$UNIQUE" ||
+		die "failed to create recursive rootfs container snapshot"
+fi
 
 if [[ -f /etc/apt/sources.list ]]; then
 	mv /etc/apt/sources.list /etc/apt/sources.list.orig ||
@@ -203,8 +244,6 @@ dpkg-query -Wf '${Package}\n' "delphix-kernel-*" | xargs apt-mark manual ||
 #    Both options, (a) and (b), are undesirable; by not using package
 #    dependencies we avoid having to deal with this problem.
 #
-
-source_version_information
 
 # shellcheck disable=SC2153
 apt_get install -y --allow-downgrades "delphix-entire-$platform=$VERSION" ||

--- a/upgrade/upgrade-scripts/rootfs-container
+++ b/upgrade/upgrade-scripts/rootfs-container
@@ -19,14 +19,6 @@
 
 CONTAINER=
 
-function get_dataset_snapshots() {
-	zfs list -rt snapshot -Hpo name "$1"
-}
-
-function get_snapshot_clones() {
-	zfs get clones -Hpo value "$1"
-}
-
 function delete() {
 	zfs list "rpool/ROOT/$CONTAINER/root" &>/dev/null ||
 		die "rootfs container '$CONTAINER' does not exist"
@@ -35,52 +27,41 @@ function delete() {
 	[[ "$MOUNTED" == "no" ]] ||
 		die "cannot delete mounted rootfs container: '$CONTAINER'"
 
-	#
-	# In the common case, the "root" dataset should never have
-	# clones of it. With that said, it is possible for clones to
-	# exist in a couple edge cases:
-	#
-	# 1. When "in-place" upgrade occurs, it'll clone the root
-	#    dataset during the upgrade verification phase; i.e. when
-	#    creating the in-place upgrade container. Thus, if there
-	#    happens to be a concurrent in-place upgrade running, a
-	#    clone of the "root" dataset could exist.
-	#
-	# 2. If an "in-place" upgrade container has been manually
-	#    created, i.e. explicitly via the "upgrade-container"
-	#    script, then it's possible for a clone of the "root"
-	#    dataset to exist.
-	#
-	# Thus, to handle these edge cases, we abort the delete
-	# operation if a clone of "root" exists.
-	#
-	for snap in $(get_dataset_snapshots "rpool/ROOT/$CONTAINER/root"); do
-		for clone in $(get_snapshot_clones "$snap"); do
-			die \
-				"cannot delete rootfs container: '$CONTAINER'," \
-				"'root' dataset clone exists: '$clone'"
-		done
-	done
+	local snapname
+	local clonesnaps=()
 
 	#
 	# The "data" and "home" datasets of a rootfs container may have
-	# been cloned as part of an upgrade. Thus, in order to delete
-	# this specific rootfs container, we need to promote any clones
-	# that exist. Otherwise we won't be able to destroy the snapshots
-	# for the "data" and "home" datasets, and thus can't destroy the
-	# datasets themselves.
+	# been cloned as part of a prior upgrade, and the "root" dataset
+	# may have been cloned as part of a prior rollback. Thus, in
+	# order to delete this specific rootfs container, we need to
+	# promote any clones that exist.
 	#
 	for snap in \
+		$(get_dataset_snapshots "rpool/ROOT/$CONTAINER/root") \
 		$(get_dataset_snapshots "rpool/ROOT/$CONTAINER/data") \
 		$(get_dataset_snapshots "rpool/ROOT/$CONTAINER/home"); do
 		for clone in $(get_snapshot_clones "$snap"); do
 			zfs promote "$clone" ||
 				die "'zfs promote $clone' failed"
+
+			snapname="$(echo "$snap" | cut -d @ -f 2-)"
+			clonesnaps+=("$clone@$snapname")
 		done
 	done
 
 	zfs destroy -r "rpool/ROOT/$CONTAINER" ||
 		die "'zfs destroy -r rpool/ROOT/$CONTAINER' failed"
+
+	#
+	# Now that all the original clones have been promoted, and the
+	# new clones (after promotion) have been destroyed, we can
+	# remove the lingering snapshots (that were previously used by
+	# the now destroyed clones).
+	#
+	for snap in "${clonesnaps[@]}"; do
+		zfs destroy "$snap" || die "'zfs destroy $snap' failed"
+	done
 }
 
 function get_bootloader_devices() {

--- a/upgrade/upgrade-scripts/upgrade
+++ b/upgrade/upgrade-scripts/upgrade
@@ -157,10 +157,6 @@ function cleanup_not_in_place_upgrade() {
 	return "$rc"
 }
 
-function get_mounted_rootfs_container() {
-	basename "$(dirname "$(zfs list -Hpo name /)")"
-}
-
 function upgrade_not_in_place() {
 	trap cleanup_not_in_place_upgrade EXIT
 
@@ -170,7 +166,7 @@ function upgrade_not_in_place() {
 	# handle the error and abort; rather than having to handle this
 	# error later, when it might require more work to handle it.
 	#
-	MOUNTED_CONTAINER="$(get_mounted_rootfs_container)"
+	MOUNTED_CONTAINER="$(get_mounted_rootfs_container_name)"
 	[[ -n "$MOUNTED_CONTAINER" ]] ||
 		die "failed to determine mounted rootfs container"
 
@@ -233,25 +229,47 @@ function upgrade_not_in_place() {
 }
 
 function rollback() {
-	MOUNTED_CONTAINER="$(get_mounted_rootfs_container)"
-	[[ -n "$MOUNTED_CONTAINER" ]] ||
-		die "failed to determine mounted rootfs container"
-
-	ROLLBACK_CONTAINER="$(zfs get -Hpo value \
-		"$ROLLBACK_PROPERTY" "rpool/ROOT/$MOUNTED_CONTAINER")"
-	[[ -n "$ROLLBACK_CONTAINER" && "$ROLLBACK_CONTAINER" != "-" ]] ||
-		die "failed to determine rollback rootfs container"
-
 	[[ "$DLPX_UPGRADE_DRY_RUN" == "true" ]] &&
 		die "unable to perform a 'dry-run' of rollback"
 
-	#
-	# The "rollback" operation is nothing more than "set-bootfs" of
-	# a specific rootfs container. Now that we have the specific
-	# rootfs container that we want to use as the next bootfs.
-	#
-	"$IMAGE_PATH/rootfs-container" set-bootfs "$ROLLBACK_CONTAINER" ||
-		die "failed to set-bootfs '$ROLLBACK_CONTAINER'"
+	MOUNTED_ROOTFS_DATASET="$(get_mounted_rootfs_container_dataset)"
+	[[ -n "$MOUNTED_ROOTFS_DATASET" ]] ||
+		die "failed to determine mounted rootfs container"
+
+	if [[ -n "$(get_dataset_rollback_snapshot_name "$MOUNTED_ROOTFS_DATASET")" ]]; then
+		#
+		# If a rollback snapshot is found, assume we're rolling
+		# back after an in-place upgrade. Thus, we need to
+		# create a new "rollback" upgrade container, and then
+		# use this upgrade container as the new rootfs/bootfs
+		# container.
+		#
+
+		CONTAINER="$("$IMAGE_PATH/upgrade-container" create rollback)"
+		[[ -n "$CONTAINER" ]] ||
+			die "failed to create 'rollback' upgrade container"
+
+		"$IMAGE_PATH/upgrade-container" convert-to-rootfs "$CONTAINER" ||
+			die "failed to convert-to-rootfs '$CONTAINER'"
+
+		"$IMAGE_PATH/rootfs-container" set-bootfs "$CONTAINER" ||
+			die "failed to set-bootfs '$CONTAINER'"
+	else
+		#
+		# If a rollback snapshot isn't found, assume we're rolling
+		# back after a not-in-place upgrade (a snapshot is not
+		# generated when performing a not-in-place upgrade), and
+		# set the bootloader to use the previous rootfs container.
+		#
+
+		CONTAINER="$(zfs get -Hpo value \
+			"$ROLLBACK_PROPERTY" "$MOUNTED_ROOTFS_DATASET")"
+		[[ -n "$CONTAINER" && "$CONTAINER" != "-" ]] ||
+			die "failed to determine rollback rootfs container"
+
+		"$IMAGE_PATH/rootfs-container" set-bootfs "$CONTAINER" ||
+			die "failed to set-bootfs '$CONTAINER'"
+	fi
 }
 
 [[ "$EUID" -ne 0 ]] && die "must be run as root"

--- a/upgrade/upgrade-scripts/upgrade-container
+++ b/upgrade/upgrade-scripts/upgrade-container
@@ -56,6 +56,14 @@ function create_upgrade_container() {
 	trap create_cleanup EXIT
 	local type="$1"
 
+	case "$type" in
+	in-place | not-in-place | rollback) ;;
+
+	*)
+		die "unsupported upgrade container type specified: '$1'"
+		;;
+	esac
+
 	#
 	# We want to use "/var/lib/machines" as the parent directory,
 	# since that directory is used by "systemd-nspawn" when looking
@@ -68,9 +76,9 @@ function create_upgrade_container() {
 	CONTAINER=$(basename "$DIRECTORY")
 	[[ -n "$CONTAINER" ]] || die "failed to obtain upgrade name"
 
-	ROOTFS_PARENT=$(dirname "$(get_mounted_rootfs_name)")
-	zfs snapshot -r "$ROOTFS_PARENT@$CONTAINER" ||
-		die "failed to create recursive upgrade container snapshot"
+	ROOTFS_DATASET=$(get_mounted_rootfs_container_dataset)
+	[[ -n "$ROOTFS_DATASET" ]] ||
+		die "unable to determine mounted rootfs container dataset"
 
 	zfs create \
 		-o canmount=off \
@@ -79,12 +87,39 @@ function create_upgrade_container() {
 		die "failed to create upgrade filesystem"
 
 	case "$type" in
-	in-place)
+	in-place | not-in-place)
+		#
+		# When creating a new "in-place" or "not-in-place"
+		# upgrade container, we need to snapshot the currently
+		# mounted rootfs datasets, so these snapshots can be
+		# used to create the new container datasets below.
+		#
+		SNAPSHOT_NAME="container-$CONTAINER"
+		zfs snapshot -r "$ROOTFS_DATASET@$SNAPSHOT_NAME" ||
+			die "failed to create upgrade container snapshots"
+		;;
+	rollback)
+		#
+		# When the "execute" script is used to perform an
+		# in-place upgrade, it will create a snapshot on the
+		# rootfs container datasets that are upgraded. It's this
+		# snapshot name that we're attempting to find here, as
+		# these snapshots are used to create the new "rollback"
+		# upgrade container datasets below.
+		#
+		SNAPSHOT_NAME=$(get_dataset_rollback_snapshot_name "$ROOTFS_DATASET")
+		[[ -n "$SNAPSHOT_NAME" ]] ||
+			die "unable to determine rollback snapshot name"
+		;;
+	esac
+
+	case "$type" in
+	in-place | rollback)
 		zfs clone \
 			-o canmount=noauto \
 			-o compression=on \
 			-o mountpoint="$DIRECTORY" \
-			"$ROOTFS_PARENT/root@$CONTAINER" \
+			"$ROOTFS_DATASET/root@$SNAPSHOT_NAME" \
 			"rpool/ROOT/$CONTAINER/root" ||
 			die "failed to create upgrade / clone"
 
@@ -119,28 +154,19 @@ function create_upgrade_container() {
 			bionic "$DIRECTORY" "file://$IMAGE_PATH/public" 1>&2 ||
 			die "failed to debootstrap upgrade filesystem"
 		;;
-	*)
-		die "unsupported upgrade container type specified: '$1'"
-		;;
 	esac
 
-	#
-	# We require the contents of /export/home and /var/delphix to persist
-	# across an upgrade, so we always use a clone of these datasets,
-	# regardless of if we're creating an in-place or not-in-place upgrade
-	# container.
-	#
 	zfs clone \
 		-o compression=on \
 		-o mountpoint=legacy \
-		"$ROOTFS_PARENT/home@$CONTAINER" \
+		"$ROOTFS_DATASET/home@$SNAPSHOT_NAME" \
 		"rpool/ROOT/$CONTAINER/home" ||
 		die "failed to create upgrade /export/home clone"
 
 	zfs clone \
 		-o compression=on \
 		-o mountpoint=legacy \
-		"$ROOTFS_PARENT/data@$CONTAINER" \
+		"$ROOTFS_DATASET/data@$SNAPSHOT_NAME" \
 		"rpool/ROOT/$CONTAINER/data" ||
 		die "failed to create upgrade /var/delphix clone"
 
@@ -345,9 +371,12 @@ function destroy() {
 			die "failed to destroy container dataset: '$CONTAINER'"
 	fi
 
-	ROOTFS_PARENT=$(dirname "$(get_mounted_rootfs_name)")
-	if zfs list "$ROOTFS_PARENT@$CONTAINER" &>/dev/null; then
-		zfs destroy -r "$ROOTFS_PARENT@$CONTAINER" ||
+	ROOTFS_DATASET=$(get_mounted_rootfs_container_dataset)
+	[[ -n "$ROOTFS_DATASET" ]] ||
+		die "unable to determine mounted rootfs container dataset"
+
+	if zfs list "$ROOTFS_DATASET@container-$CONTAINER" &>/dev/null; then
+		zfs destroy -r "$ROOTFS_DATASET@container-$CONTAINER" ||
 			die "failed to destroy container snapshot: '$CONTAINER'"
 	fi
 
@@ -570,7 +599,7 @@ function usage() {
 	PREFIX_NCHARS=$(echo -n "$PREFIX_STRING" | wc -c)
 	PREFIX_SPACES=$(printf "%.s " $(seq "$PREFIX_NCHARS"))
 
-	echo "$PREFIX_STRING create [in-place|not-in-place]"
+	echo "$PREFIX_STRING create [in-place|not-in-place|rollback]"
 	echo "$PREFIX_SPACES start <container>"
 	echo "$PREFIX_SPACES stop <container>"
 	echo "$PREFIX_SPACES destroy <container>"
@@ -590,7 +619,7 @@ create)
 	[[ $# -gt 2 ]] && usage "too many arguments specified"
 
 	case "$2" in
-	in-place | not-in-place)
+	in-place | not-in-place | rollback)
 		create_upgrade_container "$2"
 		;;
 	*)


### PR DESCRIPTION
This change enables rollback for in-place upgrades. It does this by
creating a new type of upgrade container; a "rollback" upgrade
container. This container type can only be created after an in-place
upgrade has been performed, as it relies on the snapshots that are
created by the "execute" script during an "in-place" upgrade.

During rollback after an in-place upgrade, a "rollback" upgrade
container will be created, and then this container is immediately
converted into the rootfs/bootfs container. Thus, after the rollback
operation and a subsequent reboot, that rollback container will be the
mounted rootfs.