### PR TITLE
LX-1826 /etc/issue file created/populated after not-in-place upgrade

### DIFF
--- a/upgrade/upgrade-scripts/upgrade-container
+++ b/upgrade/upgrade-scripts/upgrade-container
@@ -428,6 +428,15 @@ function migrate_file() {
 			die "'mkdir -p $parentdir' failed for '$CONTAINER'"
 		cp "$path" "/var/lib/machines/${CONTAINER}${path}" ||
 			die "'cp $path' failed for '$CONTAINER'"
+	else
+		if [[ -f "/var/lib/machines/${CONTAINER}${path}" ]]; then
+			# If the target file doesn't exist in the host then
+			# we delete the file. This case could happen if the host
+			# configuration doesn't exist but a fresh install placed
+			# package default configuration.
+			rm "/var/lib/machines/${CONTAINER}${path}" ||
+				die "failed to remove '$path' in '$CONTAINER'"
+		fi
 	fi
 }
 


### PR DESCRIPTION
As noted in the bug, we are seeing a default `/etc/issue` file present on VM upgraded with "not-in-place" upgrade.

**Cause**
* The current implementation of `migrate_file` function only migrates the file to the container if it exists on the host. This means if a host doesn't have the file but the container somehow does, then it'll leave the file in the container.
This case happens with `/etc/issue` file where host doesn't have the file, but the `not-in-place` container created it while executing`debootstrap` which has the content "Ubuntu 18.04.2 LTS \n \l".

**Fix**
* We force delete the migration target file on the container file system if the file doesn't exist on the host.