### PR TITLE
Print curl errors

### DIFF
--- a/live-build/config/hooks/vm-artifacts/90-linux-migration-artifact.binary
+++ b/live-build/config/hooks/vm-artifacts/90-linux-migration-artifact.binary
@@ -157,7 +157,7 @@ if [[ -n "${DELPHIX_SIGNATURE_TOKEN:-}" ]] && [[ -n "${DELPHIX_SIGNATURE_URL:-}"
 		echo "{\"data\": \"$(cat hashes64)\"}" >hashes64.payload
 
 		# Request signature
-		curl -s -f -H "Content-Type: application/json" \
+		curl -s -S -f -H "Content-Type: application/json" \
 			-u "$DELPHIX_SIGNATURE_TOKEN" "$SIGN_URL" -d @hashes64.payload >hashes.response
 
 		# Decode generated signature


### PR DESCRIPTION
We recently had a couple jobs fail because a request made using `curl` failed. However, we don't know what the error was because we use the `-s`/`--silent` flag. This change adds the `-S` flag, which makes `curl` print errors when it fails.