### PR TITLE
LX-1812 Increase freebsd bootloader timeout

### DIFF
--- a/live-build/misc/migration-scripts/dx_apply
+++ b/live-build/misc/migration-scripts/dx_apply
@@ -292,13 +292,6 @@ MAIN_MENU_FICL=(
 	die "failed to update /boot/menu.rc.local"
 
 #
-# Increase the automatic boot delay to 20 seconds. This would help debug
-# any potential boot issues.
-#
-sed -i '/set autoboot_delay/c\set autoboot_delay=20' /boot/menu.rc.local ||
-	die "failed to change the autoboot_delay"
-
-#
 # Note that the new /var/delphix should not contain any useful data as it will
 # be replaced by a clone of the current /var/delphix dataset in dx_execute.
 # We do not clone the current /var/delphix right away as the clone will be

--- a/live-build/misc/migration-scripts/dx_execute
+++ b/live-build/misc/migration-scripts/dx_execute
@@ -154,6 +154,13 @@ zfs clone -o compression=on -o mountpoint=legacy \
 	"${CUR_VAR_DLPX}@${LX_CONTAINER}" "$LX_VAR_DLPX"
 
 #
+# Increase the boot delay to 20 seconds to ease bootloader access during
+# the migration for debugging purposes.
+#
+sed -i '/autoboot_delay/c\set autoboot_delay=20' /boot/menu.rc.local ||
+	die "Failed to set boot delay in bootloader"
+
+#
 # Read the command from option 8 which should be the one that boots
 # into Linux. Then make it so that the same command runs whenever we
 # hit the timer of the FreeBSD bootloader menu.


### PR DESCRIPTION
The current 1 second timeout is often too short to be able to choose the right bootloader option through the ESX console or the serial console on dcenter.

As we are getting ready for the Lumen migration being able to have more time in the bootloader could become more critical to insure better supportability.

## TESTING
- Created image: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/833/
- Tested that migration works
- Verified that bootloader timeout was actually increased to 20 seconds