### PR TITLE
Use pigz(1) when compressing tarballs.

### DIFF
--- a/live-build/config/hooks/upgrade-artifacts/82-upgrade-repository.binary
+++ b/live-build/config/hooks/upgrade-artifacts/82-upgrade-repository.binary
@@ -133,6 +133,6 @@ rm -rf "binary/$DEBS_DIRECTORY"
 # This intermediate build artifact is eventually used to build an
 # upgrade image. See scripts/build-upgrade-image.sh for details.
 #
-tar -czf "$ARTIFACT_NAME.debs.tar.gz" ./*.deb -C binary/packages .
+tar -I pigz -cf "$ARTIFACT_NAME.debs.tar.gz" ./*.deb -C binary/packages .
 
 rm -rf binary/packages

--- a/live-build/config/hooks/vm-artifacts/91-gce-machine-image.binary
+++ b/live-build/config/hooks/vm-artifacts/91-gce-machine-image.binary
@@ -28,5 +28,5 @@
 # Google cloud only accepts gzip-ed tarballs with a single "disk.raw"
 # physical image.
 #
-tar -z --transform "s/$ARTIFACT_NAME.img/disk.raw/r" \
+tar -I pigz --transform "s/$ARTIFACT_NAME.img/disk.raw/r" \
 	-cvf "$ARTIFACT_NAME.gcp.tar.gz" "$ARTIFACT_NAME.img"

--- a/scripts/build-upgrade-image.sh
+++ b/scripts/build-upgrade-image.sh
@@ -71,6 +71,6 @@ aptly publish repo -skip-signing upgrade-repository
 VERSION=$(dpkg -f "$(find debs/ -name 'delphix-entire-*' | head -n 1)" version)
 sed "s/@@VERSION@@/$VERSION/" <version.info.template >version.info
 
-tar -czf "$APPLIANCE_VARIANT.upgrade.tar.gz" version.info -C upgrade-scripts . -C ~/.aptly .
+tar -I pigz -cf "$APPLIANCE_VARIANT.upgrade.tar.gz" version.info -C upgrade-scripts . -C ~/.aptly .
 
 mv "$APPLIANCE_VARIANT.upgrade.tar.gz" "$TOP/build/artifacts"


### PR DESCRIPTION
`pigz(1)` is a parallel implementation of `gzip(1)` which speeds up builds by taking advantage of multiple cores. `tar -I pigz` is a drop-in replacement for `tar -z`.

This change replaces all calls to `tar -z` with `tar -I pigz`. Note that according to [the `pigz(1)` man page](https://manpages.ubuntu.com/manpages/bionic/man1/pigz.1.html), "decompression can't be parallelized […]. As a result, `pigz` uses a single thread (the main thread) for decompression." Therefore, I have only modified the `tar` invocations that pertain to compression rather than the invocations that pertain to decompression.

On our two-core build VMs, the change results in a modest but noticeable performance improvement. For example, we save 2.5 minutes building the GCP image. Before:

```
37:25 + tar -z --transform s/internal-dev-gcp.img/disk.raw/r -cvf internal-dev-gcp.gcp.tar.gz internal-dev-gcp.img
37:25 internal-dev-gcp.img
51:52 + [[ gcp == kvm ]]
```

After:

```
13:33 + tar -I pigz --transform s/internal-dev-gcp.img/disk.raw/r -cvf internal-dev-gcp.gcp.tar.gz internal-dev-gcp.img
13:33 internal-dev-gcp.img
25:28 + [[ gcp == kvm ]]
```