### PR TITLE
Skip generation of "Contents" indices when running aptly(1).

### DIFF
--- a/scripts/build-ancillary-repository.sh
+++ b/scripts/build-ancillary-repository.sh
@@ -99,7 +99,7 @@ function build_ancillary_repository() {
 	aptly repo create \
 		-distribution=bionic -component=main ancillary-repository
 	aptly repo add ancillary-repository "$pkg_directory"
-	aptly publish repo -skip-signing ancillary-repository
+	aptly publish repo -skip-contents -skip-signing ancillary-repository
 
 	mkdir -p "$OUTPUT_DIR/.."
 	rm -rf "$OUTPUT_DIR"

--- a/scripts/build-upgrade-image.sh
+++ b/scripts/build-upgrade-image.sh
@@ -65,7 +65,7 @@ done
 # Generate an Aptly/APT repository
 aptly repo create -distribution=bionic -component=delphix upgrade-repository
 aptly repo add upgrade-repository debs
-aptly publish repo -skip-signing upgrade-repository
+aptly publish repo -skip-contents -skip-signing upgrade-repository
 
 # Include version information about this image.
 VERSION=$(dpkg -f "$(find debs/ -name 'delphix-entire-*' | head -n 1)" version)


### PR DESCRIPTION
By default, `aptly publish repo` generates "Contents" indices. Per [the Debian Repository Format specification](https://wiki.debian.org/DebianRepository/Format#A.22Contents.22_indices), these are "optional indices describing which files can be found in which packages." Our build and upgrade process does not use these indices, but they require several minutes to generate (see aptly-dev/aptly#345). We can save time during our build by skipping this unnecessary step. This change adds the `-skip-contents` option whenever we invoke `aptly publish repo`.

On our two-core build VMs, the change results in a modest but noticeable performance improvement. For example, we save over 5 minutes when generating each upgrade image. Before:

```
06:21:20 + aptly publish repo -skip-signing upgrade-repository
06:21:20 Loading packages...
06:21:20 Generating metadata files and linking package files...
06:26:44 Finalizing metadata files...
```

After:

```
00:02:29 + aptly publish repo -skip-contents -skip-signing upgrade-repository
00:02:29 Loading packages...
00:02:29 Generating metadata files and linking package files...
00:02:29 Finalizing metadata files...
```