### PR TITLE
Store the artifact name in the version information for verification

### DIFF
--- a/live-build/config/hooks/vm-artifacts/90-linux-migration-artifact.binary
+++ b/live-build/config/hooks/vm-artifacts/90-linux-migration-artifact.binary
@@ -120,6 +120,14 @@ cp migration-scripts/* $DEPOT_DIRECTORY
 	# shellcheck disable=SC2016
 	echo "DLPX_VERSION=$(chroot binary dpkg-query \
 		-Wf '${Version}' delphix-virtualization)"
+
+	#
+	# DLPX_PLATFORM is set to the type of platform this migration
+	# image was built for (i.e. internal-qa-esx). It will be used to
+	# check that we're using the correct image type for the engine
+	# being upgraded.
+	#
+	echo "DLPX_PLATFORM=$ARTIFACT_NAME"
 } >$DEPOT_DIRECTORY/version.info
 
 #


### PR DESCRIPTION
When performing a migration, we want to be able to check that the migration image we're installing from is built for the correct hypervisor. As far as I can tell, the source of this information is represented primarily by the name of the archive we download. 

One option would be have the check inspect the contents of `/var/dlpx-update/upload`. However, since this check is running after the archive has been extracted and the image unpacked, I don't think there's any guarantee that original tar file has to remain in `/var/dlpx-update/upload`. 

A second option is to store the archive name within the image somewhere. After briefly looking through the migration image layout, I thought `version.info` might be a good place for this. 

You can think of a simpler way of accessing and/or this information, let me know.  