### PR TITLE
LX-1852 migration: Failure to access CLI after migration

### DIFF
--- a/live-build/misc/migration-scripts/dx_apply
+++ b/live-build/misc/migration-scripts/dx_apply
@@ -24,6 +24,15 @@
 
 set -o pipefail
 
+#
+# Reset the umask to the default value. When called from the app-stack the
+# umask is set to 0027. Since those scripts can be called manually, we want
+# to have a consistent result regardless of the caller. A umask of 0022
+# makes directories created by this script accessible by everyone by default,
+# which is important for directories such as /export/home.
+#
+umask 0022
+
 function die() {
 	echo "$(basename "$0"): $*" >&2
 	exit 1

--- a/live-build/misc/migration-scripts/dx_execute
+++ b/live-build/misc/migration-scripts/dx_execute
@@ -16,9 +16,19 @@
 #
 
 #
-# Sets up the FreeBSD bootloader to boot into that Linux image next time
-# we reboot.
+# Finalizes the Linux image in preparation for the reboot now that the app
+# stack is quiesced; sets up the FreeBSD bootloader to boot into that Linux
+# image next time we reboot; finally reboots the system.
 #
+
+#
+# Reset the umask to the default value. When called from the app-stack the
+# umask is set to 0027. Since those scripts can be called manually, we want
+# to have a consistent result regardless of the caller. A umask of 0022
+# makes directories created by this script accessible by everyone by default,
+# which is important for directories such as /export/home.
+#
+umask 0022
 
 set -o pipefail
 

--- a/live-build/misc/migration-scripts/dx_verify
+++ b/live-build/misc/migration-scripts/dx_verify
@@ -14,6 +14,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+
+#
+# Reset the umask to the default value. When called from the app-stack the
+# umask is set to 0027. Since those scripts can be called manually, we want
+# to have a consistent result regardless of the caller. A umask of 0022
+# makes directories created by this script accessible by everyone by default.
+#
+umask 0022
+
 export MDS_SNAPNAME="MDS-CLONE-upgradeverify"
 
 DEBUG=false


### PR DESCRIPTION
This makes sure that any directory created by the migration script has the default umask.

See https://jira.delphix.com/browse/LX-1852 for more details.

## Testing

build image: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/929/
Run migration and perform some checks:
- http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/blackbox-chained/104/ (failure of the job is expected)
- Make sure cli works
- Verify that `/export` has the right permissions set.