### PR TITLE
Add repositories for debug symbol packages

### DIFF
--- a/live-build/misc/ansible-roles/appliance-build.minimal-development/tasks/main.yml
+++ b/live-build/misc/ansible-roles/appliance-build.minimal-development/tasks/main.yml
@@ -21,6 +21,12 @@
     content: |
       apt:
         preserve_sources_list: false
+        sources:
+          ddebs:
+            source: |
+              deb http://ddebs.ubuntu.com $RELEASE main restricted universe multiverse
+              deb http://ddebs.ubuntu.com $RELEASE-updates main restricted universe multiverse
+              deb http://ddebs.ubuntu.com $RELEASE-proposed main restricted universe multiverse
 
 #
 # We use "no_log" here to ensure we don't accidentally leak the contents


### PR DESCRIPTION
For developer convenience, add the repositories containing debug symbol packages in `/etc/apt/sources.list.d/` so that dbgsym packages can be installed on a new `internal-dev` VM without any extra steps.