### PR TITLE
DLPX-63098 Rework dx_delete

### DIFF
--- a/live-build/misc/migration-scripts/dx_delete
+++ b/live-build/misc/migration-scripts/dx_delete
@@ -1,0 +1,48 @@
+#!/bin/bash
+#
+# Copyright 2018 Delphix
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+#
+# Reset the umask to the default value. When called from the app-stack the
+# umask is set to 0027. Since those scripts can be called manually, we want
+# to have a consistent result regardless of the caller. A umask of 0022
+# makes directories created by this script accessible by everyone by default,
+# which is important for directories such as /export/home.
+#
+umask 0022
+
+set -o pipefail
+
+function die() {
+	echo "$(basename "$0"): $*" >&2
+	exit 1
+}
+
+#
+# Here, we assume Linux dataset names starts with "rpool/ROOT", and also
+# assume that there can be at most one migration dataset applied in current OS
+# since migration is only supported from *fixed* 5.3.X version to 6.0.X version.
+# Also, it is not possible to get a version from dataset name in Linux since
+# names are randomly generated.
+#
+
+linux_dataset="rpool/ROOT"
+if ! zfs list ${linux_dataset} &>/dev/null; then
+	echo "Linux dataset '${linux_dataset}' is not installed."
+	exit 0
+fi
+
+zfs destroy -r ${linux_dataset} || die "Failed to destroy Linux dataset '${linux_dataset}'"


### PR DESCRIPTION
The `dx_delete` logic isn't compatible with Linux dataset layout so the post upgrade verification cleanup logic fails. To be more specific, upgrade verification workflow is as follows:

1. Calls `dx_apply` which creates datasets for the new upgrade
2. Performs upgrade verification
3. Calls `dx_delete` which cleans up the datasets.


As @pzakha noted in the bug ticket, we need to 

1. Change `dx_delete` to support Linux dataset layout. 
2. App-gate should consume `dx_delete` **provided from the upgrade image** rather than the one in currently running version since layout may change in the future.

The fix requires two changes

1. Add a new `dx_delete` script in migration image which handles deleting Linux datasets. It looks for `rpool/ROOT` dataset which is Linux dataset prefix and recursively deletes it.
2. Add a logic in `dlpx-app-gate` (http://reviews.delphix.com/r/49100/) to use the `dx_delete` script to delete version specific dataset if present, otherwise fallback to use the script in the running OS in order to support backward compatibility.

