### PR TITLE
Revert "Add repositories for debug symbol packages" (Causes DLPX-63959)

### DIFF
--- a/live-build/misc/ansible-roles/appliance-build.minimal-development/tasks/main.yml
+++ b/live-build/misc/ansible-roles/appliance-build.minimal-development/tasks/main.yml
@@ -21,12 +21,6 @@
     content: |
       apt:
         preserve_sources_list: false
-        sources:
-          ddebs:
-            source: |
-              deb http://ddebs.ubuntu.com $RELEASE main restricted universe multiverse
-              deb http://ddebs.ubuntu.com $RELEASE-updates main restricted universe multiverse
-              deb http://ddebs.ubuntu.com $RELEASE-proposed main restricted universe multiverse
 
 #
 # We use "no_log" here to ensure we don't accidentally leak the contents


### PR DESCRIPTION
This reverts commit 6e4b9b782fe856f1eead34387190e22d433c2855.

Copied from evaluation of `DLPX-63959`


> The failing commit is this: https://github.com/delphix/appliance-build/commit/0210db1a31817bb0e075aecbacec88579de6d51f
As I mentioned in the previous comments, the problem is that `apt-get update` from the `execute` is failing because `cloud-init` is already holding the apt repository lock, preventing other apt update to fail.
From the source code of cloud-init (https://github.com/cloud-init/cloud-init/blob/ubuntu/bionic/cloudinit/config/cc_apt_configure.py#L629) we see that it does a apt-get update once it sees a apt.sources: list in the configuration file and the failing PR noted above did add apt.sources:.
The proper fix is currently under discuss and we are leaning toward solving the problem PR addresses in difference place rather than cloud-init's configuration file. So for now, we should revert the change to unblock testing.

