### PR TITLE
Allow public keys to be passed for internal builds with new cloud-init changes

### DIFF
--- a/live-build/misc/ansible-roles/appliance-build.minimal-internal/tasks/main.yml
+++ b/live-build/misc/ansible-roles/appliance-build.minimal-internal/tasks/main.yml
@@ -24,3 +24,4 @@
         Ec2:
           timeout: 10
           max_wait: 24
+      allow_public_ssh_keys: true


### PR DESCRIPTION
See https://github.com/delphix/delphix-platform/pull/81 for more details.
