### PR TITLE
Add new mypy version to crash-python dev role

### DIFF
--- a/live-build/misc/ansible-roles/appliance-build.crash-python-development/tasks/main.yml
+++ b/live-build/misc/ansible-roles/appliance-build.crash-python-development/tasks/main.yml
@@ -19,6 +19,15 @@
     name:
       - git
       - python3-pyelftools
+      - python3-pip
+    state: present
+  register: result
+  until: result is not failed
+  retries: 3
+  delay: 60
+
+- pip:
+    name: mypy
     state: present
   register: result
   until: result is not failed


### PR DESCRIPTION
We install the pip apt package and then use it to install mypy.  Tested by building an internal dev kvm image and verifying that mypy is installed and runnable:
```
delphix@localhost:~$ mypy --version
mypy 0.701
```