### PR TITLE
legacy mounts can timeout waiting for zpool import service to complete

### DIFF
--- a/live-build/config/hooks/vm-artifacts/90-raw-disk-image.binary
+++ b/live-build/config/hooks/vm-artifacts/90-raw-disk-image.binary
@@ -197,12 +197,14 @@ rsync --info=stats3 -Wa binary/* "$DIRECTORY/"
 # We rely on the "/etc/fstab" file to mount the non-root ZFS
 # filesystems, so that when a specific rootfs dataset is booted, it'll
 # automatically mount the correct non-rootfs datasets associated with
-# that rootfs dataset.
+# that rootfs dataset. We make sure that local mounts run before the
+# zfs-import service since that service can hold the 'spa_namespace_lock'
+# preventing legacy zfs mounts from completing.
 #
 cat <<-EOF >"$DIRECTORY/etc/fstab"
-	rpool/ROOT/$FSNAME/home /export/home zfs defaults 0 0
-	rpool/ROOT/$FSNAME/data /var/delphix zfs defaults 0 0
-	rpool/ROOT/$FSNAME/log  /var/log     zfs defaults 0 0
+	rpool/ROOT/$FSNAME/home /export/home zfs defaults,x-systemd.before=zfs-import-cache.service 0 0
+	rpool/ROOT/$FSNAME/data /var/delphix zfs defaults,x-systemd.before=zfs-import-cache.service 0 0
+	rpool/ROOT/$FSNAME/log  /var/log     zfs defaults,x-systemd.before=zfs-import-cache.service 0 0
 EOF
 
 #

--- a/live-build/misc/migration-scripts/dx_apply
+++ b/live-build/misc/migration-scripts/dx_apply
@@ -181,12 +181,13 @@ mount -F zfs "$RPOOL/ROOT/$FSNAME/log" "$TMP_ROOT/var/log"
 #
 # /export/home and /var/delphix datasets are not mounted automatically.
 # On Illumos this kind of mounting logic was performed by dxinit and svc-boot.
-# On Linux /etc/fstab is used instead.
+# On Linux /etc/fstab is used instead. These mounts need to happen before
+# the zfs-import service runs.
 #
 cat <<-EOF >"$TMP_ROOT/etc/fstab" || die "Failed to setup /etc/fstab"
-	$RPOOL/ROOT/$FSNAME/home /export/home zfs defaults 0 0
-	$RPOOL/ROOT/$FSNAME/data /var/delphix zfs defaults 0 0
-	$RPOOL/ROOT/$FSNAME/log  /var/log     zfs defaults 0 0
+	$RPOOL/ROOT/$FSNAME/home /export/home zfs defaults,x-systemd.before=zfs-import-cache.service 0 0
+	$RPOOL/ROOT/$FSNAME/data /var/delphix zfs defaults,x-systemd.before=zfs-import-cache.service 0 0
+	$RPOOL/ROOT/$FSNAME/log  /var/log     zfs defaults,x-systemd.before=zfs-import-cache.service 0 0
 EOF
 
 #

--- a/upgrade/upgrade-scripts/upgrade-container
+++ b/upgrade/upgrade-scripts/upgrade-container
@@ -213,12 +213,13 @@ function create_upgrade_container() {
 	# We rely on the "/etc/fstab" file to mount the non-root ZFS
 	# filesystems, so that when a specific rootfs dataset is booted,
 	# it'll automatically mount the correct non-rootfs datasets
-	# associated with that rootfs dataset.
+	# associated with that rootfs dataset. The mounts need to happen
+	# before the zfs-import service is run.
 	#
 	cat <<-EOF >"$DIRECTORY/etc/fstab"
-		rpool/ROOT/$CONTAINER/home /export/home zfs defaults 0 0
-		rpool/ROOT/$CONTAINER/data /var/delphix zfs defaults 0 0
-		rpool/ROOT/$CONTAINER/log  /var/log     zfs defaults 0 0
+		rpool/ROOT/$CONTAINER/home /export/home zfs defaults,x-systemd.before=zfs-import-cache.service 0 0
+		rpool/ROOT/$CONTAINER/data /var/delphix zfs defaults,x-systemd.before=zfs-import-cache.service 0 0
+		rpool/ROOT/$CONTAINER/log  /var/log     zfs defaults,x-systemd.before=zfs-import-cache.service 0 0
 	EOF
 
 	mkdir -p "/etc/systemd/nspawn" ||


### PR DESCRIPTION
I noticed that the zfs-import-cache.service and the dynamically created fstab mount services would try to run at the same time. The import logic would grab the `spa_namespace_lock` and prevent local mounts to rpool from completing. Eventually the mounts would timeout which would cause the system to come up and appear hung:

> May 10 19:05:31 localhost systemd[1]: Mounting /export/home...
> May 10 19:07:01 localhost systemd[1]: export-home.mount: Mounting timed out. Terminating.
> May 10 19:07:01 localhost systemd[1]: export-home.mount: Mount process exited, code=killed status=15
> May 10 19:07:01 localhost systemd[1]: export-home.mount: Failed with result 'timeout'.
> May 10 19:07:01 localhost systemd[1]: Failed to mount /export/home.

This change ensures that the local legacy mounts complete before we start to import any other pools