### PR TITLE
DLPX-61762 Linux verify fails, Unable to acquire the dpkg frontend lock

### DIFF
--- a/upgrade/upgrade-scripts/execute
+++ b/upgrade/upgrade-scripts/execute
@@ -28,7 +28,35 @@ function usage() {
 	exit 2
 }
 
+function wait_for_apt_lock() {
+	# The 'apt' package manager commands will fail if other package manager
+	# already holds the lock. This can fail upgrade workflow, so we try to
+	# mitigate by waiting up to a set timeout and fail only if timeout is reached.
+	local now
+	local timeout
+	now=$(date +%s)
+	timeout=$((now + 300)) # Set timeout to 5 min
+
+	while [[ $(date +%s) -lt $timeout ]]; do
+		output=$(fuser /var/lib/dpkg/{lock,lock-frontend} 2>&1)
+		if [[ -n "$output" ]]; then
+			echo "Waiting for other package manager to release lock. Timeout in $((timeout - $(date +%s))) seconds. Process tree for locked files are:"
+			while read -r line; do
+				pstree -p "$(echo "$line" | tr -s ' ' | cut -d ' ' -f 2)"
+			done <<<"${output}"
+			sleep 1
+		else
+			echo "No lock detected. Continuing with the normal workflow."
+			return
+		fi
+	done
+
+	die "Timeout reached aborting."
+}
+
 function apt_get() {
+	wait_for_apt_lock
+
 	DEBIAN_FRONTEND=noninteractive apt-get \
 		-o Dpkg::Options::="--force-confdef" \
 		-o Dpkg::Options::="--force-confold" \


### PR DESCRIPTION
## Probem

There has been `apt` lock issues in the past and the problem is that we can't predict and prevent what other processes are holding the lock.

E.g.
```
Reading package lists...
E: Could not get lock /var/lib/dpkg/lock-frontend - open (11: Resource temporarily unavailable)
E: Unable to acquire the dpkg frontend lock (/var/lib/dpkg/lock-frontend), is another process using it?
```

This message also doesn't provide any further debugging message to fix the error.


## Solution

Adds a wait function with a debugging statements to check if there are other processes holding the `/var/dpkg/lib/lock` or `/var/dpkg/lib/lock-frontend` for a fixed timeout of 5 min. IMO 5 min should be sufficient since it's unlikely there are other process that installs numerous packages. In case timeout occurs we can inspect `pstree` output to check what chain of process caused the timeout.

There is another option of using `aptdcon` which queues any apt jobs. I haven't looked deep into this since writing our own script is straightforward and it doesn't seem to be a widely used command.

## Manual Testing

Case 1: No processes holding the lock
// no output

Case 2: Lock wait times out
```delphix@harry-dlpxtrunk:~$ ./timeout.sh
Waiting for other package manager to relase lock. Timeout in 9 seconds. Process tree for locked files are:
flock(14227)───script.sh(14228)───sleep(14229)
Waiting for other package manager to relase lock. Timeout in 8 seconds. Process tree for locked files are:
flock(14227)───script.sh(14228)───sleep(14229)
Waiting for other package manager to relase lock. Timeout in 7 seconds. Process tree for locked files are:
flock(14227)───script.sh(14228)───sleep(14229)
Waiting for other package manager to relase lock. Timeout in 6 seconds. Process tree for locked files are:
flock(14227)───script.sh(14228)───sleep(14229)
Waiting for other package manager to relase lock. Timeout in 5 seconds. Process tree for locked files are:
flock(14227)───script.sh(14228)───sleep(14229)
Waiting for other package manager to relase lock. Timeout in 4 seconds. Process tree for locked files are:
flock(14227)───script.sh(14228)───sleep(14229)
Waiting for other package manager to relase lock. Timeout in 3 seconds. Process tree for locked files are:
flock(14227)───script.sh(14228)───sleep(14229)
Waiting for other package manager to relase lock. Timeout in 2 seconds. Process tree for locked files are:
flock(14227)───script.sh(14228)───sleep(14229)
Waiting for other package manager to relase lock. Timeout in 1 seconds. Process tree for locked files are:
flock(14227)───script.sh(14228)───sleep(14229)
Waiting for other package manager to relase lock. Timeout in 0 seconds. Process tree for locked files are:
flock(14227)───script.sh(14228)───sleep(14229)
Timeout reached aborting.
```

Case 3: Lock was initially held and then release while waiting
```
delphix@harry-dlpxtrunk:~$ ./timeout.sh
Waiting for other package manager to relase lock. Timeout in 9 seconds. Process tree for locked files are:
flock(14696)───script.sh(14697)───sleep(14698)
Waiting for other package manager to relase lock. Timeout in 8 seconds. Process tree for locked files are:
flock(14696)───script.sh(14697)───sleep(14698)
Waiting for other package manager to relase lock. Timeout in 7 seconds. Process tree for locked files are:
flock(14696)───script.sh(14697)───sleep(14698)
```

Case 4: One process holds `lock` another holds `lock-frontend`
```
delphix@harry-dlpxtrunk:~$ ./timeout.sh
Waiting for other package manager to relase lock. Timeout in 9 seconds. Process tree for locked files are:
flock(15073)───script.sh(15074)───sleep(15075)
flock(15076)───script.sh(15077)───sleep(15078)
Waiting for other package manager to relase lock. Timeout in 8 seconds. Process tree for locked files are:
flock(15073)───script.sh(15074)───sleep(15075)
flock(15076)───script.sh(15077)───sleep(15078)
Waiting for other package manager to relase lock. Timeout in 7 seconds. Process tree for locked files are:
flock(15073)───script.sh(15074)───sleep(15075)
flock(15076)───script.sh(15077)───sleep(15078)
Waiting for other package manager to relase lock. Timeout in 6 seconds. Process tree for locked files are:
flock(15073)───script.sh(15074)───sleep(15075)
flock(15076)───script.sh(15077)───sleep(15078)
Waiting for other package manager to relase lock. Timeout in 5 seconds. Process tree for locked files are:
flock(15076)───script.sh(15077)───sleep(15078)
```