### PR TITLE
DLPX-64347 Enable cloud-init on all platforms

### DIFF
--- a/live-build/misc/ansible-roles/appliance-build.minimal-internal/tasks/main.yml
+++ b/live-build/misc/ansible-roles/appliance-build.minimal-internal/tasks/main.yml
@@ -19,9 +19,4 @@
     dest: /etc/cloud/cloud.cfg.d/99-delphix-internal.cfg
     mode: 0644
     content: |
-      datasource_list: [ Ec2, None ]
-      datasource:
-        Ec2:
-          timeout: 10
-          max_wait: 24
       allow_public_ssh_keys: true


### PR DESCRIPTION
## Description
Re-enable cloud-init on all cloud platforms. We achieve this by using the default `datasource_list` from cloud-init.

## Dependencies
This must be pushed after https://github.com/delphix/delphix-platform/pull/94 and https://github.com/delphix/cloud-init/pull/7 are integrated.

## Testing
- git-ab-pre-push: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/1266/
   (linux-pkg build: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/linux-pkg-build/job/master/job/userland/job/pre-push/117/)
- Launched a VM created from an image for each supported platform and verified that cloud-init works properly.
- Made sure that networking is configured properly for a VM cloned from the ESX image on dcenter. Made sure that networking is also working properly for a clone of that VM. Checked that the "New instance" logic is not being executed on every restart.