### PR TITLE
Remove check for dropbox in migration dx_apply

### DIFF
--- a/live-build/misc/migration-scripts/dx_apply
+++ b/live-build/misc/migration-scripts/dx_apply
@@ -321,12 +321,9 @@ MAIN_MENU_FICL=(
 #
 (
 	cd "$TMP_ROOT/var/delphix" || die "failed to cd into $TMP_ROOT/var/delphix"
-	# We only expect to find:
-	#  ./dropbox
-	[[ $(find . -mindepth 1 | wc -l) -eq 1 ]] ||
+	# /var/delphix should be empty
+	[[ $(find . -mindepth 1 | wc -l) -eq 0 ]] ||
 		die "linux dataset for /var/delphix contains unexpected files"
-	[[ -d dropbox ]] ||
-		die "linux dataset for /var/delphix should contain directory dropbox"
 ) || die "verification of /var/delphix failed"
 
 umount "$TMP_ROOT/var/log" ||


### PR DESCRIPTION
After https://github.com/delphix/delphix-platform/pull/93, we no longer expect to see the `dropbox` directory in the migration image. Remove the relevant check in `dx_apply`

Appliance build: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/1260/

Chained migration: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/blackbox-chained/249/