### PR TITLE
DLPX-64339 Remove/refactor Illumos specific scripts/code blocks

### DIFF
--- a/live-build/misc/migration-scripts/dx_execute
+++ b/live-build/misc/migration-scripts/dx_execute
@@ -79,8 +79,8 @@ RPOOL=${RDS%%/*}
 # above the minimum version required. Since we are doing a migration the
 # minimum version should be the latest 5.3.
 #
-# CURRENT_DDS=$(dirname "$(mount | awk '/^\/opt\/delphix /{ print $3 }')")
-# CURRENT_VERSION=$(basename $current_dds)
+CURRENT_DDS=$(dirname "$(mount | awk '/^\/opt\/delphix /{ print $3 }')")
+CURRENT_VERSION=$(basename "$CURRENT_DDS")
 #
 # WIP: check if current version is 5.3, if not bail
 #
@@ -146,6 +146,7 @@ echo "Running MDS Command: '$command'"
 #
 cat <<-EOF >"/var/dlpx-update/upgrade.properties" ||
 	UPGRADE_TYPE=OS_MIGRATION
+	UPGRADE_BASE_VERSION=$CURRENT_VERSION
 EOF
 	die "failed to create upgrade.properties"
 


### PR DESCRIPTION
dxsvcinit has been silently failing to take a snapshot on migration because we do not set the base version in the migration case
```
Jun 07 08:22:52 dlpx-5350-QAR-563f3ba9.dc4 systemd[1]: Starting Delphix default PostgreSQL database server...
Jun 07 08:22:52 dlpx-5350-QAR-563f3ba9.dc4 svc-postgres[5819]: dxsvcinit: missing UPGRADE_BASE_VERSION peroperty
```
This bug was exposed when working on this app-gate change: http://reviews.delphix.com/r/49923
Testing on app-gate review