### PR TITLE
Backport cloud-init changes to projects/6.0-ea

### DIFF
--- a/live-build/misc/ansible-roles/appliance-build.minimal-internal/tasks/main.yml
+++ b/live-build/misc/ansible-roles/appliance-build.minimal-internal/tasks/main.yml
@@ -19,9 +19,4 @@
     dest: /etc/cloud/cloud.cfg.d/99-delphix-internal.cfg
     mode: 0644
     content: |
-      datasource_list: [ Ec2, None ]
-      datasource:
-        Ec2:
-          timeout: 10
-          max_wait: 24
       allow_public_ssh_keys: true


### PR DESCRIPTION
Backport cloud-init changes to get a working external-standard OVA