### PR TITLE
Add ant to internal-unittest variant

### DIFF
--- a/live-build/misc/ansible-roles/appliance-build.unittest-internal/tasks/main.yml
+++ b/live-build/misc/ansible-roles/appliance-build.unittest-internal/tasks/main.yml
@@ -18,6 +18,7 @@
 - apt:
     name:
       - adoptopenjdk-java8-jdk
+      - ant
       - bash
       - docker.io
       - git


### PR DESCRIPTION
`ant(1)` is needed to run unit tests.