### PR TITLE
Add build-essential to internal-unittest variant

### DIFF
--- a/live-build/misc/ansible-roles/appliance-build.unittest-internal/tasks/main.yml
+++ b/live-build/misc/ansible-roles/appliance-build.unittest-internal/tasks/main.yml
@@ -20,6 +20,7 @@
       - adoptopenjdk-java8-jdk
       - ant
       - bash
+      - build-essential
       - docker.io
       - git
       - python-minimal


### PR DESCRIPTION
`build-essential` is needed to run the Masking Engine unit tests on the `internal-unittest` variant. Without it, they fail with this error:

```
 Execution failed for task ':mountScripts:compileMountFilesystemExecutableMountFilesystemC'.
 > No tool chain is available to build for platform 'linux_x86-64':
     - Tool chain 'visualCpp' (Visual Studio): Visual Studio is not available on this operating system.
     - Tool chain 'gcc' (GNU GCC): Could not find C compiler 'gcc' in system path.
     - Tool chain 'clang' (Clang): Could not find C compiler 'clang' in system path.
```