### PR TITLE
Fix shellcheck that was missed in this code was moved from delphix-platform unpack-image script.

### DIFF
--- a/upgrade/prepare
+++ b/upgrade/prepare
@@ -90,7 +90,7 @@ rm payload.tar.gz || die "failed to remove payload.tar.gz"
 
 if $opt_x; then
 	sed -i \
-		"s/^\(MINIMUM_REBOOT_OPTIONAL_VERSION\)=.*$/\1=$VERSION/" \
+		"s/^\\(MINIMUM_REBOOT_OPTIONAL_VERSION\\)=.*$/\\1=$VERSION/" \
 		version.info ||
 		die "'sed -i ... version.info' failed"
 


### PR DESCRIPTION
DLPX-64972 fix shellcheck issue in prepare script in appliance-build repo

original fix in below commit from delphix-platform repo (https://github.com/delphix/delphix-platform/commit/fd777edfddba0725539406d332bdc67cc168307f)
This was missed since code was moved to appliance-build. Noticed it when I was ready to merge the delphix-platform PR to update unpack-image to remove the redundant code.

commit fd777edfddba0725539406d332bdc67cc168307f
Author: Pavel Zakharov <pavel.zakharov@delphix.com>
Date:   Thu Jun 27 13:01:19 2019 -0400

    fix shellcheck issue

testing :
git ab-pre-push CLEAN : http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/1569/