### PR TITLE
CP-2777 CRA enabled for Linux

### DIFF
--- a/live-build/misc/ansible-roles/appliance-build.virtualization-external/tasks/main.yml
+++ b/live-build/misc/ansible-roles/appliance-build.virtualization-external/tasks/main.yml
@@ -21,3 +21,4 @@
     line: "{{ item.key }}={{ item.value }}"
   with_items:
     - { key: 'cr_auth', value: 'true' }
+- command: pam-auth-update --enable challenge-response


### PR DESCRIPTION
**Description**
Challenge-response authentication for the OS support user (`delphix`) must be enabled in 6.0, both for fresh new engines and migrations from 5.3, for external engines. For internal engines, we leave CRA disabled for convenience.

There is a new role for enabling CRA, which is invoked only for the external variants.

Also, we ensure that `/etc/engine-uuid`, needed by CRA on Linux, exists. This file is not present on illumos, so without this change in `minimal-common`, CRA would not work for engines migrated from 5.3.

**Testing**
Verified using `appliance-build-pre-push` that internal engines do not get CRA enabled, and external engines do have it enabled (both fresh and migrated engines).