### PR TITLE
DLPX-64699 migration: Analytics attempts to launch dtrace on Linux

### DIFF
--- a/live-build/misc/migration-scripts/dx_execute
+++ b/live-build/misc/migration-scripts/dx_execute
@@ -124,15 +124,6 @@ touch /var/delphix/migration/perform-migration ||
 	die "failed to create delphix-migration flag file"
 
 #
-# Workaround for LX-1779: Prevent analytics from launching Illumos-specific
-# collectors.
-#
-command="TRUNCATE dlpx_analytics_slice; TRUNCATE analytics_datapoint;"
-echo "Running MDS Command: '$command'"
-/opt/delphix/server/bin/mds_client -- -c "$command" ||
-	die "Failed mds_client command."
-
-#
 # Let the app-stack know that an "OS migration" upgrade is being performed.
 #
 cat <<-EOF >"/var/dlpx-update/upgrade.properties" ||


### PR DESCRIPTION
This removes the workaround that was added via [PR-244](https://github.com/delphix/appliance-build/pull/244/).

Tests
* On a 5.3.5 DDP that had both NFS and iSCSI basic workloads running -  verified pre-migration that analytics subsystem working for all default statistic slices and that post-migration,  the same transitions/migrates over without any errors. See JIRA for more verification details.
* ab-pre-push - http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/1585/console

