### PR TITLE
CP-2777 CRA enabled for Linux (cleanup)

### DIFF
--- a/upgrade/upgrade-scripts/upgrade-container
+++ b/upgrade/upgrade-scripts/upgrade-container
@@ -605,7 +605,6 @@ function migrate_configuration() {
 		/etc/delphix-interface-names.yaml
 		/etc/default/locale
 		/etc/engine-code
-		/etc/engine-uuid
 		/etc/engine.install
 		/etc/fluent/fluent.conf
 		/etc/issue


### PR DESCRIPTION
As pointed out in http://reviews.delphix.com/r/50896/, we need to remove `/etc/engine-uuid` from the list of files to be copied for Linux upgrades.