### PR TITLE
Enable use of primary and secondary APT mirrors

### DIFF
--- a/live-build/build.gradle
+++ b/live-build/build.gradle
@@ -105,9 +105,11 @@ for (variant in allVariants) {
                 inputs.file "${rootProject.projectDir}/scripts/run-live-build.sh"
 
                 for (envVar in ["APPLIANCE_PASSWORD",
+                                "DELPHIX_APPLIANCE_VERSION",
+                                "DELPHIX_PACKAGE_MIRROR_PRIMARY",
+                                "DELPHIX_PACKAGE_MIRROR_SECONDARY",
                                 "DELPHIX_SIGNATURE_URL",
-                                "DELPHIX_SIGNATURE_TOKEN",
-                                "DELPHIX_APPLIANCE_VERSION"]) {
+                                "DELPHIX_SIGNATURE_TOKEN"]) {
                     inputs.property(envVar, System.getenv(envVar)).optional(true)
                 }
 

--- a/live-build/config/archives/delphix-secondary-mirror.list.in
+++ b/live-build/config/archives/delphix-secondary-mirror.list.in
@@ -1,0 +1,17 @@
+#
+# Copyright 2019 Delphix
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+deb [trusted=yes] @@URL@@ bionic main

--- a/scripts/docker-run.sh
+++ b/scripts/docker-run.sh
@@ -55,10 +55,12 @@ $DOCKER_RUN --rm \
 	--env APPLIANCE_PASSWORD \
 	--env AWS_ACCESS_KEY_ID \
 	--env AWS_SECRET_ACCESS_KEY \
+	--env DELPHIX_APPLIANCE_VERSION \
+	--env DELPHIX_PACKAGE_MIRROR_PRIMARY \
+	--env DELPHIX_PACKAGE_MIRROR_SECONDARY \
+	--env DELPHIX_PLATFORMS \
 	--env DELPHIX_SIGNATURE_URL \
 	--env DELPHIX_SIGNATURE_TOKEN \
-	--env DELPHIX_PLATFORMS \
-	--env DELPHIX_APPLIANCE_VERSION \
 	--volume "$TOP:/opt/appliance-build" \
 	--workdir "/opt/appliance-build" \
 	appliance-build "$@"

--- a/scripts/run-live-build.sh
+++ b/scripts/run-live-build.sh
@@ -129,7 +129,36 @@ while ! curl --output /dev/null --silent --head --fail \
 done
 set -o errexit
 
-lb config
+if [[ -n "$DELPHIX_PACKAGE_MIRROR_SECONDARY" ]]; then
+	sed "s|@@URL@@|$DELPHIX_PACKAGE_MIRROR_SECONDARY|" \
+		<config/archives/delphix-secondary-mirror.list.in \
+		>config/archives/delphix-secondary-mirror.list
+fi
+
+if [[ -n "$DELPHIX_PACKAGE_MIRROR_PRIMARY" ]]; then
+	lb config \
+		--parent-mirror-bootstrap "$DELPHIX_PACKAGE_MIRROR_PRIMARY" \
+		--parent-mirror-chroot "$DELPHIX_PACKAGE_MIRROR_PRIMARY" \
+		--parent-mirror-chroot-security "$DELPHIX_PACKAGE_MIRROR_PRIMARY" \
+		--parent-mirror-chroot-volatile "$DELPHIX_PACKAGE_MIRROR_PRIMARY" \
+		--parent-mirror-chroot-backports "$DELPHIX_PACKAGE_MIRROR_PRIMARY" \
+		--parent-mirror-binary "$DELPHIX_PACKAGE_MIRROR_PRIMARY" \
+		--parent-mirror-binary-security "$DELPHIX_PACKAGE_MIRROR_PRIMARY" \
+		--parent-mirror-binary-volatile "$DELPHIX_PACKAGE_MIRROR_PRIMARY" \
+		--parent-mirror-binary-backports "$DELPHIX_PACKAGE_MIRROR_PRIMARY" \
+		--mirror-bootstrap "$DELPHIX_PACKAGE_MIRROR_PRIMARY" \
+		--mirror-chroot "$DELPHIX_PACKAGE_MIRROR_PRIMARY" \
+		--mirror-chroot-security "$DELPHIX_PACKAGE_MIRROR_PRIMARY" \
+		--mirror-chroot-volatile "$DELPHIX_PACKAGE_MIRROR_PRIMARY" \
+		--mirror-chroot-backports "$DELPHIX_PACKAGE_MIRROR_PRIMARY" \
+		--mirror-binary "$DELPHIX_PACKAGE_MIRROR_PRIMARY" \
+		--mirror-binary-security "$DELPHIX_PACKAGE_MIRROR_PRIMARY" \
+		--mirror-binary-volatile "$DELPHIX_PACKAGE_MIRROR_PRIMARY" \
+		--mirror-binary-backports "$DELPHIX_PACKAGE_MIRROR_PRIMARY"
+else
+	lb config
+fi
+
 lb build
 
 kill -9 $APTLY_SERVE_PID


### PR DESCRIPTION
This change better enables us to use internal APT package mirrors in the
build, and to dynamically specify the URLs of such mirrors.

Specifically, this allows us to specify a "primary" mirror (which
is enabled directly with "lb config"), and a "secondary" mirror (which
is enabled via the "config/archives" directory). Further, the URLs for
both the "primary" and "secondary" mirrors can (and must!) be specified
via the two new environment variables:

 * DELPHIX_PACKAGE_MIRROR_PRIMARY
 * DELPHIX_PACKAGE_MIRROR_SECONDARY

Closes #319