### PR TITLE
Ship with an NFSv4-only configuration by default.

### DIFF
--- a/live-build/misc/ansible-roles/appliance-build.virtualization-common/tasks/main.yml
+++ b/live-build/misc/ansible-roles/appliance-build.virtualization-common/tasks/main.yml
@@ -45,3 +45,34 @@
       domain=
       dns1=
       dns2=
+
+#
+# Initial NFS Server configuration for virtualization. We do this here instead
+# of within the virtualization package because the virtualization software
+# modifies this configuration at runtime, and we don't want ansible roles that
+# are re-run as part of upgrades to undo these runtime modifications.
+#
+- name: Link initial NFS configuration
+  file:
+    src: /opt/delphix/server/etc/nfs-kernel-server-v4
+    dest: /etc/default/nfs-kernel-server
+    force: yes
+    owner: root
+    group: root
+    state: link
+
+#
+# Because we want an NFSv4-only configuration out of the box, we need to mask
+# NFSv3 services so that they don't get automatically started at boot via
+# dependencies. The virtualization software is responsible for unmasking and
+# starting these services if NFSv3 needed at runtime.
+#
+- name: Mask NFSv3 services
+  file:
+    src: "/dev/null"
+    dest: "/etc/systemd/system/{{ item }}"
+    state: link
+  with_items:
+      - rpc-statd.service
+      - rpcbind.service
+      - rpcbind.socket

--- a/upgrade/upgrade-scripts/upgrade-container
+++ b/upgrade/upgrade-scripts/upgrade-container
@@ -471,8 +471,8 @@ function migrate_file() {
 		parentdir="$(dirname "$path")"
 		mkdir -p "/var/lib/machines/${CONTAINER}${parentdir}" ||
 			die "'mkdir -p $parentdir' failed for '$CONTAINER'"
-		cp -p "$path" "/var/lib/machines/${CONTAINER}${path}" ||
-			die "'cp -p $path' failed for '$CONTAINER'"
+		cp -Pp "$path" "/var/lib/machines/${CONTAINER}${path}" ||
+			die "'cp -Pp $path' failed for '$CONTAINER'"
 	else
 		#
 		# If the target file doesn't exist in the host then we
@@ -507,13 +507,30 @@ function migrate_dir() {
 	fi
 }
 
+#
+# Preserve the persistent service state of the service named as an argument.
+#
 function migrate_svc() {
 	local svc="$1"
+	local state
+	state=$(systemctl is-enabled "$svc")
 
-	if systemctl is-enabled -q "$svc"; then
-		chroot "/var/lib/machines/$CONTAINER" systemctl enable "$svc"
+	if [[ $state == "masked" ]]; then
+		chroot "/var/lib/machines/$CONTAINER" systemctl mask "$svc"
 	else
-		chroot "/var/lib/machines/$CONTAINER" systemctl disable "$svc"
+		#
+		# The service may be masked by default, so always unmask before
+		# doing anything else. Otherwise, systemctl will ignore the new
+		# setting.
+		#
+		chroot "/var/lib/machines/$CONTAINER" systemctl unmask "$svc"
+		if systemctl is-enabled -q "$svc"; then
+			chroot "/var/lib/machines/$CONTAINER" systemctl \
+				enable "$svc"
+		else
+			chroot "/var/lib/machines/$CONTAINER" systemctl \
+				disable "$svc"
+		fi
 	fi
 }
 
@@ -540,7 +557,11 @@ function migrate_configuration() {
 		migrate_svc "$svc"
 	done <<-EOF
 		delphix-masking.service
+		nfs-mountd.service
 		ntp.service
+		rpc-statd.service
+		rpcbind.service
+		rpcbind.socket
 	EOF
 
 	#
@@ -560,6 +581,7 @@ function migrate_configuration() {
 	while read -r file; do
 		migrate_file "$file"
 	done <<-EOF
+		/etc/default/nfs-kernel-server
 		/etc/hostid
 		/etc/hostname
 		/etc/hosts


### PR DESCRIPTION
This change causes our virtualization images to ship with an NFSv4-only NFS server configuration by default out of the box. The virtualization software is responsible for dynamically enabling NFSv3 services as needed. This is being implemented in http://reviews.delphix.com/r/50851. Without the dlpx-app-gate changes, the virtualization software will not be able to mount NFSv3-based VDBs, so those changes must integrate before this PR is merged into appliance-build.

There are three changes implemented here:

1. The ansible task that creates the initial NFS server configuration in `/etc/default/nfs-kernel-server`. Note that this code previously lived in dlpx-app-gate, and is being removed from there as part of http://reviews.delphix.com/r/50851. It is being moved here because this is one-time initial configuration, and the ansible tasks from dlpx-app-gate are applied at arbitrary times when the delphix-platform service is reloaded.
2. Upgrade code that copies the `/etc/default/nfs-kernel-server` file for not-in-place upgrades (because that file can be modified by the virtualization software as reviewed at http://reviews.delphix.com/r/50851).
3. Upgrade code that preserves the state of NFSv3-related systemd services for not-in-place upgrades. This code had to be enhanced to support carrying over masked state of services.