### PR TITLE
DLPX-64524 Migration fails during dx_verify when debug mode is off

### DIFF
--- a/live-build/misc/migration-scripts/dx_verify
+++ b/live-build/misc/migration-scripts/dx_verify
@@ -141,12 +141,11 @@ function run_upgrade_verify() {
 		upgrade_verify_opts="-disableConsistentMdsZfsDataUtil"
 	local progress_low=$4
 	local progress_high=$5
-
-	[[ $(svcprop -p delphix/debug $MGMT_FMRI) == "true" ]] &&
-		delphix_debug="-Ddelphix.debug=true"
+	local debug_mode
+	debug_mode=$(svcprop -p delphix/debug $MGMT_FMRI)
 
 	local jar=$root$UPGRADE_VERIFY_JAR
-	$java -Dlog.dir=$LOG_DIR -Dmdsverify=true "$delphix_debug" \
+	$java -Dlog.dir=$LOG_DIR -Dmdsverify=true -Ddelphix.debug="$debug_mode" \
 		-DosMigration=true -jar "$jar" -d "$output" -f "$format" \
 		-l "$locale" -v "$version" -root "$root" "$upgrade_verify_opts" \
 		-droot "$root" -pl "$progress_low" -ph "$progress_high" ||


### PR DESCRIPTION
Previously, when we invoked the `upgradeVerify` jar, we passed a bash variable as a flag which is populated if debug is on, and is empty if it is not. This means that when debug mode is off, `java` is passed `""` and doesn't know what to do with it. 
This solution means the debug mode will always be specified. 

Tested manually with debug mode on and off.

`git-ab-pre-push --test-upgrade-from 5.3.6.0`: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/1766/