### PR TITLE
Add pause and stress options scripts to migration images

### DIFF
--- a/live-build/misc/migration-scripts/dx_execute
+++ b/live-build/misc/migration-scripts/dx_execute
@@ -32,6 +32,8 @@ umask 0022
 
 set -o pipefail
 
+DX_UPG_PAUSE="${BASH_SOURCE%/*}/dx_upg_pause_options"
+
 function die() {
 	echo "$(basename "$0"): $*" >&2
 	exit 1
@@ -161,6 +163,9 @@ sed -i '/autoboot_delay/c\set autoboot_delay=20' /boot/menu.rc.local ||
 MAIN_MENU_LINUX_CMD=$(grep -F 'mainmenu_command[8]' /boot/menu.rc.local |
 	cut -d = -f 2-)
 echo "set menu_timeout_command=$MAIN_MENU_LINUX_CMD" >>/boot/menu.rc.local
+
+$DX_UPG_PAUSE --pause "PAUSE_IN_DX_EXECUTE_BEFORE_RESTART" ||
+	die "failed to pause fully on stress option"
 
 # Constants used by the uadmin syscall.
 A_SHUTDOWN=2

--- a/live-build/misc/migration-scripts/dx_upg_pause_options
+++ b/live-build/misc/migration-scripts/dx_upg_pause_options
@@ -1,0 +1,216 @@
+#!/bin/bash
+#
+# Copyright (c) 2017, 2018 by Delphix. All rights reserved.
+#
+
+#
+# Utility for managing upgrade pause options.
+# Supported pause options listed below.
+#
+
+PAUSE_OPTIONS_JSON=$(cat <<-EOF
+{
+	"PAUSE_IN_DX_EXECUTE_BEFORE_RESTART": {
+	    "location": "right before reboot"
+	},
+	"PAUSE_IN_DXSVCINIT_BEFORE_UPGRADE": {
+	    "location": "post-reboot before any app upgrade logic"
+	},
+	"PAUSE_BEFORE_UPGRADE_COMMIT": {
+	    "location": "mgmt service (before point of no return)"
+	},
+	"PAUSE_BEFORE_CHECKPOINT_DISCARD": {
+	    "location": "mgmt service (before point of no return)"
+	},
+	"PAUSE_IN_SVC_ROLLBACK_BEFORE_ROLLBACK": {
+	    "location": "rollback service"
+	},
+	"PAUSE_BEFORE_REWIND_CHECKPOINT": {
+	    "location": "rollback service"
+	},
+	"PAUSE_AFTER_REWIND_CHECKPOINT": {
+	    "location": "rollback service"
+	},
+	"PAUSE_IN_DXSVCINIT_AFTER_ROLLBACK": {
+	    "location": "post-rollback before app stack starts"
+	},
+	"PAUSE_IN_SVC_MGMT_BEFORE_STACK_STARTUP": {
+	    "location": "before app stack starts"
+	}
+}
+EOF
+)
+
+PAUSE_DATASET=rpool/pause_options
+DLPX_ENTERED=com.delphix:entered
+
+function die
+{
+	echo "$(basename $0): $*" 1>&2
+	exit 1
+}
+
+function usage
+{
+	echo "$(basename $0): $*" >&2
+	echo "Usage:"
+	echo " $(basename $0) --get-options-json"
+	echo "   Prints out a detailed json of all the supported stress options."
+	echo " $(basename $0) --set <pause-option>"
+	echo "   Sets the specified pause option. Non-zero exit code on failure."
+	echo " $(basename $0) --unset <pause-option>"
+	echo "   Unsets the specified pause option. Non-zero exit code on failure."
+	echo " $(basename $0) --get <pause-option>"
+	echo "   Returns exit code 3 if given pause option is set, 0 if unset."
+	echo "   Any other non-zero exit code is an unexpected error."
+	echo " $(basename $0) --pause <pause-option>"
+	echo "   Does not terminate until the pause option is unset."
+	echo "   Non-zero exit code if errors hit, 0 if wait successful."
+	echo " $(basename $0) --wait-for-pause <pause-option>"
+	echo "   Does not terminate until the pause option is hit."
+	echo "   Non-zero exit code if errors hit, 0 if wait successful."
+	exit 2
+}
+
+function check_valid_option
+{
+	local arg=$1
+
+	local get_names=$(cat <<-EOF
+		import json, sys
+		obj=json.load(sys.stdin)
+		print(" ".join(obj.keys()))
+	EOF
+	)
+	local options=$(echo "$PAUSE_OPTIONS_JSON" | python -c "$get_names")
+
+	for option in $options; do
+		[[ "$option" = "$arg" ]] && return
+	done
+	usage "Unsupported pause option '$arg'"
+}
+
+function set_pause_option
+{
+	local option=$1
+	local entered=$2
+
+	if ! zfs list $PAUSE_DATASET &>/dev/null; then
+		zfs create -o mountpoint=legacy $PAUSE_DATASET || return 1
+	fi
+
+	if ! zfs list $PAUSE_DATASET/$option &>/dev/null; then
+		zfs create -o mountpoint=legacy -o $DLPX_ENTERED=$entered \
+		    $PAUSE_DATASET/$option || return 1
+	else
+		zfs set $DLPX_ENTERED=$entered $PAUSE_DATASET/$option || return 1
+	fi
+	return 0
+}
+
+# Requires option to be set, otherwise returns non-zero code.
+function enter_pause_option
+{
+	local option=$1
+	zfs set $DLPX_ENTERED=$entered $PAUSE_DATASET/$option || return 1
+	return 0
+}
+
+function unset_pause_option
+{
+	local option=$1
+
+	if zfs list $PAUSE_DATASET/$option &>/dev/null; then
+		zfs destroy $PAUSE_DATASET/$option || return 1
+	fi
+	return 0
+}
+
+function get_pause_option
+{
+	local option=$1
+	zfs list $PAUSE_DATASET/$option &>/dev/null && return 3
+	return 0
+}
+
+# Verify arguments
+[[ $# -ge 1 ]] || usage "missing arguments"
+
+case "$1" in
+"--set")
+	[[ $# -ge 2 ]] || usage "missing arguments"
+	check_valid_option $2
+	set_pause_option $2 "false"
+	exit $?
+	;;
+"--unset")
+	[[ $# -ge 2 ]] || usage "missing arguments"
+	check_valid_option $2
+	unset_pause_option $2
+	exit $?
+	;;
+"--get")
+	[[ $# -ge 2 ]] || usage "missing arguments"
+	check_valid_option $2
+	get_pause_option $2
+	exit $?
+	;;
+"--pause")
+	[[ $# -ge 2 ]] || usage "missing arguments"
+	check_valid_option $2
+
+	# If option not set, nothing to do.
+	get_pause_option $2 && exit 0
+
+	echo -e "Pausing on $2 ...   \c"
+
+	# Mark as entered
+	enter_pause_option $2 || die "failed to mark entered"
+
+	get_pause_option $2
+	enabled=$([[ $? -eq 3 ]] && echo true || echo false)
+	while $enabled; do
+		sleep 1
+
+		#
+		# Enjoy this spinner while you wait...
+		# (copied this genius piece of code from start_mgmt_server_jvm)
+		#
+		case $(( $SECONDS % 4 )) in
+		0) echo -e "\b\b- \c" ;;
+		1) echo -e "\b\b\\ \c" ;;
+		2) echo -e "\b\b| \c" ;;
+		3) echo -e "\b\b/ \c" ;;
+		esac
+
+		get_pause_option $2
+		enabled=$([[ $? -eq 3 ]] && echo true || echo false)
+	done
+	echo "\b\b\b done."
+	;;
+"--wait-for-pause")
+	[[ $# -ge 2 ]] || usage "missing arguments"
+	check_valid_option $2
+
+	# Check if the option was set
+	get_pause_option $2 && die "pause option $2 not set"
+
+	echo -e "Waiting for pause on $2 ... \c"
+	entered=false
+	while ! $entered; do
+		sleep 1
+		entered=$(zfs get -Ho value $DLPX_ENTERED $PAUSE_DATASET/$2)
+		[[ $? -eq 0 ]] || die "failed to get property for $2"
+	done
+	echo "done."
+	;;
+"--get-options-json")
+	echo "$PAUSE_OPTIONS_JSON"
+	exit $?
+	;;
+*)
+	usage "illegal option '$1'"
+	;;
+esac
+
+exit 0

--- a/live-build/misc/migration-scripts/dx_upg_pause_options
+++ b/live-build/misc/migration-scripts/dx_upg_pause_options
@@ -1,135 +1,135 @@
 #!/bin/bash
 #
-# Copyright (c) 2017, 2018 by Delphix. All rights reserved.
+# Copyright (c) 2017, 2019 by Delphix. All rights reserved.
 #
 
 #
 # Utility for managing upgrade pause options.
 # Supported pause options listed below.
 #
+# Note that those pause options are intended to be run exclusively for
+# migration testing, before the upgrade reboot.
+#
 
-PAUSE_OPTIONS_JSON=$(cat <<-EOF
-{
-	"PAUSE_IN_DX_EXECUTE_BEFORE_RESTART": {
-	    "location": "right before reboot"
-	},
-	"PAUSE_IN_DXSVCINIT_BEFORE_UPGRADE": {
-	    "location": "post-reboot before any app upgrade logic"
-	},
-	"PAUSE_BEFORE_UPGRADE_COMMIT": {
-	    "location": "mgmt service (before point of no return)"
-	},
-	"PAUSE_BEFORE_CHECKPOINT_DISCARD": {
-	    "location": "mgmt service (before point of no return)"
-	},
-	"PAUSE_IN_SVC_ROLLBACK_BEFORE_ROLLBACK": {
-	    "location": "rollback service"
-	},
-	"PAUSE_BEFORE_REWIND_CHECKPOINT": {
-	    "location": "rollback service"
-	},
-	"PAUSE_AFTER_REWIND_CHECKPOINT": {
-	    "location": "rollback service"
-	},
-	"PAUSE_IN_DXSVCINIT_AFTER_ROLLBACK": {
-	    "location": "post-rollback before app stack starts"
-	},
-	"PAUSE_IN_SVC_MGMT_BEFORE_STACK_STARTUP": {
-	    "location": "before app stack starts"
-	}
-}
-EOF
+PAUSE_OPTIONS_JSON=$(
+	cat <<-EOF
+		{
+		"PAUSE_IN_DX_EXECUTE_BEFORE_RESTART": {
+		    "location": "right before reboot"
+		},
+		"PAUSE_IN_DXSVCINIT_BEFORE_UPGRADE": {
+		    "location": "post-reboot before any app upgrade logic"
+		},
+		"PAUSE_BEFORE_UPGRADE_COMMIT": {
+		    "location": "mgmt service (before point of no return)"
+		},
+		"PAUSE_BEFORE_CHECKPOINT_DISCARD": {
+		    "location": "mgmt service (before point of no return)"
+		},
+		"PAUSE_IN_SVC_ROLLBACK_BEFORE_ROLLBACK": {
+		    "location": "rollback service"
+		},
+		"PAUSE_BEFORE_REWIND_CHECKPOINT": {
+		    "location": "rollback service"
+		},
+		"PAUSE_AFTER_REWIND_CHECKPOINT": {
+		    "location": "rollback service"
+		},
+		"PAUSE_IN_DXSVCINIT_AFTER_ROLLBACK": {
+		    "location": "post-rollback before app stack starts"
+		},
+		"PAUSE_IN_SVC_MGMT_BEFORE_STACK_STARTUP": {
+		    "location": "before app stack starts"
+		}
+		}
+	EOF
 )
 
 PAUSE_DATASET=rpool/pause_options
 DLPX_ENTERED=com.delphix:entered
 
-function die
-{
-	echo "$(basename $0): $*" 1>&2
+function die() {
+	echo "$(basename "$0"): $*" 1>&2
 	exit 1
 }
 
-function usage
-{
-	echo "$(basename $0): $*" >&2
+function usage() {
+	echo "$(basename "$0"): $*" >&2
 	echo "Usage:"
-	echo " $(basename $0) --get-options-json"
+	echo " $(basename "$0") --get-options-json"
 	echo "   Prints out a detailed json of all the supported stress options."
-	echo " $(basename $0) --set <pause-option>"
+	echo " $(basename "$0") --set <pause-option>"
 	echo "   Sets the specified pause option. Non-zero exit code on failure."
-	echo " $(basename $0) --unset <pause-option>"
+	echo " $(basename "$0") --unset <pause-option>"
 	echo "   Unsets the specified pause option. Non-zero exit code on failure."
-	echo " $(basename $0) --get <pause-option>"
+	echo " $(basename "$0") --get <pause-option>"
 	echo "   Returns exit code 3 if given pause option is set, 0 if unset."
 	echo "   Any other non-zero exit code is an unexpected error."
-	echo " $(basename $0) --pause <pause-option>"
+	echo " $(basename "$0") --pause <pause-option>"
 	echo "   Does not terminate until the pause option is unset."
 	echo "   Non-zero exit code if errors hit, 0 if wait successful."
-	echo " $(basename $0) --wait-for-pause <pause-option>"
+	echo " $(basename "$0") --wait-for-pause <pause-option>"
 	echo "   Does not terminate until the pause option is hit."
 	echo "   Non-zero exit code if errors hit, 0 if wait successful."
 	exit 2
 }
 
-function check_valid_option
-{
-	local arg=$1
+function check_valid_option() {
+	local arg="$1"
 
-	local get_names=$(cat <<-EOF
-		import json, sys
-		obj=json.load(sys.stdin)
-		print(" ".join(obj.keys()))
-	EOF
+	local get_names
+	get_names=$(
+		cat <<-EOF
+			import json, sys
+			obj=json.load(sys.stdin)
+			print(" ".join(obj.keys()))
+		EOF
 	)
-	local options=$(echo "$PAUSE_OPTIONS_JSON" | python -c "$get_names")
+	local options
+	options=$(echo "$PAUSE_OPTIONS_JSON" | python -c "$get_names")
 
 	for option in $options; do
-		[[ "$option" = "$arg" ]] && return
+		[[ "$option" == "$arg" ]] && return
 	done
 	usage "Unsupported pause option '$arg'"
 }
 
-function set_pause_option
-{
-	local option=$1
-	local entered=$2
+function set_pause_option() {
+	local option="$1"
+	local entered="$2"
 
-	if ! zfs list $PAUSE_DATASET &>/dev/null; then
-		zfs create -o mountpoint=legacy $PAUSE_DATASET || return 1
+	if ! zfs list "$PAUSE_DATASET" &>/dev/null; then
+		zfs create -o mountpoint=legacy "$PAUSE_DATASET" || return 1
 	fi
 
-	if ! zfs list $PAUSE_DATASET/$option &>/dev/null; then
-		zfs create -o mountpoint=legacy -o $DLPX_ENTERED=$entered \
-		    $PAUSE_DATASET/$option || return 1
+	if ! zfs list "$PAUSE_DATASET/$option" &>/dev/null; then
+		zfs create -o mountpoint=legacy -o "$DLPX_ENTERED=$entered" \
+			"$PAUSE_DATASET/$option" || return 1
 	else
-		zfs set $DLPX_ENTERED=$entered $PAUSE_DATASET/$option || return 1
+		zfs set "$DLPX_ENTERED=$entered" "$PAUSE_DATASET/$option" || return 1
 	fi
 	return 0
 }
 
 # Requires option to be set, otherwise returns non-zero code.
-function enter_pause_option
-{
-	local option=$1
-	zfs set $DLPX_ENTERED=$entered $PAUSE_DATASET/$option || return 1
+function enter_pause_option() {
+	local option="$1"
+	zfs set "$DLPX_ENTERED=$entered" "$PAUSE_DATASET/$option" || return 1
 	return 0
 }
 
-function unset_pause_option
-{
-	local option=$1
+function unset_pause_option() {
+	local option="$1"
 
-	if zfs list $PAUSE_DATASET/$option &>/dev/null; then
-		zfs destroy $PAUSE_DATASET/$option || return 1
+	if zfs list "$PAUSE_DATASET/$option" &>/dev/null; then
+		zfs destroy "$PAUSE_DATASET/$option" || return 1
 	fi
 	return 0
 }
 
-function get_pause_option
-{
-	local option=$1
-	zfs list $PAUSE_DATASET/$option &>/dev/null && return 3
+function get_pause_option() {
+	local option="$1"
+	zfs list "$PAUSE_DATASET/$option" &>/dev/null && return 3
 	return 0
 }
 
@@ -139,35 +139,35 @@ function get_pause_option
 case "$1" in
 "--set")
 	[[ $# -ge 2 ]] || usage "missing arguments"
-	check_valid_option $2
-	set_pause_option $2 "false"
+	check_valid_option "$2"
+	set_pause_option "$2" "false"
 	exit $?
 	;;
 "--unset")
 	[[ $# -ge 2 ]] || usage "missing arguments"
-	check_valid_option $2
-	unset_pause_option $2
+	check_valid_option "$2"
+	unset_pause_option "$2"
 	exit $?
 	;;
 "--get")
 	[[ $# -ge 2 ]] || usage "missing arguments"
-	check_valid_option $2
-	get_pause_option $2
+	check_valid_option "$2"
+	get_pause_option "$2"
 	exit $?
 	;;
 "--pause")
 	[[ $# -ge 2 ]] || usage "missing arguments"
-	check_valid_option $2
+	check_valid_option "$2"
 
 	# If option not set, nothing to do.
-	get_pause_option $2 && exit 0
+	get_pause_option "$2" && exit 0
 
-	echo -e "Pausing on $2 ...   \c"
+	echo -e "Pausing on $2 ...   \\c"
 
 	# Mark as entered
-	enter_pause_option $2 || die "failed to mark entered"
+	enter_pause_option "$2" || die "failed to mark entered"
 
-	get_pause_option $2
+	get_pause_option "$2"
 	enabled=$([[ $? -eq 3 ]] && echo true || echo false)
 	while $enabled; do
 		sleep 1
@@ -176,30 +176,31 @@ case "$1" in
 		# Enjoy this spinner while you wait...
 		# (copied this genius piece of code from start_mgmt_server_jvm)
 		#
-		case $(( $SECONDS % 4 )) in
-		0) echo -e "\b\b- \c" ;;
-		1) echo -e "\b\b\\ \c" ;;
-		2) echo -e "\b\b| \c" ;;
-		3) echo -e "\b\b/ \c" ;;
+		case $((SECONDS % 4)) in
+		0) echo -e "\\b\\b- \\c" ;;
+		1) echo -e "\\b\\b\\ \\c" ;;
+		2) echo -e "\\b\\b| \\c" ;;
+		3) echo -e "\\b\\b/ \\c" ;;
 		esac
 
-		get_pause_option $2
+		get_pause_option "$2"
 		enabled=$([[ $? -eq 3 ]] && echo true || echo false)
 	done
-	echo "\b\b\b done."
+	echo "\\b\\b\\b done."
 	;;
 "--wait-for-pause")
 	[[ $# -ge 2 ]] || usage "missing arguments"
-	check_valid_option $2
+	check_valid_option "$2"
 
 	# Check if the option was set
-	get_pause_option $2 && die "pause option $2 not set"
+	get_pause_option "$2" && die "pause option $2 not set"
 
-	echo -e "Waiting for pause on $2 ... \c"
+	echo -e "Waiting for pause on $2 ... \\c"
 	entered=false
 	while ! $entered; do
 		sleep 1
-		entered=$(zfs get -Ho value $DLPX_ENTERED $PAUSE_DATASET/$2)
+		entered=$(zfs get -Ho value $DLPX_ENTERED "$PAUSE_DATASET/$2")
+		# shellcheck disable=SC2181
 		[[ $? -eq 0 ]] || die "failed to get property for $2"
 	done
 	echo "done."

--- a/live-build/misc/migration-scripts/dx_upg_stress_options
+++ b/live-build/misc/migration-scripts/dx_upg_stress_options
@@ -10,232 +10,233 @@
 # This file may be sourced so the variable/function names are made as unique
 # as possible in addition to the double underscores in front.
 #
-__STRESS_OPTIONS_JSON=$(cat <<-EOF
-{
-	"STRESS_DX_APPLY_FAIL_AFTER_VERSION_CHECK": {
-	    "location": "pre-reboot",
-	    "err_msg": "Stress option triggered after version check.",
-	    "auto_unset": true
-	},
-	"STRESS_DX_INSTALL_ARCHIVE_FAIL_AFTER_VERIFY_DX_ARCHIVE": {
-	    "location": "pre-reboot",
-	    "err_msg": "Stress option triggered after verify_dx_archive.",
-	    "auto_unset": true
-	},
-	"STRESS_DX_VERIFY_FAIL_HOTFIX": {
-	    "location": "pre-reboot",
-	    "err_msg": "Stress option triggered to fail hotfix check.",
-	    "auto_unset": true
-	},
-	"STRESS_DX_VERIFY_FAIL_AFTER_TEST_MIGRATION": {
-	    "location": "pre-reboot",
-	    "err_msg": "Stress option triggered after testing migration.",
-	    "auto_unset": true
-	},
-	"STRESS_DX_EXECUTE_FAIL_BEFORE_REBOOT": {
-	    "location": "pre-reboot",
-	    "err_msg": "Stress option triggered before reboot.",
-	    "auto_unset": true
-	},
-	"STRESS_APPLY_JOB_CLEANUP_BEFORE_DISABLE_UPGRADE_MODE": {
-	    "location": "pre-reboot",
-	    "err_msg": "Stress option triggered before cleaning up upgrade mode.",
-	    "auto_unset": true
-	},
-	"STRESS_DXSVCINIT_FAIL_AFTER_UPGRADE_MODE": {
-	    "location": "boot service",
-	    "err_msg": "Stress option triggered after upgrade mode.",
-	    "auto_unset": true
-	},
-	"STRESS_FAIL_BEFORE_UPGRADE_COMMIT": {
-	    "location": "mgmt service (before point of no return)",
-	    "err_msg": "Stress option triggered before upgrade commit.",
-	    "auto_unset": true
-	},
-	"STRESS_FAIL_BEFORE_CHECKPOINT_DISCARD": {
-	    "location": "mgmt service (before point of no return)",
-	    "err_msg": "Stress option triggered before checkpoint discard.",
-	    "auto_unset": true
-	},
-	"STRESS_ROLLBACK_SVC_FAIL_BEFORE_ROLLBACK": {
-	    "location": "rollback service (all)",
-	    "err_msg": "Stress option triggered before do_rollback.",
-	    "auto_unset": false
-	},
-	"STRESS_ROLLBACK_SVC_FAIL_BEFORE_DX_ROLLBACK": {
-	    "location": "rollback service (all)",
-	    "err_msg": "Stress option triggered before dx_rollback call.",
-	    "auto_unset": false
-	},
-	"STRESS_ROLLBACK_SVC_FAIL_AFTER_DX_ROLLBACK": {
-	    "location": "rollback service (all)",
-	    "err_msg": "Stress option triggered after dx_rollback call.",
-	    "auto_unset": true
-	},
-	"STRESS_ROLLBACK_SVC_FAIL_AFTER_REMOUNT_OPT": {
-	    "location": "rollback service (stack only)",
-	    "err_msg": "Stress option triggered after remounting /opt/delphix.",
-	    "auto_unset": false
-	},
-	"STRESS_ROLLBACK_SVC_FAIL_BEFORE_CLEARING_DEPS": {
-	    "location": "rollback service (stack only)",
-	    "err_msg": "Stress option triggered before clearing dependent services.",
-	    "auto_unset": false
-	},
-	"STRESS_ROLLBACK_SVC_FAIL_BEFORE_REENABLING_BOOT": {
-	    "location": "rollback service (stack only)",
-	    "err_msg": "Stress option triggered before re-enabling boot service.",
-	    "auto_unset": false
-	},
-	"STRESS_CKPT_UTIL_FAIL_AFTER_EXPORT_DOMAIN": {
-	    "location": "rollback service (OS)",
-	    "err_msg": "Stress option triggered after exporting domain0.",
-	    "auto_unset": true
-	},
-	"STRESS_FAIL_AFTER_COMMIT_BEFORE_CHECKPOINT_DISCARD": {
-	    "location": "mgmt service (after point of no return)",
-	    "err_msg": "Stress option triggered between upgrade commit and checkpoint discard",
-	    "auto_unset": true
-	},
-	"STRESS_FAIL_AFTER_UPGRADE_COMMIT": {
-	    "location": "mgmt service (after point of no return)",
-	    "err_msg": "Stress option triggered after upgrade commit.",
-	    "auto_unset": true
-	},
-	"STRESS_UPGRADEMANAGER_FAIL_IN_START": {
-	    "location": "mgmt service (after point of no return)",
-	    "err_msg": "Stress option triggered in upgrade manager.",
-	    "auto_unset": true
-	},
-	"STRESS_POSTCLEANUP_FAIL_BEFORE_ENABLE_SOURCES": {
-	    "location": "mgmt service (after point of no return)",
-	    "err_msg": "Stress option triggered before enabling sources.",
-	    "auto_unset": true
-	}
-}
-EOF
+# Note that those stress options are intended to be run exclusively for
+# migration testing, before the upgrade reboot.
+#
+
+__STRESS_OPTIONS_JSON=$(
+	cat <<-EOF
+		{
+		"STRESS_DX_APPLY_FAIL_AFTER_VERSION_CHECK": {
+		    "location": "pre-reboot",
+		    "err_msg": "Stress option triggered after version check.",
+		    "auto_unset": true
+		},
+		"STRESS_DX_INSTALL_ARCHIVE_FAIL_AFTER_VERIFY_DX_ARCHIVE": {
+		    "location": "pre-reboot",
+		    "err_msg": "Stress option triggered after verify_dx_archive.",
+		    "auto_unset": true
+		},
+		"STRESS_DX_VERIFY_FAIL_HOTFIX": {
+		    "location": "pre-reboot",
+		    "err_msg": "Stress option triggered to fail hotfix check.",
+		    "auto_unset": true
+		},
+		"STRESS_DX_VERIFY_FAIL_AFTER_TEST_MIGRATION": {
+		    "location": "pre-reboot",
+		    "err_msg": "Stress option triggered after testing migration.",
+		    "auto_unset": true
+		},
+		"STRESS_DX_EXECUTE_FAIL_BEFORE_REBOOT": {
+		    "location": "pre-reboot",
+		    "err_msg": "Stress option triggered before reboot.",
+		    "auto_unset": true
+		},
+		"STRESS_APPLY_JOB_CLEANUP_BEFORE_DISABLE_UPGRADE_MODE": {
+		    "location": "pre-reboot",
+		    "err_msg": "Stress option triggered before cleaning up upgrade mode.",
+		    "auto_unset": true
+		},
+		"STRESS_DXSVCINIT_FAIL_AFTER_UPGRADE_MODE": {
+		    "location": "boot service",
+		    "err_msg": "Stress option triggered after upgrade mode.",
+		    "auto_unset": true
+		},
+		"STRESS_FAIL_BEFORE_UPGRADE_COMMIT": {
+		    "location": "mgmt service (before point of no return)",
+		    "err_msg": "Stress option triggered before upgrade commit.",
+		    "auto_unset": true
+		},
+		"STRESS_FAIL_BEFORE_CHECKPOINT_DISCARD": {
+		    "location": "mgmt service (before point of no return)",
+		    "err_msg": "Stress option triggered before checkpoint discard.",
+		    "auto_unset": true
+		},
+		"STRESS_ROLLBACK_SVC_FAIL_BEFORE_ROLLBACK": {
+		    "location": "rollback service (all)",
+		    "err_msg": "Stress option triggered before do_rollback.",
+		    "auto_unset": false
+		},
+		"STRESS_ROLLBACK_SVC_FAIL_BEFORE_DX_ROLLBACK": {
+		    "location": "rollback service (all)",
+		    "err_msg": "Stress option triggered before dx_rollback call.",
+		    "auto_unset": false
+		},
+		"STRESS_ROLLBACK_SVC_FAIL_AFTER_DX_ROLLBACK": {
+		    "location": "rollback service (all)",
+		    "err_msg": "Stress option triggered after dx_rollback call.",
+		    "auto_unset": true
+		},
+		"STRESS_ROLLBACK_SVC_FAIL_AFTER_REMOUNT_OPT": {
+		    "location": "rollback service (stack only)",
+		    "err_msg": "Stress option triggered after remounting /opt/delphix.",
+		    "auto_unset": false
+		},
+		"STRESS_ROLLBACK_SVC_FAIL_BEFORE_CLEARING_DEPS": {
+		    "location": "rollback service (stack only)",
+		    "err_msg": "Stress option triggered before clearing dependent services.",
+		    "auto_unset": false
+		},
+		"STRESS_ROLLBACK_SVC_FAIL_BEFORE_REENABLING_BOOT": {
+		    "location": "rollback service (stack only)",
+		    "err_msg": "Stress option triggered before re-enabling boot service.",
+		    "auto_unset": false
+		},
+		"STRESS_CKPT_UTIL_FAIL_AFTER_EXPORT_DOMAIN": {
+		    "location": "rollback service (OS)",
+		    "err_msg": "Stress option triggered after exporting domain0.",
+		    "auto_unset": true
+		},
+		"STRESS_FAIL_AFTER_COMMIT_BEFORE_CHECKPOINT_DISCARD": {
+		    "location": "mgmt service (after point of no return)",
+		    "err_msg": "Stress option triggered between upgrade commit and checkpoint discard",
+		    "auto_unset": true
+		},
+		"STRESS_FAIL_AFTER_UPGRADE_COMMIT": {
+		    "location": "mgmt service (after point of no return)",
+		    "err_msg": "Stress option triggered after upgrade commit.",
+		    "auto_unset": true
+		},
+		"STRESS_UPGRADEMANAGER_FAIL_IN_START": {
+		    "location": "mgmt service (after point of no return)",
+		    "err_msg": "Stress option triggered in upgrade manager.",
+		    "auto_unset": true
+		},
+		"STRESS_POSTCLEANUP_FAIL_BEFORE_ENABLE_SOURCES": {
+		    "location": "mgmt service (after point of no return)",
+		    "err_msg": "Stress option triggered before enabling sources.",
+		    "auto_unset": true
+		}
+		}
+	EOF
 )
 
 __STRESS_DATASET=rpool/stress_options
 __DLPX_PANIC=com.delphix:panic
 __DLPX_SVC_MGMT=svc:/system/delphix/mgmt
 
-function __dx_upg_stress_options_usage
-{
+function __dx_upg_stress_options_usage() {
 	cat <<-EOF >&2
-	$(basename $0): $*
-	Usage:
-	 $(basename $0) --get-options-json
-	   Prints out a detailed json of all the supported stress options.
-	 $(basename $0) --set <stress-option>
-	   Set the specified stress option to die on trigger.
-	   Non-zero exit status on failure.
-	 $(basename $0) --set-panic <stress-option>
-	   Set the specified stress option to system panic on trigger.
-	   Non-zero exit status on failure.
-	 $(basename $0) --unset <stress-option>
-	   Unset the specified stress option.
-	   Non-zero exit status on failure.
-	 $(basename $0) --get <stress-option>
-	   Returns exit code 3 if given stress option is set to die,
-	   0 if not.  Any other non-zero exit code is an unexpected error.
-	 $(basename $0) --get-panic <stress-option>
-	   Returns exit code 3 if given stress option is set to panic,
-	   0 if not.  Any other non-zero exit code is an unexpected error.
-	 $(basename $0) --panic-or-get-unset <stress-option>
-	   If the stress option is set to panic, unset and panic.
-	   Otherwise returns exit code:
-	     0 - the stress option is unset.
-	     3 - the stress option is set, and successfully unset it.
-	     4 - the stress option is set, but unsuccessfully unset it.
-	   Any other non-zero exit code is an unexpected error.
+		$(basename "$0"): $*
+		Usage:
+		 $(basename "$0") --get-options-json
+		   Prints out a detailed json of all the supported stress options.
+		 $(basename "$0") --set <stress-option>
+		   Set the specified stress option to die on trigger.
+		   Non-zero exit status on failure.
+		 $(basename "$0") --set-panic <stress-option>
+		   Set the specified stress option to system panic on trigger.
+		   Non-zero exit status on failure.
+		 $(basename "$0") --unset <stress-option>
+		   Unset the specified stress option.
+		   Non-zero exit status on failure.
+		 $(basename "$0") --get <stress-option>
+		   Returns exit code 3 if given stress option is set to die,
+		   0 if not.  Any other non-zero exit code is an unexpected error.
+		 $(basename "$0") --get-panic <stress-option>
+		   Returns exit code 3 if given stress option is set to panic,
+		   0 if not.  Any other non-zero exit code is an unexpected error.
+		 $(basename "$0") --panic-or-get-unset <stress-option>
+		   If the stress option is set to panic, unset and panic.
+		   Otherwise returns exit code:
+		     0 - the stress option is unset.
+		     3 - the stress option is set, and successfully unset it.
+		     4 - the stress option is set, but unsuccessfully unset it.
+		   Any other non-zero exit code is an unexpected error.
 	EOF
 	exit 2
 }
 
-function __check_valid_option
-{
-	local arg=$1
+function __check_valid_option() {
+	local arg="$1"
 
-	local get_names=$(cat <<-EOF
-		import json
-		obj=json.loads('''$__STRESS_OPTIONS_JSON''')
-		print(" ".join(obj.keys()))
-	EOF
+	local get_names
+	get_names=$(
+		cat <<-EOF
+			import json
+			obj=json.loads('''$__STRESS_OPTIONS_JSON''')
+			print(" ".join(obj.keys()))
+		EOF
 	)
-	local options=$(python -c "$get_names")
+	local options
+	options=$(python -c "$get_names")
 
 	for option in $options; do
-		[[ "$option" = "$arg" ]] && return
+		[[ "$option" == "$arg" ]] && return
 	done
 	__dx_upg_stress_options_usage "Unsupported stress option '$arg'"
 }
 
-function __set_stress_option
-{
-	local option=$1
-	local panic=$2
+function __set_stress_option() {
+	local option="$1"
+	local panic="$2"
 
-	if ! zfs list $__STRESS_DATASET &>/dev/null; then
-		zfs create -o mountpoint=legacy $__STRESS_DATASET || return 1
+	if ! zfs list "$__STRESS_DATASET" &>/dev/null; then
+		zfs create -o mountpoint=legacy "$__STRESS_DATASET" || return 1
 	fi
 
-	if ! zfs list $__STRESS_DATASET/$option &>/dev/null; then
-		zfs create -o mountpoint=legacy -o $__DLPX_PANIC=$panic \
-		    $__STRESS_DATASET/$option || return 1
+	if ! zfs list "$__STRESS_DATASET/$option" &>/dev/null; then
+		zfs create -o mountpoint=legacy -o "$__DLPX_PANIC=$panic" \
+			"$__STRESS_DATASET/$option" || return 1
 	else
-		zfs set $__DLPX_PANIC=$panic $__STRESS_DATASET/$option || return 1
+		zfs set "$__DLPX_PANIC=$panic" "$__STRESS_DATASET/$option" || return 1
 	fi
 	return 0
 }
 
-function __unset_stress_option
-{
-	local option=$1
+function __unset_stress_option() {
+	local option="$1"
 
-	if zfs list $__STRESS_DATASET/$option &>/dev/null; then
-		zfs destroy $__STRESS_DATASET/$option || return 1
+	if zfs list "$__STRESS_DATASET/$option" &>/dev/null; then
+		zfs destroy "$__STRESS_DATASET/$option" || return 1
 	fi
 	return 0
 }
 
-function __get_stress_option
-{
-	local option=$1
-	local panic=$2
+function __get_stress_option() {
+	local option="$1"
+	local panic="$2"
 
-	zfs list $__STRESS_DATASET/$option &>/dev/null && \
-	    [[ $(zfs get -Ho value $__DLPX_PANIC $__STRESS_DATASET/$option) = \
-	    $panic ]] && return 3
+	zfs list "$__STRESS_DATASET/$option" &>/dev/null &&
+		[[ $(zfs get -Ho value "$__DLPX_PANIC" "$__STRESS_DATASET/$option") == "$panic" ]] && return 3
 	return 0
 }
 
-function __get_unset_stress_option
-{
-	local option=$1
-	local panic=$2
+function __get_unset_stress_option() {
+	local option="$1"
+	local panic="$2"
 
-	__get_stress_option $option $panic
+	__get_stress_option "$option" "$panic"
 	if [[ $? -eq 3 ]]; then
-		__unset_stress_option $option || return 4
+		__unset_stress_option "$option" || return 4
 		return 3
 	fi
 	return 0
 }
 
-function __handle_panic_stress_option
-{
-	local option=$1
-	local unset=$2
+function __handle_panic_stress_option() {
+	local option="$1"
+	local unset="$2"
 	local get_func="__get_stress_option"
 	$unset && get_func="__get_unset_stress_option"
 
-	$get_func $option "true"
-	local stress_ret=$?
+	$get_func "$option" "true"
+	local stress_ret
+	stress_ret=$?
 
 	if [[ $stress_ret -eq 3 ]]; then
 		uadmin 2 1
-	elif [[ $delphix_debug = "true" ]] && [[ $stress_ret -ne 0 ]]; then
+	elif [[ $delphix_debug == "true" ]] && [[ $stress_ret -ne 0 ]]; then
 		echo "'$get_func' returned $stress_ret"
 	fi
 }
@@ -253,22 +254,25 @@ function __handle_panic_stress_option
 # If no "stress_die" is defined, it will fall back to using the original "die"
 # method for failing.
 #
-function __trigger_stress_option
-{
+function __trigger_stress_option() {
 	local option=$1
-	local delphix_debug=$(svcprop -p delphix/debug $__DLPX_SVC_MGMT)
+	local delphix_debug
+	delphix_debug=$(svcprop -p delphix/debug $__DLPX_SVC_MGMT)
 
 	__handle_panic_stress_option "$option" "false"
 
-	local get_err_msg=$(cat <<-EOF
-		import json
-		obj=json.loads('''$__STRESS_OPTIONS_JSON''')
-		print(obj["$option"]["err_msg"])
-	EOF
+	local get_err_msg
+	get_err_msg=$(
+		cat <<-EOF
+			import json
+			obj=json.loads('''$__STRESS_OPTIONS_JSON''')
+			print(obj["$option"]["err_msg"])
+		EOF
 	)
-	local message=$(python -c "$get_err_msg")
+	local message
+	message=$(python -c "$get_err_msg")
 
-	__get_stress_option $option "false"
+	__get_stress_option "$option" "false"
 	local stress_ret=$?
 	if [[ $stress_ret -eq 3 ]]; then
 		type stress_die >/dev/null 2>&1 && stress_die "$message"
@@ -277,7 +281,7 @@ function __trigger_stress_option
 			exit 1
 		fi
 		die "$message"
-	elif [[ $delphix_debug = "true" ]] && [[ $stress_ret -ne 0 ]]; then
+	elif [[ $delphix_debug == "true" ]] && [[ $stress_ret -ne 0 ]]; then
 		if ! type die >/dev/null 2>&1; then
 			echo "ERROR: no die function defined"
 			exit 1
@@ -299,22 +303,25 @@ function __trigger_stress_option
 # If no "stress_die" is defined, it will fall back to using the original "die"
 # method for failing.
 #
-function __trigger_unset_stress_option
-{
-	local option=$1
-	local delphix_debug=$(svcprop -p delphix/debug $__DLPX_SVC_MGMT)
+function __trigger_unset_stress_option() {
+	local option="$1"
+	local delphix_debug
+	delphix_debug=$(svcprop -p delphix/debug $__DLPX_SVC_MGMT)
 
 	__handle_panic_stress_option "$option" "true"
 
-	local get_err_msg=$(cat <<-EOF
-		import json
-		obj=json.loads('''$__STRESS_OPTIONS_JSON''')
-		print(obj["$option"]["err_msg"])
-	EOF
+	local get_err_msg
+	get_err_msg=$(
+		cat <<-EOF
+			import json
+			obj=json.loads('''$__STRESS_OPTIONS_JSON''')
+			print(obj["$option"]["err_msg"])
+		EOF
 	)
-	local message=$(python -c "$get_err_msg")
+	local message
+	message=$(python -c "$get_err_msg")
 
-	__get_unset_stress_option $option "false"
+	__get_unset_stress_option "$option" "false"
 	local stress_ret=$?
 	if [[ $stress_ret -eq 3 ]]; then
 		type stress_die >/dev/null 2>&1 && stress_die "$message"
@@ -323,7 +330,7 @@ function __trigger_unset_stress_option
 			exit 1
 		fi
 		die "$message"
-	elif [[ $delphix_debug = "true" ]] && [[ $stress_ret -ne 0 ]]; then
+	elif [[ $delphix_debug == "true" ]] && [[ $stress_ret -ne 0 ]]; then
 		if ! type die >/dev/null 2>&1; then
 			echo "ERROR: no die function defined"
 			exit 1
@@ -336,53 +343,51 @@ function __trigger_unset_stress_option
 case "$1" in
 "--set")
 	[[ $# -ge 2 ]] || __dx_upg_stress_options_usage "missing arguments"
-	__check_valid_option $2
-	__set_stress_option $2 "false"
+	__check_valid_option "$2"
+	__set_stress_option "$2" "false"
 	exit $?
 	;;
 "--set-panic")
 	[[ $# -ge 2 ]] || __dx_upg_stress_options_usage "missing arguments"
-	__check_valid_option $2
-	__set_stress_option $2 "true"
+	__check_valid_option "$2"
+	__set_stress_option "$2" "true"
 	exit $?
 	;;
 "--unset")
 	[[ $# -ge 2 ]] || __dx_upg_stress_options_usage "missing arguments"
-	__check_valid_option $2
-	__unset_stress_option $2 "false"
+	__check_valid_option "$2"
+	__unset_stress_option "$2" "false"
 	exit $?
 	;;
 "--get")
 	[[ $# -ge 2 ]] || __dx_upg_stress_options_usage "missing arguments"
-	__check_valid_option $2
-	__get_stress_option $2 "false"
+	__check_valid_option "$2"
+	__get_stress_option "$2" "false"
 	exit $?
 	;;
 "--get-panic")
 	[[ $# -ge 2 ]] || __dx_upg_stress_options_usage "missing arguments"
-	__check_valid_option $2
-	__get_stress_option $2 "true"
+	__check_valid_option "$2"
+	__get_stress_option "$2" "true"
 	exit $?
 	;;
 "--panic-or-get-unset")
 	[[ $# -ge 2 ]] || __dx_upg_stress_options_usage "missing arguments"
-	__check_valid_option $2
+	__check_valid_option "$2"
 
 	# Called when the stress option is set and successfully unset, exit 3.
-	function stress_die
-	{
-		echo $*
+	function stress_die() {
+		echo "$*"
 		exit 3
 	}
 
 	# Called when the stress option is set but failed to unset, exit 4.
-	function die
-	{
-		echo $*
-		exit 3
+	function die() {
+		echo "$*"
+		exit 4
 	}
 
-	__trigger_unset_stress_option $2
+	__trigger_unset_stress_option "$2"
 	exit 0
 	;;
 "--get-options-json")

--- a/live-build/misc/migration-scripts/dx_upg_stress_options
+++ b/live-build/misc/migration-scripts/dx_upg_stress_options
@@ -1,0 +1,400 @@
+#!/bin/bash
+#
+# Copyright (c) 2016, 2017 by Delphix. All rights reserved.
+#
+
+#
+# Utility for getting and setting upgrade stress options.
+# Supported failure points listed below.
+#
+# This file may be sourced so the variable/function names are made as unique
+# as possible in addition to the double underscores in front.
+#
+__STRESS_OPTIONS_JSON=$(cat <<-EOF
+{
+	"STRESS_DX_APPLY_FAIL_AFTER_VERSION_CHECK": {
+	    "location": "pre-reboot",
+	    "err_msg": "Stress option triggered after version check.",
+	    "auto_unset": true
+	},
+	"STRESS_DX_INSTALL_ARCHIVE_FAIL_AFTER_VERIFY_DX_ARCHIVE": {
+	    "location": "pre-reboot",
+	    "err_msg": "Stress option triggered after verify_dx_archive.",
+	    "auto_unset": true
+	},
+	"STRESS_DX_VERIFY_FAIL_HOTFIX": {
+	    "location": "pre-reboot",
+	    "err_msg": "Stress option triggered to fail hotfix check.",
+	    "auto_unset": true
+	},
+	"STRESS_DX_VERIFY_FAIL_AFTER_TEST_MIGRATION": {
+	    "location": "pre-reboot",
+	    "err_msg": "Stress option triggered after testing migration.",
+	    "auto_unset": true
+	},
+	"STRESS_DX_EXECUTE_FAIL_BEFORE_REBOOT": {
+	    "location": "pre-reboot",
+	    "err_msg": "Stress option triggered before reboot.",
+	    "auto_unset": true
+	},
+	"STRESS_APPLY_JOB_CLEANUP_BEFORE_DISABLE_UPGRADE_MODE": {
+	    "location": "pre-reboot",
+	    "err_msg": "Stress option triggered before cleaning up upgrade mode.",
+	    "auto_unset": true
+	},
+	"STRESS_DXSVCINIT_FAIL_AFTER_UPGRADE_MODE": {
+	    "location": "boot service",
+	    "err_msg": "Stress option triggered after upgrade mode.",
+	    "auto_unset": true
+	},
+	"STRESS_FAIL_BEFORE_UPGRADE_COMMIT": {
+	    "location": "mgmt service (before point of no return)",
+	    "err_msg": "Stress option triggered before upgrade commit.",
+	    "auto_unset": true
+	},
+	"STRESS_FAIL_BEFORE_CHECKPOINT_DISCARD": {
+	    "location": "mgmt service (before point of no return)",
+	    "err_msg": "Stress option triggered before checkpoint discard.",
+	    "auto_unset": true
+	},
+	"STRESS_ROLLBACK_SVC_FAIL_BEFORE_ROLLBACK": {
+	    "location": "rollback service (all)",
+	    "err_msg": "Stress option triggered before do_rollback.",
+	    "auto_unset": false
+	},
+	"STRESS_ROLLBACK_SVC_FAIL_BEFORE_DX_ROLLBACK": {
+	    "location": "rollback service (all)",
+	    "err_msg": "Stress option triggered before dx_rollback call.",
+	    "auto_unset": false
+	},
+	"STRESS_ROLLBACK_SVC_FAIL_AFTER_DX_ROLLBACK": {
+	    "location": "rollback service (all)",
+	    "err_msg": "Stress option triggered after dx_rollback call.",
+	    "auto_unset": true
+	},
+	"STRESS_ROLLBACK_SVC_FAIL_AFTER_REMOUNT_OPT": {
+	    "location": "rollback service (stack only)",
+	    "err_msg": "Stress option triggered after remounting /opt/delphix.",
+	    "auto_unset": false
+	},
+	"STRESS_ROLLBACK_SVC_FAIL_BEFORE_CLEARING_DEPS": {
+	    "location": "rollback service (stack only)",
+	    "err_msg": "Stress option triggered before clearing dependent services.",
+	    "auto_unset": false
+	},
+	"STRESS_ROLLBACK_SVC_FAIL_BEFORE_REENABLING_BOOT": {
+	    "location": "rollback service (stack only)",
+	    "err_msg": "Stress option triggered before re-enabling boot service.",
+	    "auto_unset": false
+	},
+	"STRESS_CKPT_UTIL_FAIL_AFTER_EXPORT_DOMAIN": {
+	    "location": "rollback service (OS)",
+	    "err_msg": "Stress option triggered after exporting domain0.",
+	    "auto_unset": true
+	},
+	"STRESS_FAIL_AFTER_COMMIT_BEFORE_CHECKPOINT_DISCARD": {
+	    "location": "mgmt service (after point of no return)",
+	    "err_msg": "Stress option triggered between upgrade commit and checkpoint discard",
+	    "auto_unset": true
+	},
+	"STRESS_FAIL_AFTER_UPGRADE_COMMIT": {
+	    "location": "mgmt service (after point of no return)",
+	    "err_msg": "Stress option triggered after upgrade commit.",
+	    "auto_unset": true
+	},
+	"STRESS_UPGRADEMANAGER_FAIL_IN_START": {
+	    "location": "mgmt service (after point of no return)",
+	    "err_msg": "Stress option triggered in upgrade manager.",
+	    "auto_unset": true
+	},
+	"STRESS_POSTCLEANUP_FAIL_BEFORE_ENABLE_SOURCES": {
+	    "location": "mgmt service (after point of no return)",
+	    "err_msg": "Stress option triggered before enabling sources.",
+	    "auto_unset": true
+	}
+}
+EOF
+)
+
+__STRESS_DATASET=rpool/stress_options
+__DLPX_PANIC=com.delphix:panic
+__DLPX_SVC_MGMT=svc:/system/delphix/mgmt
+
+function __dx_upg_stress_options_usage
+{
+	cat <<-EOF >&2
+	$(basename $0): $*
+	Usage:
+	 $(basename $0) --get-options-json
+	   Prints out a detailed json of all the supported stress options.
+	 $(basename $0) --set <stress-option>
+	   Set the specified stress option to die on trigger.
+	   Non-zero exit status on failure.
+	 $(basename $0) --set-panic <stress-option>
+	   Set the specified stress option to system panic on trigger.
+	   Non-zero exit status on failure.
+	 $(basename $0) --unset <stress-option>
+	   Unset the specified stress option.
+	   Non-zero exit status on failure.
+	 $(basename $0) --get <stress-option>
+	   Returns exit code 3 if given stress option is set to die,
+	   0 if not.  Any other non-zero exit code is an unexpected error.
+	 $(basename $0) --get-panic <stress-option>
+	   Returns exit code 3 if given stress option is set to panic,
+	   0 if not.  Any other non-zero exit code is an unexpected error.
+	 $(basename $0) --panic-or-get-unset <stress-option>
+	   If the stress option is set to panic, unset and panic.
+	   Otherwise returns exit code:
+	     0 - the stress option is unset.
+	     3 - the stress option is set, and successfully unset it.
+	     4 - the stress option is set, but unsuccessfully unset it.
+	   Any other non-zero exit code is an unexpected error.
+	EOF
+	exit 2
+}
+
+function __check_valid_option
+{
+	local arg=$1
+
+	local get_names=$(cat <<-EOF
+		import json
+		obj=json.loads('''$__STRESS_OPTIONS_JSON''')
+		print(" ".join(obj.keys()))
+	EOF
+	)
+	local options=$(python -c "$get_names")
+
+	for option in $options; do
+		[[ "$option" = "$arg" ]] && return
+	done
+	__dx_upg_stress_options_usage "Unsupported stress option '$arg'"
+}
+
+function __set_stress_option
+{
+	local option=$1
+	local panic=$2
+
+	if ! zfs list $__STRESS_DATASET &>/dev/null; then
+		zfs create -o mountpoint=legacy $__STRESS_DATASET || return 1
+	fi
+
+	if ! zfs list $__STRESS_DATASET/$option &>/dev/null; then
+		zfs create -o mountpoint=legacy -o $__DLPX_PANIC=$panic \
+		    $__STRESS_DATASET/$option || return 1
+	else
+		zfs set $__DLPX_PANIC=$panic $__STRESS_DATASET/$option || return 1
+	fi
+	return 0
+}
+
+function __unset_stress_option
+{
+	local option=$1
+
+	if zfs list $__STRESS_DATASET/$option &>/dev/null; then
+		zfs destroy $__STRESS_DATASET/$option || return 1
+	fi
+	return 0
+}
+
+function __get_stress_option
+{
+	local option=$1
+	local panic=$2
+
+	zfs list $__STRESS_DATASET/$option &>/dev/null && \
+	    [[ $(zfs get -Ho value $__DLPX_PANIC $__STRESS_DATASET/$option) = \
+	    $panic ]] && return 3
+	return 0
+}
+
+function __get_unset_stress_option
+{
+	local option=$1
+	local panic=$2
+
+	__get_stress_option $option $panic
+	if [[ $? -eq 3 ]]; then
+		__unset_stress_option $option || return 4
+		return 3
+	fi
+	return 0
+}
+
+function __handle_panic_stress_option
+{
+	local option=$1
+	local unset=$2
+	local get_func="__get_stress_option"
+	$unset && get_func="__get_unset_stress_option"
+
+	$get_func $option "true"
+	local stress_ret=$?
+
+	if [[ $stress_ret -eq 3 ]]; then
+		uadmin 2 1
+	elif [[ $delphix_debug = "true" ]] && [[ $stress_ret -ne 0 ]]; then
+		echo "'$get_func' returned $stress_ret"
+	fi
+}
+
+#
+# Fails if the given stress option was set.
+# Also fails if we are in debug mode and hit an unexpected return code.
+#
+# This function should only be used when sourcing this file.  The script
+# sourcing this file must implement the function "die" or "stress_die" for
+# this method to fail correctly.
+#
+# A caller may define a "stress_die" function if they want extra functionality
+# besides the original "die" method.  See "dx_execute" for an example of this.
+# If no "stress_die" is defined, it will fall back to using the original "die"
+# method for failing.
+#
+function __trigger_stress_option
+{
+	local option=$1
+	local delphix_debug=$(svcprop -p delphix/debug $__DLPX_SVC_MGMT)
+
+	__handle_panic_stress_option "$option" "false"
+
+	local get_err_msg=$(cat <<-EOF
+		import json
+		obj=json.loads('''$__STRESS_OPTIONS_JSON''')
+		print(obj["$option"]["err_msg"])
+	EOF
+	)
+	local message=$(python -c "$get_err_msg")
+
+	__get_stress_option $option "false"
+	local stress_ret=$?
+	if [[ $stress_ret -eq 3 ]]; then
+		type stress_die >/dev/null 2>&1 && stress_die "$message"
+		if ! type die >/dev/null 2>&1; then
+			echo "ERROR: no die function defined"
+			exit 1
+		fi
+		die "$message"
+	elif [[ $delphix_debug = "true" ]] && [[ $stress_ret -ne 0 ]]; then
+		if ! type die >/dev/null 2>&1; then
+			echo "ERROR: no die function defined"
+			exit 1
+		fi
+		die "'__get_stress_option' returned $stress_ret"
+	fi
+}
+
+#
+# Fails if the given stress option was set (unsets it too).
+# Also fails if we are in debug mode and hit an unexpected return code.
+#
+# This function should only be used when sourcing this file.  The script
+# sourcing this file must implement the function "die" or "stress_die" for
+# this method to fail correctly.
+#
+# A caller may define a "stress_die" function if they want extra functionality
+# besides the original "die" method.  See "dx_execute" for an example of this.
+# If no "stress_die" is defined, it will fall back to using the original "die"
+# method for failing.
+#
+function __trigger_unset_stress_option
+{
+	local option=$1
+	local delphix_debug=$(svcprop -p delphix/debug $__DLPX_SVC_MGMT)
+
+	__handle_panic_stress_option "$option" "true"
+
+	local get_err_msg=$(cat <<-EOF
+		import json
+		obj=json.loads('''$__STRESS_OPTIONS_JSON''')
+		print(obj["$option"]["err_msg"])
+	EOF
+	)
+	local message=$(python -c "$get_err_msg")
+
+	__get_unset_stress_option $option "false"
+	local stress_ret=$?
+	if [[ $stress_ret -eq 3 ]]; then
+		type stress_die >/dev/null 2>&1 && stress_die "$message"
+		if ! type die >/dev/null 2>&1; then
+			echo "ERROR: no die function defined"
+			exit 1
+		fi
+		die "$message"
+	elif [[ $delphix_debug = "true" ]] && [[ $stress_ret -ne 0 ]]; then
+		if ! type die >/dev/null 2>&1; then
+			echo "ERROR: no die function defined"
+			exit 1
+		fi
+		die "'__get_unset_stress_option' returned $stress_ret"
+	fi
+}
+
+[[ $# -ge 1 ]] || __dx_upg_stress_options_usage "missing arguments"
+case "$1" in
+"--set")
+	[[ $# -ge 2 ]] || __dx_upg_stress_options_usage "missing arguments"
+	__check_valid_option $2
+	__set_stress_option $2 "false"
+	exit $?
+	;;
+"--set-panic")
+	[[ $# -ge 2 ]] || __dx_upg_stress_options_usage "missing arguments"
+	__check_valid_option $2
+	__set_stress_option $2 "true"
+	exit $?
+	;;
+"--unset")
+	[[ $# -ge 2 ]] || __dx_upg_stress_options_usage "missing arguments"
+	__check_valid_option $2
+	__unset_stress_option $2 "false"
+	exit $?
+	;;
+"--get")
+	[[ $# -ge 2 ]] || __dx_upg_stress_options_usage "missing arguments"
+	__check_valid_option $2
+	__get_stress_option $2 "false"
+	exit $?
+	;;
+"--get-panic")
+	[[ $# -ge 2 ]] || __dx_upg_stress_options_usage "missing arguments"
+	__check_valid_option $2
+	__get_stress_option $2 "true"
+	exit $?
+	;;
+"--panic-or-get-unset")
+	[[ $# -ge 2 ]] || __dx_upg_stress_options_usage "missing arguments"
+	__check_valid_option $2
+
+	# Called when the stress option is set and successfully unset, exit 3.
+	function stress_die
+	{
+		echo $*
+		exit 3
+	}
+
+	# Called when the stress option is set but failed to unset, exit 4.
+	function die
+	{
+		echo $*
+		exit 3
+	}
+
+	__trigger_unset_stress_option $2
+	exit 0
+	;;
+"--get-options-json")
+	echo "$__STRESS_OPTIONS_JSON"
+	exit $?
+	;;
+"--source")
+	# do nothing
+	;;
+*)
+	__dx_upg_stress_options_usage "illegal option '$1'"
+	;;
+esac
+
+# Do not exit here because sourcing this file will exit the parent.


### PR DESCRIPTION
This adds the pause and stress options scripts to the migration image.

Note that for now the scripts are taken as is from the 5.3/stage branch. They have been slightly modified to comply with the shell format checks.

Note that we are going to add some new options and remove those that do not apply to migration in follow-up work, as we will be iterating on the migration-specific stress tests.

## TESTING
ab-pre-push: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/1772/
