### PR TITLE
Store engine uuid before migration

### DIFF
--- a/live-build/misc/migration-scripts/dx_apply
+++ b/live-build/misc/migration-scripts/dx_apply
@@ -195,6 +195,17 @@ cat <<-EOF >"$TMP_ROOT/etc/fstab" || die "Failed to setup /etc/fstab"
 EOF
 
 #
+# On some platforms (currently AWS and new enough versions of ESX), the
+# engine's UUID as reported by the os-level tools changes after
+# migration. This is because of a confusion over the proper endianness of the
+# first three fields of the UUID. To avoid having engine UUIDs change after
+# migration, we store the current UUID before we finish the migration, and
+# then use that on Linux.
+#
+/opt/delphix/server/bin/bos_mgmt get_system_uuid appliance >"$TMP_ROOT/etc/engine-uuid" ||
+	die "failed to copy engine uuid"
+
+#
 # Set things up for the FreeBSD bootloader to provide an option for
 # booting into the Linux environment This happens in two steps:
 # [1] We place vmlinuz and initrd from our migration image into

--- a/upgrade/upgrade-scripts/upgrade-container
+++ b/upgrade/upgrade-scripts/upgrade-container
@@ -605,6 +605,7 @@ function migrate_configuration() {
 		/etc/delphix-interface-names.yaml
 		/etc/default/locale
 		/etc/engine-code
+		/etc/engine-uuid
 		/etc/engine.install
 		/etc/fluent/fluent.conf
 		/etc/issue


### PR DESCRIPTION
This change works with an associated app-gate change that uses the cached UUID in place of the system's detected UUID if the cached version and the system's version are potentially byteswapped versions of each other.

Tested by migrating aws 5.3.5.0 VM, verified that reported UUID remained the same. In addition, ab-pre-push testing is in progress.