### PR TITLE
DLPX-65345 Applying L early release migration image results in two upgrade versions being created

### DIFF
--- a/live-build/build.gradle
+++ b/live-build/build.gradle
@@ -113,6 +113,17 @@ for (variant in allVariants) {
                     inputs.property(envVar, System.getenv(envVar)).optional(true)
                 }
 
+                if (!System.getenv('DELPHIX_APPLIANCE_VERSION')) {
+                    /*
+                     * If we are running the build manually and
+                     * DELPHIX_APPLIANCE_VERSION is not set explicitly,
+                     * just use an arbitrarily high value for the
+                     * appliance version to allow upgrading to the
+                     * produced image.
+                     */
+                    environment 'DELPHIX_APPLIANCE_VERSION', '99.9.9.9'
+                }
+
                 switch (runType) {
                     case upgradeArtifactsRunType:
                         outputs.file "${buildDir}/artifacts/${variant}-${platform}.debs.tar.gz"

--- a/live-build/config/hooks/configuration/81-upgrade-repository.binary
+++ b/live-build/config/hooks/configuration/81-upgrade-repository.binary
@@ -92,25 +92,9 @@ chroot binary dpkg-query -Wf '${Package}=${Version}\n' | sort >packages.list
 
 echo "$APPLIANCE_VARIANT" >variant
 
-if [[ -n "${DELPHIX_APPLIANCE_VERSION:-}" ]]; then
-	#
-	# If the build specified a version for the delphix-entire package,
-	# then use it.
-	#
-	VERSION=$DELPHIX_APPLIANCE_VERSION
-else
-	#
-	# Otherwise, just use a default value for the version, based on when
-	# the build occurs.
-	#
-	# Note that we want to generate the timestamp without any leading
-	# zeroes, because the Delphix API handles versions as integers.
-	# Leading zeroes will be stripped and cause mismatches.
-	#
-	VERSION=$(date '+%Y.%-m.%-d.%-H')
-fi
+test -n "$DELPHIX_APPLIANCE_VERSION"
 
-sed -i "s/@@VERSION@@/$VERSION/" delphix-entire.ctl
+sed -i "s/@@VERSION@@/$DELPHIX_APPLIANCE_VERSION/" delphix-entire.ctl
 sed -i "s/@@PLATFORM@@/$APPLIANCE_PLATFORM/" delphix-entire.ctl
 
 equivs-build delphix-entire.ctl

--- a/live-build/config/hooks/vm-artifacts/90-linux-migration-artifact.binary
+++ b/live-build/config/hooks/vm-artifacts/90-linux-migration-artifact.binary
@@ -85,6 +85,8 @@ mkdir $DEPOT_DIRECTORY
 #
 cp migration-scripts/* $DEPOT_DIRECTORY
 
+test -n "$DELPHIX_APPLIANCE_VERSION"
+
 #
 # There may be a version.info file in the current directory already.
 # That version.info is Linux-specific and does not necessarily have
@@ -118,8 +120,7 @@ cp migration-scripts/* $DEPOT_DIRECTORY
 	# nickname, etc.)
 	#
 	# shellcheck disable=SC2016
-	echo "DLPX_VERSION=$(chroot binary dpkg-query \
-		-Wf '${Version}' delphix-virtualization)"
+	echo "DLPX_VERSION=$DELPHIX_APPLIANCE_VERSION"
 } >$DEPOT_DIRECTORY/version.info
 
 #


### PR DESCRIPTION
In the past the version of the `delphix-virtualization` package would be used to determine the version of the appliance. This was changed, but we forgot to update the logic when generating the migration image.

## Testing

- manually tested building a variant with `DELPHIX_APPLIANCE_VERSION` set and unset on a `bootstrap-18-04` system.
- ab-pre-push: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/1896/
- migration: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/1895/
- Check that after performing a migration we do not see 2 versions anymore: **TODO**