### PR TITLE
LX-1817 /etc/system whitelist file and check for migration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -79,7 +79,9 @@ def shellScripts = fileTree("scripts") +
                    fileTree("live-build/config/hooks").include({ details ->
                         details.file.canExecute()
                    }) +
-                   fileTree("live-build/misc/migration-scripts") +
+                   fileTree("live-build/misc/migration-scripts", {
+                       exclude "etc_system_whitelist"
+                   }) +
                    fileTree("upgrade", {
                        include "prepare"
                    }) +

--- a/live-build/misc/migration-scripts/dx_verify
+++ b/live-build/misc/migration-scripts/dx_verify
@@ -93,8 +93,7 @@ function mount_datasets() {
 	chmod 755 "$root" || die "unable to set permissions for $root"
 	mount -F zfs -o ignoremountpoint "$rds" "$root" || die "unable to mount $rds"
 
-	#TODO dummy files for UpgradeVerify, see LX-1817 and LX-1808
-	touch /var/dlpx-update/"$version"/etc_system_whitelist
+	#TODO dummy file for UpgradeVerify see LX-1808
 	touch /var/dlpx-update/"$version"/dx_upg_stress_options
 
 	#

--- a/live-build/misc/migration-scripts/etc_system_whitelist
+++ b/live-build/misc/migration-scripts/etc_system_whitelist
@@ -1,0 +1,10 @@
+sd:bypass_mode_sense_for_geometry
+zfs_recover
+zfs_vdev_async_read_max_active
+zfs_vdev_async_read_min_active
+zfs_vdev_async_write_max_active
+zfs_vdev_async_write_min_active
+zfs_vdev_sync_read_max_active
+zfs_vdev_sync_read_min_active
+zfs_vdev_sync_write_max_active
+zfs_vdev_sync_write_min_active


### PR DESCRIPTION
### Background 
When migrating from Illumos to Linux, we want to use the existing `EtcSystemWhitelistCheck` from `UpgradeVerify` to make sure that customers have not modified system variables that will not be preserved. 

This check relies on the existence of a whitelist file in the `/var/dlpx-update/<version>` directory. In regular upgrade, it was stored as a `resources` file in the app-gate and placed in the upgrade image as part of the build. Because we use the `appliance-build` gate to build the migration image, I figured placing it here would be a simple solution. This strategy also allows for different whitelist entries between upgrades and migration, if required.

For now, keeping the entries identical makes sense to me. I checked that all the `zfs` tunables in the whitelist still exist and can be re-applied (which will be done in the tunable migration task). `sd:bypass_mode_sense_for_geometry` was added for a VMware emulation issue outlined in https://jira.delphix.com/browse/ESCL-982. I haven't found any evidence that this is applicable on Linux, so we will probably not migrate it, but it's ok if it's set on an Illumos machine. 

### Testing 
**Manual** Built an image with these changes and saw the the appropriate `etc_system_whitelist` file made it into `/var/dlpx-update`. Added a dummy propery to `/etc/system` and saw a critical `UpgradeVerify` failure. Added `zfs_recover` to `/etc/system` and saw no `UpgradeVerify` failures.

**Automated**
git-ab-pre-push --test-upgrade-from 5.3.6.0 (successful):  http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/1917/