### PR TITLE
DLPX-64429 not-in-place upgrade should copy files related to cloud-init

### DIFF
--- a/upgrade/upgrade-scripts/upgrade-container
+++ b/upgrade/upgrade-scripts/upgrade-container
@@ -581,6 +581,7 @@ function migrate_configuration() {
 	while read -r file; do
 		migrate_file "$file"
 	done <<-EOF
+		/etc/cloud/templates/hosts.debian.tmpl
 		/etc/default/nfs-kernel-server
 		/etc/hostid
 		/etc/hostname
@@ -646,6 +647,35 @@ function migrate_configuration() {
 	done <<-EOF
 		/var/lib/nfs
 		/var/target/pr
+	EOF
+
+	#
+	# These directories and files are created by cloud-init. When
+	# cloud-init runs, it stores some metadata such as the instance id,
+	# hostname, timestamps for when given modules were last run.
+	# We also want to persist the network configuration auto-generated
+	# by cloud-init.
+	#
+	# If we do not migrate those files, cloud-init will consider this
+	# system as a new instance and re-configure it. This should not be
+	# an issue in most cases since we have tuned our cloud-init
+	# configuration to eliminate unwanted side-effects on new instance
+	# detection. However, those tunings were done as a precaution and
+	# are not guaranteed to be always sufficient to avoid side-effects.
+	#
+	while read -r dir; do
+		migrate_dir "$dir"
+	done <<-EOF
+		/var/lib/cloud/data
+		/var/lib/cloud/instances
+		/var/lib/cloud/sem
+	EOF
+
+	while read -r file; do
+		migrate_file "$file"
+	done <<-EOF
+		/etc/netplan/50-cloud-init.yaml
+		/var/lib/cloud/instance
 	EOF
 
 	#


### PR DESCRIPTION
- We copy all cloud-init directories that are related to cloud init cache, that is:
`/var/lib/cloud/{data, instance, instances, sem}`
We do not copy the whole `/var/lib/cloud` directory as it contains directories/files managed by other packages (e.g. `/var/lib/cloud/seed`)

- We copy the auto-generated network configuration:
`/etc/netplan/50-cloud-init.yaml`
Note that this file may not be present if the default network configuration was modified. In that case `/etc/netplan/10-delphix.yaml` and `/etc/cloud/cloud.cfg.d/99-disable-network-config.cfg` should be present instead.

- We copy the `/etc/hosts` template file:
`/etc/cloud/templates/hosts.debian.tmpl`
This is the file that is used by cloud-init to auto-generate `/etc/hosts`, so any changes that support wants to make to `/etc/hosts` should be made there or they will be lost.

## Testing
- ab-pre-push: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/1904/
- manually tested not-in-place upgrade and made sure that the system comes back up without any errors. Did a sanity check on cloud-init's `/var/lib/cloud`.