### PR TITLE
DLPX-65276 Create new dataset that will be shared across versions to store rollback and verify logs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,9 @@
 .gradle/
 .gradleUserHome/
 build/
+
+# Ignore IntelliJ .iml files
+*.iml
+
+# Ignore the .idea directory that IntelliJ puts in the root of projects
+.idea

--- a/upgrade/upgrade-scripts/upgrade-container
+++ b/upgrade/upgrade-scripts/upgrade-container
@@ -304,21 +304,6 @@ function create_upgrade_container() {
 	fi
 
 	#
-	# Lastly, we create the log directory and bind mount this into
-	# the container. This is meant as a way for software running in
-	# the container, to share files with software running on the
-	# host; e.g. during upgrade verify, this directory can be used
-	# to store logs, such that they persist after the container is
-	# destroyed.
-	#
-	mkdir -p "$LOG_DIRECTORY" ||
-		die "failed to create directory: '$LOG_DIRECTORY'"
-	cat >>"/etc/systemd/nspawn/$CONTAINER.nspawn" <<-EOF ||
-		Bind=$LOG_DIRECTORY
-	EOF
-		die "failed to add '$LOG_DIRECTORY' to container config file"
-
-	#
 	# We want to enable all available capabilities to the container
 	# that we will use to run the ugprade verification. Ideally, we
 	# would accomplish this by using "CAPABILITY=all" in the


### PR DESCRIPTION
Removed the code where `/var/tmp/delphix-upgrade` folder is created and shared with container. 
This is not necessary anymore as going forward we will have that folder mounting the dataset which will be shared across versions.