### PR TITLE
DLPX-65626 Incorrect value for property UPGRADE_BASE_VERSION set in upgrade properties file during In-Place upgrade

### DIFF
--- a/upgrade/upgrade-scripts/upgrade
+++ b/upgrade/upgrade-scripts/upgrade
@@ -106,6 +106,8 @@ function upgrade_in_place() {
 		;;
 	esac
 
+	pre_upgrade_version=$(get_installed_version)
+
 	CONTAINER=$("$IMAGE_PATH/upgrade-container" create in-place)
 	[[ -n "$CONTAINER" ]] || die "failed to create container"
 
@@ -138,7 +140,7 @@ function upgrade_in_place() {
 		die "failed to set upgrade property 'UPGRADE_BASE_CONTAINER'"
 
 	set_upgrade_property "UPGRADE_BASE_VERSION" \
-		"$(get_installed_version)" ||
+		"$pre_upgrade_version" ||
 		die "failed to set upgrade property 'UPGRADE_BASE_VERSION'"
 
 	#


### PR DESCRIPTION
pre-upgrade-version has to be set before upgrading container for in-place upgrades