### PR TITLE
Require DELPHIX_SIGNATURE_VERSIONS to be passed in

### DIFF
--- a/scripts/build-upgrade-image.sh
+++ b/scripts/build-upgrade-image.sh
@@ -104,11 +104,10 @@ if [[ -n "${DELPHIX_SIGNATURE_TOKEN:-}" ]] && [[ -n "${DELPHIX_SIGNATURE_URL:-}"
 	#
 	# Here, we need to generate signature files for all of the appliance
 	# versions that'll be allowed to upgrade from, using this upgrade
-	# image. For now, we hardcode this to simply generate a signature for
-	# the "5.3" release, but eventually we'll need to update this code to
-	# support more versions (as more linux-based versions are released).
+	# image. We rely on the user of this script to pass in this list
+	# of versions; generally this will be some Jenkins automation.
 	#
-	for signature_version in "5.3"; do
+	for signature_version in $DELPHIX_SIGNATURE_VERSIONS; do
 		curl -s -S -f -H "Content-Type: application/json" \
 			-u "$DELPHIX_SIGNATURE_TOKEN" -d @sign-request.payload \
 			"$DELPHIX_SIGNATURE_URL/upgrade/keyVersion/${signature_version}/sign" \

--- a/scripts/docker-run.sh
+++ b/scripts/docker-run.sh
@@ -61,6 +61,7 @@ $DOCKER_RUN --rm \
 	--env DELPHIX_PLATFORMS \
 	--env DELPHIX_SIGNATURE_URL \
 	--env DELPHIX_SIGNATURE_TOKEN \
+	--env DELPHIX_SIGNATURE_VERSIONS \
 	--volume "$TOP:/opt/appliance-build" \
 	--workdir "/opt/appliance-build" \
 	appliance-build "$@"


### PR DESCRIPTION
This changes which keys are used when signing the upgrade image.

Previously we used a hardcoded value of 5.3, and thus we always signed
the upgrade image with the 5.3 key. Now, we require the user to specify
a space seperated list of versions, and we sign the upgrade image with
the key corresponding to each version in the list.

This is intended to work inconjunction with some Jenkins changes, where
Jenkins will build the correct list of signature versions, based the
specific version of the upgrade image being built.