### PR TITLE
DLPX-65496 Re-adjust dx_apply version checks for migration

### DIFF
--- a/live-build/config/hooks/vm-artifacts/90-linux-migration-artifact.binary
+++ b/live-build/config/hooks/vm-artifacts/90-linux-migration-artifact.binary
@@ -110,7 +110,11 @@ test -n "$DELPHIX_APPLIANCE_VERSION"
 	# DLPX_MIN_VERSION is specified for ensuring that we are
 	# migrating from the right version.
 	#
-	echo "DLPX_MIN_VERSION=5.3.5.0"
+	# Note that this will be checked by the dx_apply script
+	# of migration, so every time we bump this number we
+	# need to bump the one from the checks there too.
+	#
+	echo "DLPX_MIN_VERSION=5.3.6.0"
 
 	#
 	# DLPX_VERSION is set explicitly to match the version of the

--- a/live-build/misc/migration-scripts/dx_apply
+++ b/live-build/misc/migration-scripts/dx_apply
@@ -64,8 +64,10 @@ ARCHIVE_DIR="$1"
 	die "$ARCHIVE_DIR does not have a version.info file"
 
 . "$ARCHIVE_DIR/version.info"
-[[ "$DLPX_MIN_VERSION" == "5.3.5.0" ]] ||
-	die "expected DLPX_MIN_VERSION for migration to be 5.3.5.0"
+MIN_MIGRATION_VERSION="5.3.6.0"
+[[ "$DLPX_MIN_VERSION" == "$MIN_MIGRATION_VERSION" ]] ||
+	die "expected DLPX_MIN_VERSION for migration to be" \
+		"$MIN_MIGRATION_VERSION"
 
 #
 # Ensure that this VM is version 5.3.5.X or greater (but not 5.4 or 6.X).
@@ -75,14 +77,15 @@ CURRENT_VERSION=$(basename "$CURRENT_DDS")
 MAJOR_VERSION_0=$(echo "$CURRENT_VERSION" | cut -d. -f1)
 MAJOR_VERSION_1=$(echo "$CURRENT_VERSION" | cut -d. -f2)
 [[ $MAJOR_VERSION_0 -eq 5 ]] ||
-	die "expected version 5.3.5 or greater but found" \
+	die "expected version $MIN_MIGRATION_VERSION or greater but found" \
 		"$MAJOR_VERSION_0.$MAJOR_VERSION_1.$MINOR_VERSION"
 [[ $MAJOR_VERSION_1 -eq 3 ]] ||
-	die "expected version 5.3.5 or greater but found" \
+	die "expected version $MIN_MIGRATION_VERSION or greater but found" \
 		"$MAJOR_VERSION_0.$MAJOR_VERSION_1.$MINOR_VERSION"
 MINOR_VERSION=$(echo "$CURRENT_VERSION" | cut -d. -f3)
-[[ $MINOR_VERSION -ge 3 ]] ||
-	die "expected version 5.3.5 or greater but found" \
+MIGRATION_MINOR_VERSION=$(echo "$MIN_MIGRATION_VERSION" | cut -d. -f3)
+[[ $MINOR_VERSION -ge $MIGRATION_MINOR_VERSION ]] ||
+	die "expected version $MIN_MIGRATION_VERSION or greater but found" \
 		"$MAJOR_VERSION_0.$MAJOR_VERSION_1.$MINOR_VERSION"
 
 #


### PR DESCRIPTION
`git-ab-pre-push -a --test-upgrade-from 5.3.6.0`:
http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/1991/

^ linux-precommit at dx-test failed because of unrelated known failure

`git-ab-pre-push -a --test-upgrade-from 5.3.5.0`:
http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/1992/

^ Failed as expected with the following message:
```
[2019-08-23T04:33:02.780Z] !!!!!!!!!!!!!!!!!!!
[2019-08-23T04:33:02.780Z] Details: The minimum version required for this upgrade is "5.3.6.0". The Delphix Engine is currently running version "5.3.5.0".
[2019-08-23T04:33:02.780Z] Action: Upgrade to an interim version that is equal to or newer than the minimum required.
[2019-08-23T04:33:02.780Z] ID: exception.upgrade.current_too_old
[2019-08-23T04:33:02.780Z] !!!!!!!!!!!!!!!!!!!
```