### PR TITLE
LX-1948 migration: add first round of stress test options (appliance-build part)

### DIFF
--- a/live-build/misc/migration-scripts/dx_upg_stress_options
+++ b/live-build/misc/migration-scripts/dx_upg_stress_options
@@ -116,6 +116,41 @@ __STRESS_OPTIONS_JSON=$(
 		    "location": "mgmt service (after point of no return)",
 		    "err_msg": "Stress option triggered before enabling sources.",
 		    "auto_unset": true
+		},
+		"STRESS_MIGRATION_FAIL_BEGIN_MIGRATION_SERVICE": {
+		    "location": "migration service",
+		    "err_msg": "Stress option triggered starting migration service.",
+		    "auto_unset": true
+		},
+		"STRESS_MIGRATION_FAIL_BEFORE_DOMAIN0_IMPORT": {
+		    "location": "migration service",
+		    "err_msg": "Stress option triggered before importing domain0.",
+		    "auto_unset": true
+		},
+		"STRESS_MIGRATION_FAIL_AFTER_DOMAIN0_IMPORT": {
+		    "location": "migration service",
+		    "err_msg": "Stress option triggered after importing domain0.",
+		    "auto_unset": true
+		},
+		"STRESS_MIGRATION_FAIL_AFTER_ZFS_MOUNT": {
+		    "location": "migration service",
+		    "err_msg": "Stress option triggered after zfs mount -a.",
+		    "auto_unset": true
+		},
+		"STRESS_MIGRATION_FAIL_AFTER_MOUNT_PERMISSION_FIX": {
+		    "location": "migration service",
+		    "err_msg": "Stress option triggered after fixing mount permissions.",
+		    "auto_unset": true
+		},
+		"STRESS_MIGRATION_FAIL_BEFORE_MIGRATE_CONFIG": {
+		    "location": "migration service",
+		    "err_msg": "Stress option triggered before calling migrate-config.",
+		    "auto_unset": true
+		},
+		"STRESS_MIGRATION_FAIL_AFTER_MIGRATE_CONFIG": {
+		    "location": "migration service",
+		    "err_msg": "Stress option triggered after calling migrate-config.",
+		    "auto_unset": true
 		}
 		}
 	EOF


### PR DESCRIPTION
This adds a bunch of stress options to test failures during migration.
This is not the final set of options but this will allow implementing QA tasks.

## Related changes
- app-gate: http://reviews.delphix.com/r/52088/
- delphix-platform: https://github.com/delphix/delphix-platform/pull/122 (should be pushed last)

## Next steps
Write BlackBox tests to trigger those options and test that migration can successfully complete.

## Testing
- ab-pre-push, including related changes: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/2004/
- manually test roll forward: set 2 of the stress options before upgrade, perform upgrade, and observe delphix-migration failing at boot time. Run `migrationctl resume` to resume the migration, which first triggers then second stress options. Run it again and verify that migration completes successfully.
