### PR TITLE
Upgrade image file is better left uncompressed

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ directory:
 
     $ ls -lh build/artifacts/
     total 837M
-    -rw-r--r-- 1 root root 837M Jan 11 22:35 internal-minimal.upgrade.tar.gz
+    -rw-r--r-- 1 root root 837M Jan 11 22:35 internal-minimal.upgrade.tar
 
 ## Using Gradle
 

--- a/scripts/build-upgrade-image.sh
+++ b/scripts/build-upgrade-image.sh
@@ -123,11 +123,11 @@ fi
 set -o xtrace
 
 # shellcheck disable=SC2046
-tar -I pigz -cf "$APPLIANCE_VARIANT.upgrade.tar.gz" \
+tar -cf "$APPLIANCE_VARIANT.upgrade.tar" \
 	$(ls SHA256SUMS.sig.* 2>/dev/null) \
 	SHA256SUMS \
 	version.info \
 	prepare \
 	payload.tar.gz
 
-mv "$APPLIANCE_VARIANT.upgrade.tar.gz" "$TOP/build/artifacts"
+mv "$APPLIANCE_VARIANT.upgrade.tar" "$TOP/build/artifacts"

--- a/upgrade/README.md
+++ b/upgrade/README.md
@@ -37,7 +37,7 @@ Run this command on "dlpxdc.co" to create the VM used to do the upgrade:
 Log into that VM using the "delphix" user, and run these commands:
 
     $ download-latest-image internal-dev
-    $ sudo unpack-image internal-dev.upgrade.tar.gz
+    $ sudo unpack-image internal-dev.upgrade.tar
     $ sudo /var/dlpx-update/latest/upgrade -v deferred
 
 ## FAQ


### PR DESCRIPTION
The file we use for the upgrade image is better left uncompressed
because most of its contents is already compressed. Thus, by having
the file compressed as well, we're mostly wasting resources attempting
to compress (and later decompress) data that is already compressed.

If we leave the file uncompressed, it's actually slightly smaller in
size, than the compressed version of the same data:

    $ du -k internal-dev.upgrade.tar*
    5615228 internal-dev.upgrade.tar
    5616954 internal-dev.upgrade.tar.gz

    $ file internal-dev.upgrade.tar*
    internal-dev.upgrade.tar:    POSIX tar archive (GNU)
    internal-dev.upgrade.tar.gz: gzip compressed data, last modified: Tue Aug 27 12:54:30 2019, from Unix

    $ tar --list -f internal-dev.upgrade.tar
    SHA256SUMS.sig.5.3
    SHA256SUMS
    version.info
    prepare
    payload.tar.gz

    $ tar --list -f internal-dev.upgrade.tar.gz
    SHA256SUMS.sig.5.3
    SHA256SUMS
    version.info
    prepare
    payload.tar.gz