### PR TITLE
Rely on caller to provide upgrade minimum versions

### DIFF
--- a/scripts/docker-run.sh
+++ b/scripts/docker-run.sh
@@ -62,6 +62,8 @@ $DOCKER_RUN --rm \
 	--env DELPHIX_SIGNATURE_URL \
 	--env DELPHIX_SIGNATURE_TOKEN \
 	--env DELPHIX_SIGNATURE_VERSIONS \
+	--env DELPHIX_UPGRADE_MINIMUM_VERSION \
+	--env DELPHIX_UPGRADE_MINIMUM_REBOOT_OPTIONAL_VERSION \
 	--volume "$TOP:/opt/appliance-build" \
 	--workdir "/opt/appliance-build" \
 	appliance-build "$@"

--- a/upgrade/version.info.template
+++ b/upgrade/version.info.template
@@ -44,7 +44,7 @@ VERSION=@@VERSION@@
 # image has to be compatible with, and is typically set to be 2 major
 # versions behind the latest version.
 #
-MINIMUM_VERSION=5.3.0.0
+MINIMUM_VERSION=@@MINIMUM_VERSION@@
 
 #
 # The minimum version from which a reboot after upgrade is optional.
@@ -56,4 +56,4 @@ MINIMUM_VERSION=5.3.0.0
 # This version must be equal to, or greater, than the version specified by
 # MINIMUM_VERSION above.
 #
-MINIMUM_REBOOT_OPTIONAL_VERSION=5.3.0.0
+MINIMUM_REBOOT_OPTIONAL_VERSION=@@MINIMUM_REBOOT_OPTIONAL_VERSION@@


### PR DESCRIPTION
This change modifies how we populate the "version.info" file of an
upgrade image. Rather than having the "minimum version" and "minimum
reboot optinal version" fields be stored directly in the template file,
we now rely on the caller to pass in those files. Generally, this will
be passed in by our Jenkins automation.