### PR TITLE
Use compression on rpool by default

### DIFF
--- a/live-build/config/hooks/vm-artifacts/90-raw-disk-image.binary
+++ b/live-build/config/hooks/vm-artifacts/90-raw-disk-image.binary
@@ -101,6 +101,7 @@ zpool create -d \
 	-o version=28 \
 	-O canmount=off \
 	-O mountpoint=none \
+	-O compression=on \
 	-R "$DIRECTORY" \
 	rpool "/dev/mapper/${LOOPNAME}p1"
 
@@ -116,24 +117,20 @@ zfs create \
 
 zfs create \
 	-o canmount=noauto \
-	-o compression=on \
 	-o mountpoint=/ \
 	"rpool/ROOT/$FSNAME/root"
 
 zfs mount "rpool/ROOT/$FSNAME/root"
 
 zfs create \
-	-o compression=on \
 	-o mountpoint=legacy \
 	"rpool/ROOT/$FSNAME/home"
 
 zfs create \
-	-o compression=on \
 	-o mountpoint=legacy \
 	"rpool/ROOT/$FSNAME/data"
 
 zfs create \
-	-o compression=on \
 	-o mountpoint=legacy \
 	"rpool/ROOT/$FSNAME/log"
 
@@ -155,7 +152,6 @@ zfs create \
 # make changes to it, and then quickly unmount it.
 #
 zfs create \
-	-o compression=on \
 	-o mountpoint=legacy \
 	rpool/grub
 
@@ -170,7 +166,6 @@ zfs create \
 # first boot or upgrade.
 #
 zfs create \
-	-o compression=on \
 	-o mountpoint=legacy \
 	rpool/crashdump
 

--- a/live-build/misc/migration-scripts/dx_apply
+++ b/live-build/misc/migration-scripts/dx_apply
@@ -140,7 +140,6 @@ zfs create \
 
 zfs create \
 	-o canmount=noauto \
-	-o compression=on \
 	-o mountpoint="$TMP_ROOT" \
 	"$RPOOL/ROOT/$FSNAME/root" ||
 	die "failed to create linux dataset $RPOOL/ROOT/$FSNAME/root"
@@ -149,19 +148,16 @@ zfs mount "$RPOOL/ROOT/$FSNAME/root" ||
 	die "failed to mount $RPOOL/ROOT/$FSNAME/root in temporary dir $TMP_ROOT"
 
 zfs create \
-	-o compression=on \
 	-o mountpoint=legacy \
 	"$RPOOL/ROOT/$FSNAME/home" ||
 	die "failed to create linux dataset $RPOOL/ROOT/$FSNAME/home"
 
 zfs create \
-	-o compression=on \
 	-o mountpoint=legacy \
 	"$RPOOL/ROOT/$FSNAME/data" ||
 	die "failed to create linux dataset $RPOOL/ROOT/$FSNAME/data"
 
 zfs create \
-	-o compression=on \
 	-o mountpoint=legacy \
 	"$RPOOL/ROOT/$FSNAME/log" ||
 	die "failed to create linux dataset $RPOOL/ROOT/$FSNAME/log"

--- a/live-build/misc/migration-scripts/dx_execute
+++ b/live-build/misc/migration-scripts/dx_execute
@@ -157,8 +157,10 @@ CUR_VAR_DLPX=$(zfs list -Ho name /var/delphix)
 cleanup_leftover_dataset "${CUR_VAR_DLPX}@migration"
 zfs snapshot "${CUR_VAR_DLPX}@migration" ||
 	die "failed to create snapshot '${CUR_VAR_DLPX}@migration'"
-zfs clone -o compression=on -o mountpoint=legacy \
-	"${CUR_VAR_DLPX}@migration" "$LX_VAR_DLPX" ||
+zfs clone \
+	-o mountpoint=legacy \
+	"${CUR_VAR_DLPX}@migration" \
+	"$LX_VAR_DLPX" ||
 	die "failed to clone dataset ${CUR_VAR_DLPX}@migration"
 
 #
@@ -174,8 +176,10 @@ cleanup_leftover_dataset "${CUR_HOME}@migration"
 cleanup_leftover_dataset rpool/illumos-home
 zfs snapshot "${CUR_HOME}@migration" ||
 	die "failed to create snapshot '${CUR_HOME}@migration'"
-zfs clone -o compression=on -o mountpoint=legacy \
-	"${CUR_HOME}@migration" rpool/illumos-home ||
+zfs clone \
+	-o mountpoint=legacy \
+	"${CUR_HOME}@migration" \
+	rpool/illumos-home ||
 	die "failed to clone dataset ${CUR_HOME}@migration"
 
 #

--- a/upgrade/upgrade-scripts/upgrade-container
+++ b/upgrade/upgrade-scripts/upgrade-container
@@ -120,7 +120,6 @@ function create_upgrade_container() {
 	in-place | rollback)
 		zfs clone \
 			-o canmount=noauto \
-			-o compression=on \
 			-o mountpoint="$DIRECTORY" \
 			"$ROOTFS_DATASET/root@$SNAPSHOT_NAME" \
 			"rpool/ROOT/$CONTAINER/root" ||
@@ -132,7 +131,6 @@ function create_upgrade_container() {
 	not-in-place)
 		zfs create \
 			-o canmount=noauto \
-			-o compression=on \
 			-o mountpoint="$DIRECTORY" \
 			"rpool/ROOT/$CONTAINER/root" ||
 			die "failed to create upgrade / filesystem"
@@ -143,21 +141,18 @@ function create_upgrade_container() {
 	esac
 
 	zfs clone \
-		-o compression=on \
 		-o mountpoint=legacy \
 		"$ROOTFS_DATASET/home@$SNAPSHOT_NAME" \
 		"rpool/ROOT/$CONTAINER/home" ||
 		die "failed to create upgrade /export/home clone"
 
 	zfs clone \
-		-o compression=on \
 		-o mountpoint=legacy \
 		"$ROOTFS_DATASET/data@$SNAPSHOT_NAME" \
 		"rpool/ROOT/$CONTAINER/data" ||
 		die "failed to create upgrade /var/delphix clone"
 
 	zfs clone \
-		-o compression=on \
 		-o mountpoint=legacy \
 		"$ROOTFS_DATASET/log@$SNAPSHOT_NAME" \
 		"rpool/ROOT/$CONTAINER/log" ||


### PR DESCRIPTION
Turning on compression on rpool makes sure it is inherited
by all the other datasets, so we do not need to set it
explicitly on each dataset we create.

## Motivation
Simplify our ZFS setup and reduce differences between Linux native and migrated systems.

## Testing
- ab-pre-push: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/2022/
- migration: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/2023/
- Manually verified that compression was set on all datasets on a fresh Linux system and after a migration.