### PR TITLE
Sporadic failures when loading the crash kernel in low memory due to KASLR

### DIFF
--- a/live-build/misc/migration-scripts/dx_apply
+++ b/live-build/misc/migration-scripts/dx_apply
@@ -279,7 +279,8 @@ LX_CMDLINE=(
 	"root=ZFS=$RPOOL/ROOT/$FSNAME/root"
 	'console=tty0 console=ttyS0,115200n8'
 	'ipv6.disable=1'
-	'crashkernel=1024M-:512M'
+	'crashkernel=256M,high'
+	'crashkernel=256M,low'
 	'zfsforce=1'
 	'mitigations=off'
 )


### PR DESCRIPTION
The respective change of the commit in delphix-platform with
the same title.

### Testing

git-ab-pre-push --test-upgrade-from 5.3.6.0:
http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/2209/