### PR TITLE
[Backport of LB-209 to 6.0/release] Want to consume new mirror for pr…

### DIFF
--- a/branch.config
+++ b/branch.config
@@ -1,0 +1,13 @@
+#
+# Copyright (c) 2019 by Delphix. All rights reserved.
+#
+
+#
+# The "BRANCH" parameter tracks the upstream branch of appliance-build. It is
+# used to determine which branch of the linux package mirror will be used for
+# the build if UPSTREAM_PRODUCT_BRANCH is not set. UPSTREAM_PRODUCT_BRANCH is
+# set when appliance build is built by the appliance-build Jenkins job. The
+# UPSTREAM_BRANCH parameter should be updated by the release lead on branching
+#
+
+UPSTREAM_BRANCH="6.0/release"

--- a/scripts/build-ancillary-repository.sh
+++ b/scripts/build-ancillary-repository.sh
@@ -142,27 +142,30 @@ function build_ancillary_repository() {
 #    environment variables, and the script will work as expected.
 #
 
-upstream_branch="${UPSTREAM_PRODUCT_BRANCH:-master}"
+if [[ -z "$UPSTREAM_BRANCH" ]]; then
+	echo "UPSTREAM_BRANCH is not set."
+	exit 1
+fi
 
 AWS_S3_URI_VIRTUALIZATION=$(resolve_s3_uri \
 	"$AWS_S3_URI_VIRTUALIZATION" \
 	"$AWS_S3_PREFIX_VIRTUALIZATION" \
-	"dlpx-app-gate/${upstream_branch}/build-package/post-push/latest")
+	"dlpx-app-gate/${UPSTREAM_BRANCH}/build-package/post-push/latest")
 
 AWS_S3_URI_MASKING=$(resolve_s3_uri \
 	"$AWS_S3_URI_MASKING" \
 	"$AWS_S3_PREFIX_MASKING" \
-	"dms-core-gate/${upstream_branch}/build-package/post-push/latest")
+	"dms-core-gate/${UPSTREAM_BRANCH}/build-package/post-push/latest")
 
 AWS_S3_URI_USERLAND_PKGS=$(resolve_s3_uri \
 	"$AWS_S3_URI_USERLAND_PKGS" \
 	"$AWS_S3_PREFIX_USERLAND_PKGS" \
-	"devops-gate/master/linux-pkg-build/${upstream_branch}/userland/post-push/latest")
+	"devops-gate/master/linux-pkg-build/${UPSTREAM_BRANCH}/userland/post-push/latest")
 
 AWS_S3_URI_KERNEL_PKGS=$(resolve_s3_uri \
 	"$AWS_S3_URI_KERNEL_PKGS" \
 	"$AWS_S3_PREFIX_KERNEL_PKGS" \
-	"devops-gate/master/linux-pkg-build/${upstream_branch}/kernel/post-push/latest")
+	"devops-gate/master/linux-pkg-build/${UPSTREAM_BRANCH}/kernel/post-push/latest")
 
 #
 # All package files will be placed into this temporary directory, such

--- a/scripts/docker-run.sh
+++ b/scripts/docker-run.sh
@@ -38,6 +38,29 @@ else
 	DOCKER_RUN="docker run"
 fi
 
+#
+# Set UPSTREAM_BRANCH. This will determine which version of the linux package
+# mirror is used.
+#
+if [[ -z "$UPSTREAM_PRODUCT_BRANCH" ]]; then
+	echo "UPSTREAM_PRODUCT_BRANCH is not set."
+	if ! source "$TOP/branch.config" 2>/dev/null; then
+		echo "No branch.config file found in repo root."
+		exit 1
+	fi
+
+	if [[ -z "$UPSTREAM_BRANCH" ]]; then
+		echo "UPSTREAM_BRANCH parameter was not sourced from branch.config." \
+			"Ensure branch.config is properly formatted with e.g." \
+			"UPSTREAM_BRANCH=\"<upstream-product-branch>\""
+		exit 1
+	fi
+	echo "Defaulting to branch $UPSTREAM_BRANCH set in branch.config."
+else
+	UPSTREAM_BRANCH="$UPSTREAM_PRODUCT_BRANCH"
+fi
+echo "Running with UPSTREAM_BRANCH set to ${UPSTREAM_BRANCH}"
+
 $DOCKER_RUN --rm \
 	--privileged \
 	--network host \
@@ -64,6 +87,7 @@ $DOCKER_RUN --rm \
 	--env DELPHIX_SIGNATURE_VERSIONS \
 	--env DELPHIX_UPGRADE_MINIMUM_VERSION \
 	--env DELPHIX_UPGRADE_MINIMUM_REBOOT_OPTIONAL_VERSION \
+	--env UPSTREAM_BRANCH="$UPSTREAM_BRANCH" \
 	--volume "$TOP:/opt/appliance-build" \
 	--workdir "/opt/appliance-build" \
 	appliance-build "$@"


### PR DESCRIPTION
Backport of commit 4aa9fc996e5c589545f507eb8d7d309f68e96aed on master to allow appliance-build to use the package mirror for 6.0/release builds.

Testing link (kicked off appliance-build-stage1 without UPSTREAM_PRODUCT_BRANCH set and verified `Defaulting to branch 6.0/release set in branch.config` was present in jenkins log )
http://collins.d.delphix.com:35379/job/devops-gate/job/master/job/appliance-build-stage1/job/master/job/post-push/359/consoleFull