### PR TITLE
DLPX-66286 Interrupting a running upgrade verify can leave the engine not-upgradable

### DIFF
--- a/live-build/misc/migration-scripts/dx_apply
+++ b/live-build/misc/migration-scripts/dx_apply
@@ -113,21 +113,12 @@ rm -f /boot/vmlinuz-* /boot/initrd.img-* ||
 zfs destroy -r "$RPOOL/ROOT" 2>/dev/null
 zfs list "$RPOOL/ROOT" 2>/dev/null &&
 	die "could not destroy linux root dataset from previous run"
-sed -i '/set lxcmdline/d' /boot/menu.rc.local
-[[ "$(grep -cF 'set lxcmdline' /boot/menu.rc.local)" -eq 0 ]] ||
-	die "failed to cleanup lxcmdline from previous run"
-sed -i '/set mainmenu_caption\[8\]/d' /boot/menu.rc.local
-[[ "$(grep -cF 'mainmenu_caption[8]' /boot/menu.rc.local)" -eq 0 ]] ||
-	die "failed to cleanup mainmenu_caption from previous run"
-sed -i '/set mainansi_caption\[8\]/d' /boot/menu.rc.local
-[[ "$(grep -cF 'mainansi_caption[8]' /boot/menu.rc.local)" -eq 0 ]] ||
-	die "failed to cleanup mainansi_caption from previous run"
-sed -i '/set mainmenu_keycode\[8\]/d' /boot/menu.rc.local
-[[ "$(grep -cF 'mainmenu_keycode[8]' /boot/menu.rc.local)" -eq 0 ]] ||
-	die "failed to cleanup mainmenu_keycode from previous run"
-sed -i '/set mainmenu_command\[8\]/d' /boot/menu.rc.local
-[[ "$(grep -cF 'mainmenu_command[8]' /boot/menu.rc.local)" -eq 0 ]] ||
-	die "failed to cleanup mainmenu_command from previous run"
+
+#
+# Save a copy of the boot menu to restore if we aren't upgrading
+#
+cp "/boot/menu.rc.local" "/boot/menu.rc.local.copy" ||
+	die "failed to save copy of /boot/menu.rc.local"
 
 report_progress_inc 20
 

--- a/live-build/misc/migration-scripts/dx_delete
+++ b/live-build/misc/migration-scripts/dx_delete
@@ -39,10 +39,84 @@ function die() {
 # names are randomly generated.
 #
 
-linux_dataset="rpool/ROOT"
-if ! zfs list ${linux_dataset} &>/dev/null; then
-	echo "Linux dataset '${linux_dataset}' is not installed."
+LX_DATASET="rpool/ROOT"
+if ! zfs list ${LX_DATASET} &>/dev/null; then
+	echo "Linux dataset '${LX_DATASET}' is not installed."
 	exit 0
 fi
 
-zfs destroy -r ${linux_dataset} || die "Failed to destroy Linux dataset '${linux_dataset}'"
+LX_RDS_PARENT=$(zfs list -o name -H -d 1 "$LX_DATASET" | tail -n 1)
+[[ -n $LX_RDS_PARENT ]] || die "could not find Linux RDS parent dataset"
+LX_CONTAINER="${LX_RDS_PARENT##*/}"
+LX_RDS_TMP_ROOT_MOUNT="/tmp/$LX_CONTAINER/root"
+
+MDS_SNAPNAME="MDS-CLONE-upgradeverify"
+MDS_CLONE=domain0/$MDS_SNAPNAME
+SVC=svc:/system/delphix/postgres:$MDS_SNAPNAME
+PG_DATA=/$MDS_CLONE/db
+
+BOOT_MENU=/boot/menu.rc.local
+BOOT_MENU_COPY=$BOOT_MENU.copy
+
+function dx_apply_cleanup() {
+	#
+	# Restore original version of the bootloader
+	#
+	if [[ -e $BOOT_MENU_COPY ]]; then
+		mv $BOOT_MENU_COPY $BOOT_MENU ||
+			die "failed to restore copy of $BOOT_MENU"
+	fi
+
+	rm -f /boot/vmlinuz-* /boot/initrd.img-* ||
+		die "failed to destroy previously copied Linux kernel data"
+}
+
+function dx_verify_cleanup() {
+	#
+	# dx_verify creates a clone of the MDS dataset and the postgres
+	# service as well as a clone of /var/delphix for masking validation.
+	# If any are left, clean them up. (This logic is based on dx_manage_pg
+	# stop and cleanup.)
+	#
+	local sta
+	sta=$(svcs -Ho sta $SVC)
+	if [[ -n "$sta" ]]; then
+		/usr/sbin/svcadm disable -s $SVC ||
+			die "unable to disable SMF service: $SVC"
+		/usr/sbin/svccfg delete -f $SVC ||
+			die "unable to delete SMF service: $SVC"
+	fi
+
+	#
+	# Clean up the postmaster.pid leftover from the main MDS in the
+	# snapshot. This needs to be done after disabling the SMF service in
+	# case the postmaster.pid was instead from the active clone.
+	#
+	if [[ -e $PG_DATA/postmaster.pid ]]; then
+		echo "renaming $PG_DATA/postmaster.pid to $PG_DATA/postmaster.pid.original"
+		mv $PG_DATA/postmaster.pid $PG_DATA/postmaster.pid.original ||
+			echo "failed to move postmaster.pid file"
+	fi
+
+	[[ $(zfs list domain0/mds@$MDS_SNAPNAME) ]] &&
+		zfs destroy -R "domain0/mds@$MDS_SNAPNAME"
+	[[ $(zfs list domain0/mds@$MDS_SNAPNAME) ]] &&
+		die "unable to cleanup domain0/mds@$MDS_SNAPNAME"
+
+	runningVar=$(mount | awk '/^\/var\/delphix /{ print $3 }')
+	[[ $(zfs list "$runningVar@$MDS_SNAPNAME") ]] &&
+		zfs destroy -R "$runningVar@$MDS_SNAPNAME"
+	[[ $(zfs list "$runningVar@$MDS_SNAPNAME") ]] &&
+		die "unable to cleanup $runningVar@$MDS_SNAPNAME"
+}
+
+dx_apply_cleanup
+dx_verify_cleanup
+
+#
+# Recursively destroy and force-unmount the Linux Root Dataset. Even though all the
+# datasets are cleaned up in a normal execution of Verify, this handles the case when
+# it was cancelled early.
+#
+zfs destroy -rf ${LX_DATASET} || die "Failed to destroy Linux dataset '${LX_DATASET}'"
+rm -rf "$LX_RDS_TMP_ROOT_MOUNT"

--- a/live-build/misc/migration-scripts/dx_verify
+++ b/live-build/misc/migration-scripts/dx_verify
@@ -104,15 +104,13 @@ function mount_datasets() {
 		die "unable to create snapshot $runningVar@$MDS_SNAPNAME"
 	zfs clone "$runningVar@$MDS_SNAPNAME" "$runningVar/$MDS_SNAPNAME" ||
 		die "unable to create $runningVar/$MDS_SNAPNAME"
-	zfs destroy -d "$runningVar@$MDS_SNAPNAME" ||
-		die "unable to defer destroy $runningVar@$MDS_SNAPNAME"
 	mount -F zfs "$runningVar/$MDS_SNAPNAME" "$root/var/delphix" ||
 		die "unable to mount $root/var/delphix"
 }
 
 function cleanup_datasets() {
 	if [[ -n "$runningVar" ]]; then
-		zfs destroy -f "$runningVar/$MDS_SNAPNAME"
+		zfs destroy -R "$runningVar@$MDS_SNAPNAME"
 	fi
 	umount -f "$root"
 	rmdir "$root"


### PR DESCRIPTION
Extending `dx_delete` for migration to clean up the state of verify, even when it was cancelled in the middle of an operation. This includes: undoing changes to the bootloader, removing the MDS clone service and datasets and destroying `rpool/ROOT` using `-f`, which force unmounts its children as well. 

This was all based on what `dx_apply` and `dx_verify` do to clean up after themselves and replicating that logic in `dx_delete` so we can guarantee ending up in a "clean" state if we're cancelled or fail unexpectedly. 

I manually tested this by running a verify and cancelling it at various stages (roughly during `dx_apply` and `dx_verify`), ensuring that the cancel succeeded and then checking that a subsequent verify can run successfully as well. 

Automated testing: 
`git-ab-pre-push --test-upgrade-from 5.3.6.0` (diff 1) http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/2375/
`git-ab-pre-push --test-upgrade-from 5.3.6.0` (diff 2) http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/2385/
`git-ab-pre-push --test-upgrade-from 5.3.6.0` (diff 3) http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/2391/