### PR TITLE
DLPX-66946 Set 'elevator=noop' GRUB option for first boot after migration

### DIFF
--- a/live-build/misc/migration-scripts/dx_apply
+++ b/live-build/misc/migration-scripts/dx_apply
@@ -283,6 +283,7 @@ LX_CMDLINE=(
 	'crashkernel=256M,low'
 	'zfsforce=1'
 	'mitigations=off'
+	'elevator=noop'
 )
 
 #


### PR DESCRIPTION
This migration change is equivalent to https://github.com/delphix/delphix-platform/pull/155 PR