### PR TITLE
DLPX-66696 migration: add stress options in the pre-reboot dx scripts

### DIFF
--- a/live-build/misc/migration-scripts/dx_apply
+++ b/live-build/misc/migration-scripts/dx_apply
@@ -97,6 +97,11 @@ MIGRATION_MINOR_VERSION=$(echo "$MIN_MIGRATION_VERSION" | cut -d. -f3)
 	die "expected version $MIN_MIGRATION_VERSION or greater but found" \
 		"$MAJOR_VERSION_0.$MAJOR_VERSION_1.$MINOR_VERSION"
 
+DX_UPG_STRESS=$ARCHIVE_DIR/dx_upg_stress_options
+# shellcheck source=/dev/null
+. $DX_UPG_STRESS --source
+__trigger_unset_stress_option "STRESS_DX_APPLY_FAIL_AFTER_VERSION_CHECK"
+
 #
 # Get the root dataset and the current ZFS pool that we're currently using.
 #
@@ -337,6 +342,8 @@ MAIN_MENU_FICL=(
 	[[ $(find . -mindepth 1 | wc -l) -eq 0 ]] ||
 		die "linux dataset for /var/delphix contains unexpected files"
 ) || die "verification of /var/delphix failed"
+
+__trigger_unset_stress_option "STRESS_DX_APPLY_FAIL_BEFORE_UNMOUNTING"
 
 umount "$TMP_ROOT/var/log" ||
 	die "couldn't unmount linux dataset $TMP_ROOT/var/log"

--- a/live-build/misc/migration-scripts/dx_execute
+++ b/live-build/misc/migration-scripts/dx_execute
@@ -33,6 +33,9 @@ umask 0022
 set -o pipefail
 
 DX_UPG_PAUSE="${BASH_SOURCE%/*}/dx_upg_pause_options"
+DX_UPG_STRESS="${BASH_SOURCE%/*}/dx_upg_stress_options"
+# shellcheck source=/dev/null
+. $DX_UPG_STRESS --source
 
 function die() {
 	echo "$(basename "$0"): $*" >&2
@@ -58,7 +61,7 @@ function cleanup_leftover_dataset() {
 	local dataset=$1
 
 	if zfs list "$dataset" &>/dev/null; then
-		zfs destroy "$dataset" ||
+		zfs destroy -R "$dataset" ||
 			die "Failed to destroy leftover dataset '$dataset'"
 	fi
 }
@@ -129,6 +132,9 @@ mount -F zfs -o ignoremountpoint "$LX_RDS" "$LX_RDS_MOUNT" ||
 	die "failed to mount the root Linux dataset"
 "${LX_RDS_MOUNT}${MIGRATION_SCRIPT}" pre-upgrade \
 	>>/var/delphix/migration/log 2>&1 || die "failed to run migration"
+
+__trigger_unset_stress_option "STRESS_DX_EXECUTE_FAIL_AFTER_CONFIG_MIGRATION"
+
 #
 # Create a flag file that notifies the delphix-migration service that
 # post-reboot migration logic should be run. Note that the /var/delphix
@@ -213,6 +219,8 @@ timeout 10 /opt/delphix/server/bin/jmxtool boot upgrade server
 
 $DX_UPG_PAUSE --pause "PAUSE_IN_DX_EXECUTE_BEFORE_RESTART" ||
 	die "failed to pause fully on stress option"
+
+__trigger_unset_stress_option "STRESS_DX_EXECUTE_FAIL_BEFORE_REBOOT"
 
 # Constants used by the uadmin syscall.
 A_SHUTDOWN=2

--- a/live-build/misc/migration-scripts/dx_upg_stress_options
+++ b/live-build/misc/migration-scripts/dx_upg_stress_options
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (c) 2016, 2017 by Delphix. All rights reserved.
+# Copyright (c) 2016, 2019 by Delphix. All rights reserved.
 #
 
 #
@@ -22,6 +22,11 @@ __STRESS_OPTIONS_JSON=$(
 		    "err_msg": "Stress option triggered after version check.",
 		    "auto_unset": true
 		},
+		"STRESS_DX_APPLY_FAIL_BEFORE_UNMOUNTING": {
+		    "location": "pre-reboot",
+		    "err_msg": "Stress option triggered before dx_apply dataset cleanup.",
+		    "auto_unset": true
+		},
 		"STRESS_DX_INSTALL_ARCHIVE_FAIL_AFTER_VERIFY_DX_ARCHIVE": {
 		    "location": "pre-reboot",
 		    "err_msg": "Stress option triggered after verify_dx_archive.",
@@ -34,7 +39,12 @@ __STRESS_OPTIONS_JSON=$(
 		},
 		"STRESS_DX_VERIFY_FAIL_AFTER_TEST_MIGRATION": {
 		    "location": "pre-reboot",
-		    "err_msg": "Stress option triggered after testing migration.",
+		    "err_msg": "Stress option triggered after upgrade-verify.jar.",
+		    "auto_unset": true
+		},
+		"STRESS_DX_EXECUTE_FAIL_AFTER_CONFIG_MIGRATION": {
+		    "location": "pre-reboot",
+		    "err_msg": "Stress option triggered after migrating OS config.",
 		    "auto_unset": true
 		},
 		"STRESS_DX_EXECUTE_FAIL_BEFORE_REBOOT": {

--- a/live-build/misc/migration-scripts/dx_verify
+++ b/live-build/misc/migration-scripts/dx_verify
@@ -198,7 +198,12 @@ report_progress_inc 0 "preparing for verification"
 mount_datasets "$version"
 report_progress_inc 20 "running upgrade checks"
 run_upgrade_verify "$output" "$format" "$locale" 20 95
-#TODO LX-1808 stress options
+
+DX_UPG_STRESS="${BASH_SOURCE%/*}/dx_upg_stress_options"
+# shellcheck source=/dev/null
+. $DX_UPG_STRESS --source
+__trigger_unset_stress_option "STRESS_DX_VERIFY_FAIL_AFTER_TEST_MIGRATION"
+
 test_masking
 report_progress_inc 95 "cleaning up post-verification"
 cleanup


### PR DESCRIPTION
Add stress options to `dx_apply`, `dx_verify` and `dx_execute` to make sure that the pre-upgrade migration processes can recover from unexpected failures. 

I found that after hitting `STRESS_DX_EXECUTE_FAIL_BEFORE_REBOOT`, `cleanup_leftover_dataset` in `dx_excute`  fail to destroy snapshots with residual clones, so I added `-R` to clean those up. I also renamed `STRESS_DX_VERIFY_FAIL_AFTER_TEST_MIGRATION` for clarity. 

Manually tested that when set, the stress options do cause the scripts to fail at the expected point. Confirmed that the prior state of the failed runs was cleaned up and the run was successful.

`git-ab-pre-push --test-upgrade-from 5.3.6.0`: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/2452/