### PR TITLE
DLPX-67184 migration: dx_apply should call dx_delete to cleanup previous state

### DIFF
--- a/live-build/misc/migration-scripts/dx_apply
+++ b/live-build/misc/migration-scripts/dx_apply
@@ -106,13 +106,8 @@ RPOOL=${RDS%%/*}
 #
 # Cleanup any previous intermediate state.
 #
-rm -rf /tmp/delphix.* ||
-	die "failed to destroy old delphix temporary directories"
-rm -f /boot/vmlinuz-* /boot/initrd.img-* ||
-	die "failed to destroy previously copied Linux kernel data"
-zfs destroy -r "$RPOOL/ROOT" 2>/dev/null
-zfs list "$RPOOL/ROOT" 2>/dev/null &&
-	die "could not destroy linux root dataset from previous run"
+"${BASH_SOURCE%/*}/dx_delete" ||
+	die "failed to cleanup previous state with dx_delete"
 
 #
 # Save a copy of the boot menu to restore if we aren't upgrading


### PR DESCRIPTION
`dx-delete` will restore the old bootloader menu before the Linux dataset was dx-applied, effectively removing all the new linux entries.

Regarding the cleanup of `rpool/ROOT`, dx-delete takes care of it, so we can remove the now redundant logic.

## Testing 
ab-pre-push: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/2414/