### PR TITLE
DLPX-67355 [Backport of Issue DLPX-66957 to 6.0.0.0] hostname is not locally resolvable

### DIFF
--- a/live-build/config/hooks/vm-artifacts/83-etc-resolv-conf.binary
+++ b/live-build/config/hooks/vm-artifacts/83-etc-resolv-conf.binary
@@ -31,4 +31,4 @@
 # environment.
 #
 chroot binary rm -f /etc/resolv.conf
-chroot binary ln -s ../run/systemd/resolve/resolv.conf /etc/resolv.conf
+chroot binary ln -s ../run/systemd/resolve/stub-resolv.conf /etc/resolv.conf

--- a/upgrade/upgrade-scripts/upgrade-container
+++ b/upgrade/upgrade-scripts/upgrade-container
@@ -589,15 +589,6 @@ function migrate_configuration() {
 	# system to properly operate; these must be preserved acorss
 	# upgrades.
 	#
-	# Note, the "/etc/resolv.conf" file is in this list, but the
-	# "migrate_file" function will only migrate this path if it
-	# points to a regular file. Often, this file will be a symlink,
-	# in which case it won't be migrated, and we don't want it to
-	# be. We only want to migrate this file if the admin (or some
-	# software on the system) has converted it to a regular file,
-	# and configured some host specific DNS settings, in which case
-	# we want these settings to persist across the upgrade.
-	#
 	while read -r file; do
 		migrate_file "$file"
 	done <<-EOF


### PR DESCRIPTION
At boot time, applications will fail to resolve the local hostname
to an IP address (i.e. the loopback address) until DNS servers are
reachable, and once they are reachable, such lookups will result in
external DNS requests, which is suboptimal given how often applications
resolve the local hostname. These lookups should all be done locally
without relying on external DNS servers.

When applications resolve a hostname to an IP address, they use the NSS
switch, which has a policy for how lookups should be done. On Delphix,
the hosts entry for /etc/nsswitch.conf looks like this:
```
hosts:          files dns mymachines
```
This means that any lookup will first consult local files (/etc/hosts),
and if that fails, will go out to DNS. The /etc/hosts file is managed
by cloud-init, and will contain the local hostname in cases where
Delphix is running in the cloud. However, when Delphix is not in a cloud
environment (e.g. on ESX), cloud-init does not update /etc/hosts with
the local hostname (e.g. when it comes from a DHCP option). Lookups then
end up going to DNS.

The DNS configuration is in /etc/resolv.conf. Today, this file is a
symbolic link to /run/systemd/resolve/resolv.conf, which in a DHCP
environment, contains the set of DNS servers obtained via DHCP. As such,
even requests to resolve the local hostname will end up going out to a
remote DNS server.

Ubuntu does, however, ship with a local caching DNS server that is built
into systemd-resolved, and this caching DNS server has built-in support
for resolving the local hostname without having to send such queries
externally. Delphix doesn't use this because that would require that
/etc/resolv.conf include a "localhost" DNS server so that DNS queries
are made to the local DNS server.

This can be accomplished by having /etc/resolv.conf be a symbolic link
to /run/systemd/resolve/stub-resolv.conf. This resolver configuration
points to the localhost server (systemd-resolved), which forwards
queries that it wasn't able to satisfy from its local cache to external
servers. This also happens to be the recommended default configuration
according to the systemd-resolved.service man page.

This fix simply changes the default symlink target for /etc/resolv.conf
to be /run/systemd/resolve/stub-resolv.conf.