### PR TITLE
Retry downloading packages on failure

### DIFF
--- a/live-build/config/hooks/configuration/81-upgrade-repository.binary
+++ b/live-build/config/hooks/configuration/81-upgrade-repository.binary
@@ -59,16 +59,8 @@ fi
 # This directory of download packages will later be passed to Aptly to
 # build our "upgrade repository".
 #
-chroot binary bash -eux <<'EOF'
-set -o pipefail
-
-mkdir -p /packages
-cd /packages
-
-apt-get update
-
-dpkg-query -Wf '${Package}=${Version}\n' | xargs apt-get download
-EOF
+cp config/hooks/download-packages.sh binary/tmp/
+chroot binary /tmp/download-packages.sh
 
 #
 # After downloading the packages, the package filenames any have the

--- a/live-build/config/hooks/configuration/download-packages.sh
+++ b/live-build/config/hooks/configuration/download-packages.sh
@@ -1,0 +1,23 @@
+#!/bin/bash -eu
+
+set -o pipefail
+
+function download_packages() {
+	echo "Downloading: $*"
+	for _ in {1..5}; do
+		apt-get download "$@" && return
+		echo "Download failed, retrying."
+		sleep 5
+	done
+	echo "Failed to download packages after 5 attempts. Aborting." >&2
+	return 1
+}
+
+mkdir -p /packages
+cd /packages
+
+apt-get update
+
+export -f download_packages
+dpkg-query -Wf '${Package}=${Version}\n' |
+	xargs -n 20 bash -c 'download_packages "$@"' _

--- a/live-build/misc/migration-scripts/dx_apply
+++ b/live-build/misc/migration-scripts/dx_apply
@@ -99,7 +99,7 @@ MIGRATION_MINOR_VERSION=$(echo "$MIN_MIGRATION_VERSION" | cut -d. -f3)
 
 DX_UPG_STRESS=$ARCHIVE_DIR/dx_upg_stress_options
 # shellcheck source=/dev/null
-. $DX_UPG_STRESS --source
+. "$DX_UPG_STRESS" --source
 __trigger_unset_stress_option "STRESS_DX_APPLY_FAIL_AFTER_VERSION_CHECK"
 
 #

--- a/live-build/misc/migration-scripts/dx_execute
+++ b/live-build/misc/migration-scripts/dx_execute
@@ -35,7 +35,7 @@ set -o pipefail
 DX_UPG_PAUSE="${BASH_SOURCE%/*}/dx_upg_pause_options"
 DX_UPG_STRESS="${BASH_SOURCE%/*}/dx_upg_stress_options"
 # shellcheck source=/dev/null
-. $DX_UPG_STRESS --source
+. "$DX_UPG_STRESS" --source
 
 function die() {
 	echo "$(basename "$0"): $*" >&2

--- a/live-build/misc/migration-scripts/dx_verify
+++ b/live-build/misc/migration-scripts/dx_verify
@@ -201,7 +201,7 @@ run_upgrade_verify "$output" "$format" "$locale" 20 95
 
 DX_UPG_STRESS="${BASH_SOURCE%/*}/dx_upg_stress_options"
 # shellcheck source=/dev/null
-. $DX_UPG_STRESS --source
+. "$DX_UPG_STRESS" --source
 __trigger_unset_stress_option "STRESS_DX_VERIFY_FAIL_AFTER_TEST_MIGRATION"
 
 test_masking


### PR DESCRIPTION
This is a proposed workaround for #380 

## Testing
relevant sub-job from ab-pre-push: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-stage1/job/master/job/pre-push/7356/consoleFull
ab-pre-push: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/2506/