### PR TITLE
Modify propagation type of root dataset mount before mounting children

### DIFF
--- a/live-build/config/hooks/vm-artifacts/90-raw-disk-image.binary
+++ b/live-build/config/hooks/vm-artifacts/90-raw-disk-image.binary
@@ -138,6 +138,37 @@ zfs create \
 
 zfs mount "rpool/ROOT/$FSNAME/root"
 
+#
+# We are later going to recursively bind mount /proc/, /sys/, and /dev/
+# beneath the root dataset. Before doing that, we need to change the root
+# dataset's mount so that it has type 'slave'. If were to leave it 'shared',
+# the following would happen:
+#
+#  - The mount of $DIRECTORY/sys/ would be propagated to other existing
+#    namespaces.
+#  - We would recursively change the propagation type of $DIRECTORY/sys/ to
+#    be 'slave', for reasons explained below.
+#  - After finishing our work, we would 'umount -R $DIRECTORY/sys/'. For the
+#    children operated on recursively, this event would _not_ be propagated
+#    because they are not longer shared.
+#  - We would unmount $DIRECTORY. This would succeed, but propagation of it
+#    would silently fail, because it is busy in other namespaces, because
+#    $DIRECTORY/sys/ is still mounted on it.
+#  - We would export the pool, which would fail because the pool is busy
+#    because root filesystem is still mounted in other namespaces.
+#
+# To prevent this, we can change the propagation type of $DIRECTORY so that
+# the bind mount of /sys and the others is never propagated to other
+# namespaces.
+#
+# Also, since we are going to change the propagation type, we need to change
+# it before before mounting _any_ children. Otherwise we would end up in the
+# same situation, but with a different child: the mount would be proagated,
+# the unmount would not, and we would end up with EBUSY errors when exporting
+# the pool because some filesystems are mounted in other namespaces.
+#
+mount --make-slave "$DIRECTORY"
+
 zfs create \
 	-o mountpoint=legacy \
 	"rpool/ROOT/$FSNAME/home"
@@ -235,9 +266,18 @@ EOF
 # need to have the /dev, /proc, and /sys mountpoints present in that chroot
 # environment, which is why we bind mount here.
 #
-mount --make-slave "$DIRECTORY"
 for dir in /dev /proc /sys; do
 	mount --rbind "$dir" "${DIRECTORY}${dir}"
+	#
+	# Bind mounts are placed in the same peer group as the mount being
+	# copied. This means that when we later need to 'umount -R' this
+	# directory, the unmount events for any children of this mount will
+	# be propagated to the original mount point. So, for instance, when
+	# we unmount $DIRECTORY/sys/fs/cgroup, that will also attempt to
+	# unmount /sys/fs/cgroup. To prevent this from happening, we need to
+	# change the mount propagation type to prevent the unmount from being
+	# propagated.
+	#
 	mount --make-rslave "${DIRECTORY}${dir}"
 done
 


### PR DESCRIPTION
The change is to unblock a future change along the lines of https://github.com/delphix/appliance-build/pull/247.

The issue is that when we run the build outside of a container, there are mnt namespaces which are peers to the one in which the build is running. Currently, the following happens

- The root dataset `rpool/ROOT/delphix.v8IGiyn/root` is mounted on `/mnt/delphix.v8IGiyn`. This mount is propagated to the peer mnt namespaces.
- Child datasets `data`, `home`, and `log` are mounted beneath `/mnt/delphix.v8IGiyn`. These mounts are propagated to the peer mnt namespaces.
- The propagation type of `/mnt/delphix.v8IGiyn` is changed to 'slave'.
- We mount and unmount some other things which aren't directly relevant.
- We unmount  `data`, `home`, and `log`. These unmount events are _not_ propagated, because the parent mount is now no longer 'shared'. These datasets remain mounted in the other namespaces.
- We unmount `root`. This is also not propagated, because the mount is busy in the other namespaces, because of the children still mounted.
- We try to export the pool, but the pool is busy because of the mounts which still exist in the other namespaces.

We can resolve this by changing the propagation type of `/mnt/delphix.v8IGiyn` before mounting the other datasets on top of it. This way the child mounts are never propagated to the other namespaces.