### PR TITLE
Disable pipelining in apt when fetching packages

### DIFF
--- a/live-build/config/hooks/configuration/81-upgrade-repository.binary
+++ b/live-build/config/hooks/configuration/81-upgrade-repository.binary
@@ -59,6 +59,9 @@ fi
 # This directory of download packages will later be passed to Aptly to
 # build our "upgrade repository".
 #
+# Note that we pass "Acquire::http::Pipeline-Depth=0" as a workaround for
+# issue https://github.com/delphix/appliance-build/issues/380.
+#
 chroot binary bash -eux <<'EOF'
 set -o pipefail
 
@@ -67,7 +70,8 @@ cd /packages
 
 apt-get update
 
-dpkg-query -Wf '${Package}=${Version}\n' | xargs apt-get download
+dpkg-query -Wf '${Package}=${Version}\n' |
+	xargs apt-get -o Acquire::http::Pipeline-Depth=0 download
 EOF
 
 #


### PR DESCRIPTION
This is a first stab at fixing https://github.com/delphix/appliance-build/issues/380.

Note that if we find that this works, for a more complete solution we would also need to apply this setting to live-build, however it is a bit more complicated so I want to test this out first since most of our failures are in `81-upgrade-repository.binary`.

I've tested the performance impact of disabling apt pipelining, and it is quite low for our use case. Downloading 643 packages (total of 356 MB) from our internal mirror takes 6.5 seconds instead of 5.5 with this change.

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build was run locally and any changes were pushed
- [ ] Lint has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Testing
- ab-pre-push: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/2742/