### PR TITLE
Disable apt pipelining for the whole duration of live-build

### DIFF
--- a/live-build/config/hooks/configuration/10-disable-pipeline.chroot_early
+++ b/live-build/config/hooks/configuration/10-disable-pipeline.chroot_early
@@ -1,0 +1,30 @@
+#!/bin/bash -eux
+#
+# Copyright 2020 Delphix
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+#
+# This setting is necessary to prevent the "Undetermined Error" issue when
+# downloading packages using apt during the build. chroot_early hooks
+# are run after debootstrap and before packages are installed in lb_chroot.
+# This setting is reverted in the 84-reset-apt-config.binary hook, after
+# all apt operations have been completed.
+#
+# See https://github.com/delphix/appliance-build/issues/380 for more info
+# on the issue.
+#
+cat <<-EOF >/etc/apt/apt.conf.d/99-delphix-build-disable-pipeline
+	Acquire::http::Pipeline-Depth 0;
+EOF

--- a/live-build/config/hooks/configuration/81-upgrade-repository.binary
+++ b/live-build/config/hooks/configuration/81-upgrade-repository.binary
@@ -59,9 +59,6 @@ fi
 # This directory of download packages will later be passed to Aptly to
 # build our "upgrade repository".
 #
-# Note that we pass "Acquire::http::Pipeline-Depth=0" as a workaround for
-# issue https://github.com/delphix/appliance-build/issues/380.
-#
 chroot binary bash -eux <<'EOF'
 set -o pipefail
 
@@ -70,8 +67,7 @@ cd /packages
 
 apt-get update
 
-dpkg-query -Wf '${Package}=${Version}\n' |
-	xargs apt-get -o Acquire::http::Pipeline-Depth=0 download
+dpkg-query -Wf '${Package}=${Version}\n' | xargs apt-get download
 EOF
 
 #

--- a/live-build/config/hooks/vm-artifacts/84-reset-apt-config.binary
+++ b/live-build/config/hooks/vm-artifacts/84-reset-apt-config.binary
@@ -1,0 +1,22 @@
+#!/bin/bash -eux
+#
+# Copyright 2019 Delphix
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+#
+# Clear the apt configuration applied for the duration of live-build in the
+# 10-disable-pipeline.chroot_early hook.
+#
+rm binary/etc/apt/apt.conf.d/99-delphix-build-disable-pipeline


### PR DESCRIPTION
This change supersedes https://github.com/delphix/appliance-build/pull/412.

It's been now a week since the we pushed the previous fix and we have not seen any failures on master related to downloading packages in `81-upgrade-repository.binary`. We did however see a few failures in the `lb_chroot_install-packages` step when installing `delphix-platform` and its dependencies.

This follow-up adds a conf file in `/etc/apt/apt.conf/` with this setting very early in the build. This makes sure that whenever apt is invoked within the image, it will always apply this setting. This includes:
 - packages installed by live-build in `lb_chroot` (i.e. `delphix-platform` and its dependencies)
 - packages installed through the various ansible roles in `80-build-configuration.binary`
 - packages downloaded to create the upgrade image in `81-upgrade-repository.binary`

I've tried other alternatives, but they didn't cover all of the cases pointed out above, so this looks.

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build was run locally and any changes were pushed
- [ ] Lint has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

## Testing
- Verified that the apt configuration file was applied early on and was removed before creating images.
- Verified at various stages of the build that pipelining was indeed disabled by using `apt-config dump`
- ab-pre-push: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/2785/

fixes #380 