### PR TITLE
[Backport to 6.0.1.0] Disable apt pipelining for the whole duration of live-build

### DIFF
--- a/live-build/config/hooks/configuration/10-disable-pipeline.chroot_early
+++ b/live-build/config/hooks/configuration/10-disable-pipeline.chroot_early
@@ -1,0 +1,30 @@
+#!/bin/bash -eux
+#
+# Copyright 2020 Delphix
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+#
+# This setting is necessary to prevent the "Undetermined Error" issue when
+# downloading packages using apt during the build. chroot_early hooks
+# are run after debootstrap and before packages are installed in lb_chroot.
+# This setting is reverted in the 84-reset-apt-config.binary hook, after
+# all apt operations have been completed.
+#
+# See https://github.com/delphix/appliance-build/issues/380 for more info
+# on the issue.
+#
+cat <<-EOF >/etc/apt/apt.conf.d/99-delphix-build-disable-pipeline
+	Acquire::http::Pipeline-Depth 0;
+EOF

--- a/live-build/config/hooks/vm-artifacts/84-reset-apt-config.binary
+++ b/live-build/config/hooks/vm-artifacts/84-reset-apt-config.binary
@@ -1,0 +1,22 @@
+#!/bin/bash -eux
+#
+# Copyright 2019 Delphix
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+#
+# Clear the apt configuration applied for the duration of live-build in the
+# 10-disable-pipeline.chroot_early hook.
+#
+rm binary/etc/apt/apt.conf.d/99-delphix-build-disable-pipeline


### PR DESCRIPTION
Clean cherry-pick of https://github.com/delphix/appliance-build/pull/415

## Testing
ab-pre-push: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/2805/