### PR TITLE
Add "shell" subcommand to upgrade-container script

### DIFF
--- a/upgrade/upgrade-scripts/upgrade-container
+++ b/upgrade/upgrade-scripts/upgrade-container
@@ -476,6 +476,10 @@ function run() {
 		--quiet --wait --pipe -- "$@"
 }
 
+function shell() {
+	machinectl shell "$CONTAINER"
+}
+
 function convert_to_rootfs() {
 	#
 	# We're relying on the "mountpoint" property for the "data" and
@@ -807,6 +811,7 @@ function usage() {
 	echo "$PREFIX_SPACES stop <container>"
 	echo "$PREFIX_SPACES destroy <container>"
 	echo "$PREFIX_SPACES run <container> <command>"
+	echo "$PREFIX_SPACES shell <container>"
 	echo "$PREFIX_SPACES upgrade <container>"
 	echo "$PREFIX_SPACES convert-to-rootfs <container>"
 	echo "$PREFIX_SPACES get-type <container>"
@@ -854,6 +859,12 @@ run)
 	CONTAINER="$2"
 	shift 2
 	run "$@"
+	;;
+shell)
+	[[ $# -lt 3 ]] && usage "too few arguments specified"
+	CONTAINER="$2"
+	shift 2
+	shell
 	;;
 upgrade)
 	[[ $# -lt 2 ]] && usage "too few arguments specified"


### PR DESCRIPTION
This adds a new "shell" subcommand to the "upgrade-container" script,
which is intended to enable users to obtain an interactive shell session
within the specified container.

Currently, the "run" subcommand can be used, while specifying the shell
to run (e.g. /bin/bash), but since that does not specify the "--pty"
option with "systemd-run", the terminal may not work correctly (e.g.
keyboard input, pager output, etc).

Now, when folks want to obtain an interactive shell, they should use
this new "shell" subcommand, rather than "run".