### PR TITLE
Fix "upgrade-container stop" return code on success (#433)

### DIFF
--- a/upgrade/upgrade-scripts/upgrade-container
+++ b/upgrade/upgrade-scripts/upgrade-container
@@ -420,6 +420,13 @@ function stop() {
 
 	machinectl status "$CONTAINER" &>/dev/null &&
 		die "timeout waiting for container termination: '$CONTAINER'"
+
+	#
+	# We don't want to return the error code from the call to
+	# "machinectl status" above, so we explicitly return success if
+	# we've reached this far.
+	#
+	return 0
 }
 
 function destroy() {


### PR DESCRIPTION
This change fixes a regression introduced in acb60f4c. Without this
change, calling "upgrade-container stop" will return an error code, even
when the call successfully stops the container. With this change, when
the container is stopped successfully, we'll now properly return 0.