### PR TITLE
QA-20893 Add the snmptrapd pkg to the delphix VM

### DIFF
--- a/live-build/misc/ansible-roles/appliance-build.qa-internal/tasks/main.yml
+++ b/live-build/misc/ansible-roles/appliance-build.qa-internal/tasks/main.yml
@@ -15,10 +15,13 @@
 #
 # This file is intended only for QA-specific testing items and frameworks.
 # Anything required by customers should not be added here.
+# snmptrapd pkg is added to test snmp traps feature.
 #
 
 - apt:
-    name: nftables
+    name:
+      - nftables
+      - snmptrapd
     state: present
   register: result
   until: result is not failed


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:
- Tests for the changes have been added (for bug fixes / features)
_git-ab-pre-push_
http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/2977/console completed fine.
I cloned from the snapshot of the aws image and found that the snmptrapd pkg was available in the delphix VM when it came up. But it was inactive. I started the service and it came up fine with no errors.

```
delphix@ip-10-110-241-203:~$ sudo systemctl status  snmptrapd
● snmptrapd.service - Simple Network Management Protocol (SNMP) Trap Daemon.
   Loaded: loaded (/lib/systemd/system/snmptrapd.service; disabled; vendor preset: enabled)
   Active: inactive (dead)
delphix@ip-10-110-241-203:~$ sudo systemctl start  snmptrapd
delphix@ip-10-110-241-203:~$ sudo systemctl status  snmptrapd
● snmptrapd.service - Simple Network Management Protocol (SNMP) Trap Daemon.
   Loaded: loaded (/lib/systemd/system/snmptrapd.service; disabled; vendor preset: enabled)
   Active: active (running) since Wed 2020-02-26 02:23:13 UTC; 2s ago
 Main PID: 10495 (snmptrapd)
    Tasks: 1 (limit: 4915)
   CGroup: /system.slice/snmptrapd.service
           └─10495 /usr/sbin/snmptrapd -Lsd -f

Feb 26 02:23:13 ip-10-110-241-203 systemd[1]: Started Simple Network Management Protocol (SNMP) Trap Daemon..
Feb 26 02:23:14 ip-10-110-241-203 snmptrapd[10495]: NET-SNMP version 5.7.3 AgentX subagent connected
Feb 26 02:23:14 ip-10-110-241-203 snmptrapd[10495]: Warning: no access control information configured.
                                                      (Config search path: /etc/snmp:/usr/share/snmp:/usr/lib/x86_64-linux-gnu/snmp)
                                                    This receiver will *NOT* accept any incoming notifications.
Feb 26 02:23:14 ip-10-110-241-203 snmptrapd[10495]: NET-SNMP version 5.7.3
```



## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Other (please describe): 
New snmptrapd pkg is being installed in the qa variant delphix vm. It pulls in libmysqlclient20 and mysql-common. A total of 4MB. These 2 packages don’t install any new services or have new dependencies. snmptrapd does provide a new service. The daemon listens to the 162 port.


## What is the current behavior?
Presently this pkg is not available in the QA delphix VM.

Issue Number: N/A


## What is the new behavior?
Snmptrapd pkg will be installed in the VM when deployed during QA testing. The service will be inactive.

-
-
-

## Does this introduce a breaking change?

- [ ] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
