### PR TITLE
Add S3 inputs to "artifacts" directory

### DIFF
--- a/scripts/build-ancillary-repository.sh
+++ b/scripts/build-ancillary-repository.sh
@@ -103,6 +103,7 @@ function download_input_delphix_s3_debs() {
 	#
 	mkdir -p "$TOP/build/artifacts/inputs"
 	mv "$tmp_directory" "$TOP/build/artifacts/inputs/$input_name"
+	echo "$s3_uri" >"$TOP/build/artifacts/inputs/$input_name/S3_URI"
 }
 
 function build_ancillary_repository() {

--- a/scripts/build-ancillary-repository.sh
+++ b/scripts/build-ancillary-repository.sh
@@ -103,7 +103,7 @@ function download_input_delphix_s3_debs() {
 	#
 	local dir="$TOP/live-build/build/artifacts/inputs"
 	mkdir -p "$dir"
-	[[ -e "$dir/$input_name" ]] && rm -rf "$dir/$input_name"
+	[[ -e "$dir/$input_name" ]] && rm -rf "${dir:?}/$input_name"
 	mv "$tmp_directory" "$dir/$input_name"
 	echo "$s3_uri" >"$dir/$input_name/S3_URI"
 

--- a/scripts/build-ancillary-repository.sh
+++ b/scripts/build-ancillary-repository.sh
@@ -102,6 +102,8 @@ function download_input_delphix_s3_debs() {
 	# same exact S3 artifacts used during the original build.
 	#
 	mkdir -p "$TOP/build/artifacts/inputs"
+	[[ -e "$TOP/build/artifacts/inputs/$input_name" ]] &&
+		rm -rf "$TOP/build/artifacts/inputs/$input_name"
 	mv "$tmp_directory" "$TOP/build/artifacts/inputs/$input_name"
 	echo "$s3_uri" >"$TOP/build/artifacts/inputs/$input_name/S3_URI"
 }

--- a/scripts/build-ancillary-repository.sh
+++ b/scripts/build-ancillary-repository.sh
@@ -106,6 +106,17 @@ function download_input_delphix_s3_debs() {
 	[[ -e "$dir/$input_name" ]] && rm -rf "$dir/$input_name"
 	mv "$tmp_directory" "$dir/$input_name"
 	echo "$s3_uri" >"$dir/$input_name/S3_URI"
+
+	#
+	# Since the original directory was generated via "mktemp", the
+	# permissions of the artifact directory will be more restrictive
+	# than we want. Thus, here we fix this, and enable all users the
+	# ability to read/traverse the directory. This is useful since
+	# the build will likely be run as root, but the artifacts will
+	# be consumed after the build has finished, and by a non-root
+	# user.
+	#
+	chmod 755 "$dir/$input_name"
 }
 
 function build_ancillary_repository() {

--- a/scripts/build-ancillary-repository.sh
+++ b/scripts/build-ancillary-repository.sh
@@ -101,11 +101,11 @@ function download_input_delphix_s3_debs() {
 	# build inputs, as we could later re-run the build using the
 	# same exact S3 artifacts used during the original build.
 	#
-	mkdir -p "$TOP/build/artifacts/inputs"
-	[[ -e "$TOP/build/artifacts/inputs/$input_name" ]] &&
-		rm -rf "$TOP/build/artifacts/inputs/$input_name"
-	mv "$tmp_directory" "$TOP/build/artifacts/inputs/$input_name"
-	echo "$s3_uri" >"$TOP/build/artifacts/inputs/$input_name/S3_URI"
+	local dir="$TOP/live-build/build/artifacts/inputs"
+	mkdir -p "$dir"
+	[[ -e "$dir/$input_name" ]] && rm -rf "$dir/$input_name"
+	mv "$tmp_directory" "$dir/$input_name"
+	echo "$s3_uri" >"$dir/$input_name/S3_URI"
 }
 
 function build_ancillary_repository() {


### PR DESCRIPTION
This change helps us preserve the inputs to the build that come from S3.
Previously, after the files from S3 were downloaded and processed, they
would be deleted. Now, we preserve the files within the "artifacts"
file, such that they can be preserved by any automation running the
build, just like we've been doing with the outputs of the build.