### PR TITLE
DLPX-68848 [Backport of DLPX-68832 to 6.0.2.0] DFE during trunk to trunk deferred upgrade, Failed to set-bootfs for container 'delphix.AvZ8Xle'.

### DIFF
--- a/upgrade/upgrade-scripts/rootfs-container
+++ b/upgrade/upgrade-scripts/rootfs-container
@@ -77,7 +77,7 @@ function get_bootloader_devices() {
 	#
 	zpool list -vH rpool |
 		awk '! /rpool|mirror|replacing|spare/ {print $1}' |
-		sed 's/[0-9]*$//'
+		sed 's/p\{0,1\}[0-9]*$//'
 }
 
 function set_bootfs_not_mounted_cleanup() {


### PR DESCRIPTION
The "get_bootloader_devices" function attempts to list all devices
attached to "rpool" that are valid devices for storing the bootloader.
Since the devices used for "rpool" are partitions, it has to convert the
partion name (as returned by "zpool list") to the underlying device
name.

Unfortunately, the logic to do that mapping did not properly support
device partiations with "p" in the name; e.g. "nvme0n1p1" should map to
"nvme0n1", and "sda1" to "sda". This change updates this logic to better
support partitions names, regardless of it containing a "p" in the
partiation name, or not.