### PR TITLE
DLPX-68157 Update 'finalize' logic to clean up snapshots older than c…

### DIFF
--- a/upgrade/upgrade-scripts/common.sh
+++ b/upgrade/upgrade-scripts/common.sh
@@ -288,3 +288,9 @@ function set_upgrade_property() {
 	source_upgrade_properties ||
 		die "failed to read properties file after setting '$1=$2'"
 }
+
+function verify_upgrade_not_in_progress() {
+	. "$UPDATE_DIR/upgrade.properties"
+
+	[[ -z "$UPGRADE_TYPE" ]] || die "upgrade currently in-progress"
+}

--- a/upgrade/upgrade-scripts/upgrade
+++ b/upgrade/upgrade-scripts/upgrade
@@ -379,32 +379,69 @@ function finalize() {
 
 	[[ -n "$UPGRADE_TYPE" ]] ||
 		die "variable UPGRADE_TYPE is not set; is upgrade in progress?"
+	[[ -n "$UPGRADE_BASE_VERSION" ]] ||
+		die "variable UPGRADE_BASE_VERSION is not set"
 
 	case "$UPGRADE_TYPE" in
-	DEFERRED)
-		#
-		# Currently, we've only implemented "finalize" for
-		# DEFERRED upgrades. This is to avoid adding the logic
-		# for "not-in-place" upgrades (DEFERRED is strictly
-		# "in-place") and rollback (which is not supported for
-		# DEFERRED), until we determine those are required.
-		#
-		;;
+	DEFERRED | FULL | ROLLBACK) ;;
 	*)
-		die "rollback is not supported for upgrade type: '$UPGRADE_TYPE'"
+		die "finalize is not supported for upgrade type: '$UPGRADE_TYPE'"
 		;;
 	esac
 
-	ROOTFS_DATASET=$(get_mounted_rootfs_container_dataset)
-	[[ -n "$ROOTFS_DATASET" ]] ||
-		die "unable to determine mounted rootfs container dataset"
+	#
+	# This first pass checks for available "execute.upgrade" snapshots
+	# and deletes snapshots that are older than the base upgrade version.
+	# This pass takes care of cleanup after in-place and deferred upgrades.
+	#
+	SNAPSHOT_LIST=$(zfs list -t snapshot -r rpool/ROOT -d 2 -Ho name) ||
+		die "unable to determine available rollback snapshots"
 
-	SNAPSHOT_NAME=$(get_dataset_rollback_snapshot_name "$ROOTFS_DATASET")
-	[[ -n "$SNAPSHOT_NAME" ]] ||
-		die "unable to determine rollback snapshot name"
+	for snapshot in $SNAPSHOT_LIST; do
+		local SNAPSHOT_NAME
+		SNAPSHOT_NAME=$(echo "$snapshot" | awk -F@ '{print $2}')
+		#
+		# We skip container-delphix instances since `rootfs-container delete`
+		# handles them in the second pass below.
+		#
+		grep -qE "^container-delphix.[[:alnum:]]{7}$" <(echo "$SNAPSHOT_NAME") &&
+			continue
+		grep -qE "^execute-upgrade.[[:alnum:]]{7}$" <(echo "$SNAPSHOT_NAME") ||
+			die "unexpected snapshot name: '$snapshot'"
+		local SNAPSHOT_VERSION
+		SNAPSHOT_VERSION=$(zfs get -Hpo value "$PROP_CURRENT_VERSION" "$snapshot") ||
+			die "failed to get snapshot version"
+		[[ "$SNAPSHOT_VERSION" != "-" ]] ||
+			die "failed to get current version for snapshot '$snapshot'"
+		if compare_versions \
+			"$SNAPSHOT_VERSION" "lt" "$UPGRADE_BASE_VERSION"; then
+			zfs destroy -r "$snapshot" ||
+				die "failed to destroy rollback snapshot"
+		fi
+	done
 
-	zfs destroy -r "$ROOTFS_DATASET@$SNAPSHOT_NAME" ||
-		die "failed to destroy rollback snapshots"
+	#
+	# This second pass checks for available filesystems and deletes those
+	# that are older than the base upgrade version. This pass takes care
+	# of cleanup following rollbacks and not-in-place upgrades.
+	#
+	FILESYSTEM_LIST=$(zfs list -t filesystem -r rpool/ROOT -d 1 -Ho name | tail -n +2) ||
+		die "unable to determine available filesystems"
+
+	for filesystem in $FILESYSTEM_LIST; do
+		local FILESYSTEM_VERSION
+		FILESYSTEM_VERSION=$(zfs get -Hpo value "$PROP_CURRENT_VERSION" "$filesystem") ||
+			die "failed to get filesystem version"
+		[[ "$FILESYSTEM_VERSION" != "-" ]] ||
+			die "failed to get current version for filesystem '$filesystem'"
+		if compare_versions \
+			"$FILESYSTEM_VERSION" "lt" "$UPGRADE_BASE_VERSION"; then
+			local FILESYSTEM_NAME
+			FILESYSTEM_NAME=$(echo "$filesystem" | awk -F/ '{print $3}')
+			"$IMAGE_PATH/rootfs-container" delete "$FILESYSTEM_NAME" ||
+				die "failed to delete filesystem '$filesystem"
+		fi
+	done
 
 	rm -rf "$IMAGE_PATH" || die "failed to remove unpacked upgrade image"
 
@@ -434,12 +471,14 @@ deferred)
 	shift 1
 	verify_upgrade_is_allowed
 	verify_upgrade_in_place_is_allowed
+	verify_upgrade_not_in_progress
 	upgrade_in_place "$@"
 	;;
 full)
 	UPGRADE_TYPE="FULL"
 	shift 1
 	verify_upgrade_is_allowed
+	verify_upgrade_not_in_progress
 
 	#
 	# FULL upgrade always perform a reboot but can take on two


### PR DESCRIPTION
Wanted to get some reviews for this change. This change modifies Prakash's implementation of `upgrade finalize` in the upgrade scripts. With the new logic, only snapshots older than the previous snapshot (this being the snapshot of the version we just upgraded from) are deleted. Currently the `finalize` logic still only supports deferred upgrades. The logic for post-rollback cleanup will be developed following this.

JIRA: https://jira.delphix.com/browse/DLPX-68157

Dependent review for app-gate changes: http://reviews.delphix.com/r/55544/

git ab-pre-push (SUCCESS): http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/3099/console

---------------------------------
Manual Testing:
---------------------------------
```
Before deferred upgrade 
$ sudo zfs list -t all -r rpool
NAME                                                      USED  AVAIL     REFER  MOUNTPOINT
rpool                                                    33.9G  33.4G       64K  none
rpool/ROOT                                               25.7G  33.4G       64K  none
rpool/ROOT/delphix.PLOfKjK                               25.7G  33.4G       65K  none
rpool/ROOT/delphix.PLOfKjK@execute-upgrade.pPc3ac3          0B      -       65K  -
rpool/ROOT/delphix.PLOfKjK/data                          9.77M  33.4G     9.30M  legacy
rpool/ROOT/delphix.PLOfKjK/data@execute-upgrade.pPc3ac3   476K      -     7.75M  -
rpool/ROOT/delphix.PLOfKjK/home                          14.8G  33.4G     14.8G  legacy
rpool/ROOT/delphix.PLOfKjK/home@execute-upgrade.pPc3ac3   167K      -     11.9G  -
rpool/ROOT/delphix.PLOfKjK/log                           51.3M  33.4G     50.2M  legacy
rpool/ROOT/delphix.PLOfKjK/log@execute-upgrade.pPc3ac3   1.05M      -     32.8M  -
rpool/ROOT/delphix.PLOfKjK/root                          10.8G  33.4G     5.99G  /
rpool/ROOT/delphix.PLOfKjK/root@execute-upgrade.pPc3ac3  4.82G      -     6.02G  -
rpool/crashdump                                          65.5K  33.4G     65.5K  legacy
rpool/grub                                               3.03M  33.4G     3.03M  legacy
rpool/public                                               64K  33.4G       64K  /public
rpool/update                                             8.23G  21.8G     8.23G  /var/dlpx-update
rpool/upgrade-logs                                         65K  33.4G       65K  /var/tmp/delphix-upgrade
———————————————————————
$ sudo /var/dlpx-update/latest/upgrade -v deferred
$ sudo zfs list -t all -r rpool
NAME                                                      USED  AVAIL     REFER  MOUNTPOINT
rpool                                                    38.7G  28.6G       64K  none
rpool/ROOT                                               30.4G  28.6G       64K  none
rpool/ROOT/delphix.PLOfKjK                               30.4G  28.6G       65K  none
rpool/ROOT/delphix.PLOfKjK@execute-upgrade.pPc3ac3          0B      -       65K  -
rpool/ROOT/delphix.PLOfKjK@execute-upgrade.RNNPqan          0B      -       65K  -
rpool/ROOT/delphix.PLOfKjK/data                          10.4M  28.6G     9.45M  legacy
rpool/ROOT/delphix.PLOfKjK/data@execute-upgrade.pPc3ac3   476K      -     7.75M  -
rpool/ROOT/delphix.PLOfKjK/data@execute-upgrade.RNNPqan   458K      -     9.38M  -
rpool/ROOT/delphix.PLOfKjK/home                          14.8G  28.6G     14.8G  legacy
rpool/ROOT/delphix.PLOfKjK/home@execute-upgrade.pPc3ac3   167K      -     11.9G  -
rpool/ROOT/delphix.PLOfKjK/home@execute-upgrade.RNNPqan     0B      -     14.8G  -
rpool/ROOT/delphix.PLOfKjK/log                           81.7M  28.6G     79.4M  legacy
rpool/ROOT/delphix.PLOfKjK/log@execute-upgrade.pPc3ac3   1.05M      -     32.8M  -
rpool/ROOT/delphix.PLOfKjK/log@execute-upgrade.RNNPqan   1.27M      -     63.6M  -
rpool/ROOT/delphix.PLOfKjK/root                          15.5G  28.6G     6.10G  /
rpool/ROOT/delphix.PLOfKjK/root@execute-upgrade.pPc3ac3  4.82G      -     6.02G  -
rpool/ROOT/delphix.PLOfKjK/root@execute-upgrade.RNNPqan  4.42G      -     5.99G  -
rpool/crashdump                                          65.5K  28.6G     65.5K  legacy
rpool/grub                                               3.03M  28.6G     3.03M  legacy
rpool/public                                               64K  28.6G       64K  /public
rpool/update                                             8.30G  21.7G     8.30G  /var/dlpx-update
rpool/upgrade-logs                                         65K  28.6G       65K  /var/tmp/delphix-upgrade
———————————————————————
$ sudo /var/dlpx-update/latest/upgrade finalize
$ sudo zfs list -t all -r rpool
NAME                                                      USED  AVAIL     REFER  MOUNTPOINT
rpool                                                    25.9G  41.4G       64K  none
rpool/ROOT                                               25.6G  41.4G       64K  none
rpool/ROOT/delphix.PLOfKjK                               25.6G  41.4G       65K  none
rpool/ROOT/delphix.PLOfKjK@execute-upgrade.RNNPqan          0B      -       65K  -
rpool/ROOT/delphix.PLOfKjK/data                          10.3M  41.4G     9.75M  legacy
rpool/ROOT/delphix.PLOfKjK/data@execute-upgrade.RNNPqan   574K      -     9.38M  -
rpool/ROOT/delphix.PLOfKjK/home                          14.8G  41.4G     14.8G  legacy
rpool/ROOT/delphix.PLOfKjK/home@execute-upgrade.RNNPqan   147K      -     14.8G  -
rpool/ROOT/delphix.PLOfKjK/log                           81.0M  41.4G     79.8M  legacy
rpool/ROOT/delphix.PLOfKjK/log@execute-upgrade.RNNPqan   1.27M      -     63.6M  -
rpool/ROOT/delphix.PLOfKjK/root                          10.7G  41.4G     6.10G  /
rpool/ROOT/delphix.PLOfKjK/root@execute-upgrade.RNNPqan  4.59G      -     5.99G  -
rpool/crashdump                                           299M  34.5G      299M  legacy
rpool/grub                                               3.03M  41.4G     3.03M  legacy
rpool/public                                               64K  41.4G       64K  /public
rpool/update                                               88K  30.0G       88K  /var/dlpx-update
rpool/upgrade-logs                                         65K  41.4G       65K  /var/tmp/delphix-upgrade

```