### PR TITLE
Revert "[Backport of DLPX-68628 to 6.0.1.0] Bump minimum version for migration to 5.3.7.0"

### DIFF
--- a/live-build/config/hooks/vm-artifacts/90-linux-migration-artifact.binary
+++ b/live-build/config/hooks/vm-artifacts/90-linux-migration-artifact.binary
@@ -114,7 +114,7 @@ test -n "$DELPHIX_APPLIANCE_VERSION"
 	# of migration, so every time we bump this number we
 	# need to bump the one from the checks there too.
 	#
-	echo "DLPX_MIN_VERSION=5.3.7.0"
+	echo "DLPX_MIN_VERSION=5.3.6.0"
 
 	#
 	# DLPX_VERSION is set explicitly to match the version of the

--- a/live-build/misc/migration-scripts/dx_apply
+++ b/live-build/misc/migration-scripts/dx_apply
@@ -73,7 +73,7 @@ ARCHIVE_DIR="$1"
 #
 [[ -n "$DLPX_VERSION" ]] || die "DLPX_VERSION variable is missing"
 
-MIN_MIGRATION_VERSION="5.3.7.0"
+MIN_MIGRATION_VERSION="5.3.6.0"
 [[ "$DLPX_MIN_VERSION" == "$MIN_MIGRATION_VERSION" ]] ||
 	die "expected DLPX_MIN_VERSION for migration to be" \
 		"$MIN_MIGRATION_VERSION"


### PR DESCRIPTION
This reverts commit 7868fcdad6b620549fec13aee137c4429d46e92f.

We've decided to allow migrations from 5.3.6.0 to 6.0.1.0 given the small amount of differences between 5.3.6.0 and 5.3.7.0 and the desire to avoid double-upgrades for customers who already moved to 5.3.6.0 and will be wishing to upgrade to 6.0.1.0+.

## Testing
migration from 5.3.6.0: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/3053/