### PR TITLE
DLPX-68846 logic for determining device path for grub operations duri…

### DIFF
--- a/upgrade/upgrade-scripts/rootfs-container
+++ b/upgrade/upgrade-scripts/rootfs-container
@@ -77,7 +77,17 @@ function get_bootloader_devices() {
 	#
 	zpool list -vH rpool |
 		awk '! /rpool|mirror|replacing|spare/ {print $1}' |
-		sed 's/p\{0,1\}[0-9]*$//'
+		while read -r part; do
+			#
+			# If the rpool is not installed a parition, we throw
+			# an error. We expect this to never happen, and the
+			# calling code is likely untested in that case, so we
+			# throw an error rather than try to handle it.
+			#
+			[[ "$(lsblk --nodeps -no type "/dev/$part")" == "part" ]] ||
+				die "rpool installed on full disk \"$part\""
+			lsblk -no pkname "/dev/$part"
+		done
 }
 
 function set_bootfs_not_mounted_cleanup() {


### PR DESCRIPTION
…ng upgrade is fragile

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build was run locally and any changes were pushed
- [x] Lint has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
Currently, the logic used during upgrade to determine the disk that a partition is part of is fragile. We perform a purely regex-based manipulation, which is prone to failure on more complex device names.

Issue Number: DLPX-68846


## What is the new behavior?
A better approach is to leverage the lsblk command to directly determine the parent of the partition.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

Tested manually on ESX, GCP, Azure, and AWS.
http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/3057/console