### PR TITLE
"rootfs-container delete" must process "log" dataset

### DIFF
--- a/upgrade/upgrade-scripts/rootfs-container
+++ b/upgrade/upgrade-scripts/rootfs-container
@@ -31,16 +31,17 @@ function delete() {
 	local clonesnaps=()
 
 	#
-	# The "data" and "home" datasets of a rootfs container may have
-	# been cloned as part of a prior upgrade, and the "root" dataset
-	# may have been cloned as part of a prior rollback. Thus, in
-	# order to delete this specific rootfs container, we need to
-	# promote any clones that exist.
+	# The "data", "home", and "log" datasets of a rootfs container
+	# may have been cloned as part of a prior upgrade, and the
+	# "root" dataset may have been cloned as part of a prior
+	# rollback. Thus, in order to delete this specific rootfs
+	# container, we need to promote any clones that exist.
 	#
 	for snap in \
 		$(get_dataset_snapshots "rpool/ROOT/$CONTAINER/root") \
 		$(get_dataset_snapshots "rpool/ROOT/$CONTAINER/data") \
-		$(get_dataset_snapshots "rpool/ROOT/$CONTAINER/home"); do
+		$(get_dataset_snapshots "rpool/ROOT/$CONTAINER/home") \
+		$(get_dataset_snapshots "rpool/ROOT/$CONTAINER/log"); do
 		for clone in $(get_snapshot_clones "$snap"); do
 			zfs promote "$clone" ||
 				die "'zfs promote $clone' failed"


### PR DESCRIPTION
When "/var/log" was moved to a seperate dataset in commit 76a37744, we
failed to properly adapt the "rootfs-container delete" script to account
for this change. Since then, the "rootfs-container delete" script has
likely been broken; currently, when I attempt to use this script, it
fails with the following error:

    $ sudo /var/dlpx-update/latest/rootfs-container delete delphix.xfXCbRc
    cannot destroy 'rpool/ROOT/delphix.xfXCbRc': filesystem has dependent clones
    use '-R' to destroy the following datasets:
    rpool/ROOT/delphix.iluoSLh/log
    rootfs-container: 'zfs destroy -r rpool/ROOT/delphix.xfXCbRc' failed

The problem is, we're not properly handling the "log" dataset clones.
The fix is simple, we need to add the "log" dataset to the list of
datasets that we account for (i.e. the datasets that may need to be
"zfs promote"-ed) when calling "rootfs-container delete".