### PR TITLE
Remove lingering snapshots after rollback event

### DIFF
--- a/upgrade/upgrade-scripts/rootfs-container
+++ b/upgrade/upgrade-scripts/rootfs-container
@@ -63,6 +63,15 @@ function delete() {
 	for snap in "${clonesnaps[@]}"; do
 		zfs destroy "$snap" || die "'zfs destroy $snap' failed"
 	done
+
+	ROOTFS_DATASET=$(get_mounted_rootfs_container_dataset)
+	[[ -n "$ROOTFS_DATASET" ]] ||
+		die "unable to determine mounted rootfs container dataset"
+
+	if zfs list "$ROOTFS_DATASET@container-$CONTAINER" &>/dev/null; then
+		zfs destroy -r "$ROOTFS_DATASET@container-$CONTAINER" ||
+			die "failed to destroy container snapshot: '$CONTAINER'"
+	fi
 }
 
 function get_bootloader_devices() {


### PR DESCRIPTION
After performing a rollback of a failed not-in-place upgrade, if we remove
the container associated with that failure (i.e. the "new" container), we
will not remove the "container-delphix.XXXXXXX" snapshots used to generate
that new container, and these snapshots will persist indefinitely. This
change adds the necessary logic to the "rootfs-container delete" script to
remove these snapshots, after removing the container itself.

For example, without this change:

    $ download-latest-image internal-dev
    $ sudo unpack-image -x internal-dev.upgrade.tar
    $ sudo /var/dlpx-update/latest/upgrade -v full
    $ sudo /var/dlpx-update/latest/upgrade rollback
    $ sudo /var/dlpx-update/latest/rootfs-container delete delphix.Bs4VTPo
    $ sudo zfs list -t all -r rpool/ROOT/delphix.jDHoOtU
    NAME                                                        USED  AVAIL     REFER  MOUNTPOINT
    rpool/ROOT/delphix.jDHoOtU                                 17.7G  44.3G       64K  none
    rpool/ROOT/delphix.jDHoOtU@container-delphix.Bs4VTPo          0B      -       64K  -
    rpool/ROOT/delphix.jDHoOtU/data                            34.1M  44.3G     33.1M  legacy
    rpool/ROOT/delphix.jDHoOtU/data@container-delphix.Bs4VTPo  1006K      -     30.5M  -
    rpool/ROOT/delphix.jDHoOtU/home                            11.8G  44.3G     11.8G  legacy
    rpool/ROOT/delphix.jDHoOtU/home@container-delphix.Bs4VTPo   151K      -     11.8G  -
    rpool/ROOT/delphix.jDHoOtU/log                             28.7M  44.3G     27.0M  legacy
    rpool/ROOT/delphix.jDHoOtU/log@container-delphix.Bs4VTPo   1.61M      -     3.95M  -
    rpool/ROOT/delphix.jDHoOtU/root                            5.86G  44.3G     5.86G  /
    rpool/ROOT/delphix.jDHoOtU/root@container-delphix.Bs4VTPo  2.02M      -     5.86G  -

And now, with this change:

    $ download-latest-image internal-dev
    $ sudo unpack-image -x internal-dev.upgrade.tar
    $ sudo /var/dlpx-update/latest/upgrade -v full
    $ sudo /var/dlpx-update/latest/upgrade rollback
    $ sudo /var/dlpx-update/latest/rootfs-container delete delphix.lJvMWgM
    $ sudo zfs list -t all -r rpool/ROOT/delphix.jDHoOtU
    NAME                              USED  AVAIL     REFER  MOUNTPOINT
    rpool/ROOT/delphix.jDHoOtU       17.7G  44.3G       64K  none
    rpool/ROOT/delphix.jDHoOtU/data  34.5M  44.3G     34.5M  legacy
    rpool/ROOT/delphix.jDHoOtU/home  11.8G  44.3G     11.8G  legacy
    rpool/ROOT/delphix.jDHoOtU/log   27.1M  44.3G     27.1M  legacy
    rpool/ROOT/delphix.jDHoOtU/root  5.86G  44.3G     5.86G  /

Thus, with this change, the "container-delphix.XXXXXXX" snapshots are
properly removed after calling "rootfs-container delete".