### PR TITLE
CP-3067 Delphix Window Connector: Install binaries at ubuntu to build window connector

### DIFF
--- a/live-build/misc/ansible-roles/appliance-build.qa-internal/tasks/main.yml
+++ b/live-build/misc/ansible-roles/appliance-build.qa-internal/tasks/main.yml
@@ -52,12 +52,12 @@
       - libnss3-tools
       - libpam0g-dev
       - libssl-dev
-      - python-pip
-      - mono-complete
       - mingw-64
-      - nsis
+      - mono-complete
       - mono-reference-assemblies-3.5
       - mono-reference-assemblies-4.0
+      - nsis
+      - python-pip
     state: present
   register: result
   until: result is not failed

--- a/live-build/misc/ansible-roles/appliance-build.qa-internal/tasks/main.yml
+++ b/live-build/misc/ansible-roles/appliance-build.qa-internal/tasks/main.yml
@@ -53,6 +53,11 @@
       - libpam0g-dev
       - libssl-dev
       - python-pip
+      - mono
+      - mingw-64
+      - nsis
+      - mono-reference-assemblies-3.5
+      - mono-reference-assemblies-4.0
     state: present
   register: result
   until: result is not failed

--- a/live-build/misc/ansible-roles/appliance-build.qa-internal/tasks/main.yml
+++ b/live-build/misc/ansible-roles/appliance-build.qa-internal/tasks/main.yml
@@ -52,7 +52,7 @@
       - libnss3-tools
       - libpam0g-dev
       - libssl-dev
-      - mingw-64
+      - mingw-w64
       - mono-complete
       - mono-reference-assemblies-3.5
       - mono-reference-assemblies-4.0

--- a/live-build/misc/ansible-roles/appliance-build.qa-internal/tasks/main.yml
+++ b/live-build/misc/ansible-roles/appliance-build.qa-internal/tasks/main.yml
@@ -53,7 +53,7 @@
       - libpam0g-dev
       - libssl-dev
       - python-pip
-      - mono
+      - mono-complete
       - mingw-64
       - nsis
       - mono-reference-assemblies-3.5


### PR DESCRIPTION
Summary: Earlier we were building DelphixConector (A MSI Installer) with window + visual studio setup using a static host winbuild.delphix.com. Recently we found this is doable on ubuntu DE with some available binaries like 

a)  mono-complete **[to build CS project]**
b) mingw-64 **[a cross comiler to build CPP project]** 
c) nsis **[to create window installer]**
d) mono-reference-assemblies-3.5 **[This is helper package for mono]** and
e) mono-reference-assemblies-4.0 **[This is helper package for mono]**

above binaries need not to be available on Production’s DEs because these are only require during build time and once an installer is built we will package installer directly on production DE.

Please suggest testing strategies for above? 