### PR TITLE
TOOL-9008 LDAP user homes should be mounted using NFSv3

### DIFF
--- a/live-build/misc/ansible-roles/appliance-build.delphix-ldap/tasks/main.yml
+++ b/live-build/misc/ansible-roles/appliance-build.delphix-ldap/tasks/main.yml
@@ -65,7 +65,7 @@
 
 - lineinfile:
     dest: etc/auto.master
-    line: "/home   auto_home    -nobrowse"
+    line: "/home   auto_home    -nobrowse,vers=3"
 
 - copy:
     src: 80-internal-ldap


### PR DESCRIPTION
# Disclaimer: 
This is my first pull-request to delphix Github repos so I'm sure I've messed something up, let me know and I will address it. 

# Jira Issue
https://jira.delphix.com/browse/TOOL-9008

# Problem:
When mounting LDAP user homes in the DCenter variant we have been seeing spurious issues due to mounting the pharos user homes over NFSv4. Seb has implemented this fix on scale-dc2 (DCoL system) to confirm that this works better. I talked to George and he was of the opinion that this this fix should also be extended to internal-dev variant. 

# Solution
Modify /etc/auto.master to mount user homes with `vers=3`.

# Testing:
`git ab-pre-push -v "internal-dev internal-dcenter" -p esx`:
http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/3141/console