### PR TITLE
Fix calls to "verify_upgrade_not_in_progress"

### DIFF
--- a/upgrade/upgrade-scripts/common.sh
+++ b/upgrade/upgrade-scripts/common.sh
@@ -290,7 +290,14 @@ function set_upgrade_property() {
 }
 
 function verify_upgrade_not_in_progress() {
-	. "$UPDATE_DIR/upgrade.properties"
+	#
+	# This function only works properly if the UPGRADE_TYPE variable
+	# is not set prior to this function being called. Thus, to help
+	# catch cases where this function is called incorrectly, we
+	# verify the variable is empty before proceeding.
+	#
+	[[ -z "$UPGRADE_TYPE" ]] || die "UPGRADE_TYPE already set"
 
+	. "$UPDATE_DIR/upgrade.properties" &>/dev/null
 	[[ -z "$UPGRADE_TYPE" ]] || die "upgrade currently in-progress"
 }

--- a/upgrade/upgrade-scripts/upgrade
+++ b/upgrade/upgrade-scripts/upgrade
@@ -467,18 +467,20 @@ shift $((OPTIND - 1))
 
 case "$1" in
 deferred)
+	verify_upgrade_not_in_progress
+
 	UPGRADE_TYPE="DEFERRED"
 	shift 1
 	verify_upgrade_is_allowed
 	verify_upgrade_in_place_is_allowed
-	verify_upgrade_not_in_progress
 	upgrade_in_place "$@"
 	;;
 full)
+	verify_upgrade_not_in_progress
+
 	UPGRADE_TYPE="FULL"
 	shift 1
 	verify_upgrade_is_allowed
-	verify_upgrade_not_in_progress
 
 	#
 	# FULL upgrade always perform a reboot but can take on two


### PR DESCRIPTION
The "verify_upgrade_not_in_progress" function only works correctly if
the "UPGRADE_TYPE" variable is not set prior to the function being
called. Unfortunately, in the two places we currently call that
function, that variable will have already been set.

This change fixes the issue by moving the calls to the function, such
that we call it prior to setting the variable. Additionally, we add a
check to the function to catch this error in usage earlier, and emit a
more appropriate error message.

Closes #461