### PR TITLE
Backport of PR #455 to 6.0.2.0 (6.0/stage)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -51,7 +51,10 @@ for (variant in allVariants) {
             }
         }
 
-        for (envVar in ["DELPHIX_PLATFORMS", "AWS_S3_URI_LIVEBUILD_ARTIFACTS"]) {
+        for (envVar in ["DELPHIX_PLATFORMS", 
+                        "AWS_S3_URI_LIVEBUILD_ARTIFACTS",
+                        "AWS_S3_URI_UPGRADE_VERIFICATION",
+                        "AWS_S3_PREFIX_UPGRADE_VERIFICATION"]) {
             inputs.property(envVar, System.getenv(envVar)).optional(true)
         }
 

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+#
+# Copyright 2020 Delphix
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+TOP=$(git rev-parse --show-toplevel 2>/dev/null)
+
+function resolve_s3_uri() {
+	local pkg_uri="$1"
+	local pkg_prefix="$2"
+	local latest_subprefix="$3"
+
+	local bucket="snapshot-de-images"
+	local jenkinsid="jenkins-ops"
+	local resolved_uri
+
+	if [[ -n "$pkg_uri" ]]; then
+		resolved_uri="$pkg_uri"
+	elif [[ "$pkg_prefix" == s3* ]]; then
+		resolved_uri="$pkg_prefix"
+	elif [[ -n "$pkg_prefix" ]]; then
+		resolved_uri="s3://$bucket/$pkg_prefix"
+	elif [[ -n "$latest_subprefix" ]]; then
+		aws s3 cp --quiet \
+			"s3://$bucket/builds/$jenkinsid/$latest_subprefix" .
+		resolved_uri="s3://$bucket/$(cat latest)"
+		rm -f latest
+	else
+		echo "Invalid arguments provided to resolve_s3_uri()" 2>&1
+		exit 1
+	fi
+
+	if aws s3 ls "$resolved_uri" &>/dev/null; then
+		echo "$resolved_uri"
+	else
+		echo "'$resolved_uri' not found." 1>&2
+		exit 1
+	fi
+}
+
+function download_delphix_s3_debs() {
+	local pkg_directory="$1"
+	local S3_URI="$2"
+	local tmp_directory
+
+	tmp_directory=$(mktemp -d -p "$TOP/build" tmp.s3-debs.XXXXXXXXXX)
+	pushd "$tmp_directory" &>/dev/null
+
+	aws s3 sync --only-show-errors "$S3_URI" .
+	sha256sum -c --strict SHA256SUMS
+
+	mv ./*deb "$pkg_directory/"
+
+	popd &>/dev/null
+	rm -rf "$tmp_directory"
+}

--- a/upgrade/upgrade-scripts/common.sh
+++ b/upgrade/upgrade-scripts/common.sh
@@ -289,6 +289,20 @@ function set_upgrade_property() {
 		die "failed to read properties file after setting '$1=$2'"
 }
 
+function apt_get() {
+	DEBIAN_FRONTEND=noninteractive apt-get \
+		-o Dpkg::Options::="--force-confdef" \
+		-o Dpkg::Options::="--force-confold" \
+		"$@"
+}
+
+function xargs_apt_get() {
+	DEBIAN_FRONTEND=noninteractive xargs apt-get \
+		-o Dpkg::Options::="--force-confdef" \
+		-o Dpkg::Options::="--force-confold" \
+		"$@"
+}
+
 function verify_upgrade_not_in_progress() {
 	. "$UPDATE_DIR/upgrade.properties"
 

--- a/upgrade/upgrade-scripts/execute
+++ b/upgrade/upgrade-scripts/execute
@@ -28,20 +28,6 @@ function usage() {
 	exit 2
 }
 
-function apt_get() {
-	DEBIAN_FRONTEND=noninteractive apt-get \
-		-o Dpkg::Options::="--force-confdef" \
-		-o Dpkg::Options::="--force-confold" \
-		"$@"
-}
-
-function xargs_apt_get() {
-	DEBIAN_FRONTEND=noninteractive xargs apt-get \
-		-o Dpkg::Options::="--force-confdef" \
-		-o Dpkg::Options::="--force-confold" \
-		"$@"
-}
-
 while getopts ':rlBfsp:' c; do
 	case $c in
 	r | l | B | f | s) ;; # LX-72: For now, silently ignore these.

--- a/upgrade/upgrade-scripts/verify-jar
+++ b/upgrade/upgrade-scripts/verify-jar
@@ -20,6 +20,8 @@
 
 IMAGE_VERSION=$(get_image_version)
 [[ -n "$IMAGE_VERSION" ]] || die "failed to determine image version"
+IMAGE_PATH=$(get_image_path)
+[[ -n "$IMAGE_PATH" ]] || die "failed to determine image path"
 
 function verify_jar_verify_cleanup() {
 	local rc="$?"
@@ -40,6 +42,11 @@ function verify_jar_verify_cleanup() {
 	if zfs list "domain0/${MDS_SNAPNAME}" &>/dev/null; then
 		/opt/delphix/server/bin/dx_manage_pg cleanup -s "${MDS_SNAPNAME}" ||
 			die "failed to cleanup postgres for snapshot '${MDS_SNAPNAME}'."
+	fi
+
+	if dpkg-query -W delphix-upgrade-verification &>/dev/null; then
+		apt_get remove --purge -y delphix-upgrade-verification ||
+			die "failed to uninstall delphix-upgrade-verification package"
 	fi
 
 	[[ $rc -eq 0 ]] &&
@@ -142,10 +149,26 @@ report_progress 10 "Started application upgrade verification"
 
 [[ "$EUID" -ne 0 ]] && die "must be run as root"
 
+#
+# Install the delphix-upgrade-verification debian package from the
+# unpack directory. This package is not installed as part of
+# the execute script since no other package has a dependency on
+# the delphix-upgrade-verification package. This is by design.
+# This package is only meant to be used during upgrade verification
+# and will be un-installed once verification is complete. This allows
+# two engines that might have used different version of the
+# delphix-upgrade-verification package to still have identical software
+# post-upgrade.
+#
+
+find "$IMAGE_PATH" -name "delphix-upgrade-verification*.deb" |
+	xargs_apt_get install -y --allow-downgrades ||
+	die "failed to install delphix-upgrade-verification package"
+
 JAVA_PARAMETERS=(
 	"-Dlog.dir=/var/delphix/server/upgrade-verify"
 	"-Dmdsverify=true"
-	"-jar" "/opt/delphix/server/lib/exec/upgrade-verify/upgrade-verify.jar"
+	"-jar" "/opt/delphix-upgrade-verification/upgrade-verify.jar"
 )
 
 if [[ -n "$DLPX_DEBUG" ]] && $DLPX_DEBUG; then

--- a/upgrade/verification-version.info.template
+++ b/upgrade/verification-version.info.template
@@ -1,0 +1,26 @@
+#
+# Copyright 2020 Delphix
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+#
+# This file is consumed by the upgrade logic prior to upgrade in order to
+# communicate the verification package version via API and CLI for the upgrade
+# being performed.
+#
+
+#
+# The version of the upgrade verification package contained in the upgrade image.
+#
+VERIFICATION_VERSION=@@VERIFICATION_VERSION@@

--- a/upgrade/version.info.template
+++ b/upgrade/version.info.template
@@ -57,3 +57,8 @@ MINIMUM_VERSION=@@MINIMUM_VERSION@@
 # MINIMUM_VERSION above.
 #
 MINIMUM_REBOOT_OPTIONAL_VERSION=@@MINIMUM_REBOOT_OPTIONAL_VERSION@@
+
+#
+# The version of the upgrade verification package contained in the upgrade image.
+#
+VERIFICATION_VERSION=@@VERIFICATION_VERSION@@


### PR DESCRIPTION
clean cherry-pick of https://github.com/delphix/appliance-build/pull/455

DLPX-69062 [Backport of DLPX-64198 to 6.0.2.0] define and implement version info file for verification package
DLPX-69063 [Backport of DLPX-68919] Use New upgrade-verify.jar in appliance-build
DLPX-69107 [Backport of DLPX-69031 to 6.0.2.0] Make sure that the delphix-verification package is not installed post upgrade

CLEAN git ab-pre-push: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/3211/

CLEAN git ab-pre-push --test-upgrade-from 6.0.0.0 -a: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/3212/
RUNNING git ab-pre-push --test-upgrade-from 6.0.1.0 -a: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/3216/
CLEAN git ab-pre-push --test-upgrade-from 6.0.1.1 -a: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/3214/

Below migration run failed in post upgrade cleanup due to what seems to be a regression from the push for DLPX-69176. The upgrade itself seems to be fine.
git ab-pre-push --test-upgrade-from 5.3.9.0 -a: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/3215/
