### PR TITLE
Revert "TOOL-9008 LDAP user homes should be mounted using NFSv3 (#456)"

### DIFF
--- a/live-build/misc/ansible-roles/appliance-build.delphix-ldap/tasks/main.yml
+++ b/live-build/misc/ansible-roles/appliance-build.delphix-ldap/tasks/main.yml
@@ -65,7 +65,7 @@
 
 - lineinfile:
     dest: etc/auto.master
-    line: "/home   auto_home    -nobrowse,vers=3"
+    line: "/home   auto_home    -nobrowse"
 
 - copy:
     src: 80-internal-ldap


### PR DESCRIPTION
Turns out this change is causing issues for user logging into internal-dev Delphix Engines via LDAP. One example of a workflow that has been broken is:
```
git au -m vm.dlpxdc.co
Updating: vm.dlpxdc.co
john.doe@vm.dlpxdc.co's password: 
```
This workflow has previously work with passwordless ssh as long as the user has their ssh keys in authorized_keys in the LDAP home directory. 

I have not clue why this works on scale-dc2 but not on internal-dev instances but I figure we should revert the change in https://github.com/delphix/appliance-build/commit/f84edf69cad73ebd653050e135877f11d5ec7855
and then investigate the issue. 