### PR TITLE
copy static DNS configuration for not-in-place upgrades

### DIFF
--- a/upgrade/upgrade-scripts/upgrade-container
+++ b/upgrade/upgrade-scripts/upgrade-container
@@ -639,6 +639,7 @@ function migrate_configuration() {
 		/etc/ssh/ssh_host_rsa_key
 		/etc/ssh/ssh_host_rsa_key.pub
 		/etc/sudoers.d/90-cloud-init-users
+		/etc/systemd/resolved.conf.d/delphix-static.con
 		/etc/zfs/zpool.cache
 	EOF
 

--- a/upgrade/upgrade-scripts/upgrade-container
+++ b/upgrade/upgrade-scripts/upgrade-container
@@ -639,7 +639,7 @@ function migrate_configuration() {
 		/etc/ssh/ssh_host_rsa_key
 		/etc/ssh/ssh_host_rsa_key.pub
 		/etc/sudoers.d/90-cloud-init-users
-		/etc/systemd/resolved.conf.d/delphix-static.con
+		/etc/systemd/resolved.conf.d/delphix-static.conf
 		/etc/zfs/zpool.cache
 	EOF
 


### PR DESCRIPTION
http://reviews.delphix.com/r/58876/ changes how static DNS configuration is maintained. With this PR, we ensure that the static configuration file is persisted across not-in-place upgrades.