### PR TITLE
TOOL-9772 dcenter image should increase mountd thread count

### DIFF
--- a/live-build/misc/ansible-roles/appliance-build.dcenter/tasks/main.yml
+++ b/live-build/misc/ansible-roles/appliance-build.dcenter/tasks/main.yml
@@ -1,5 +1,5 @@
 #
-# Copyright 2018 Delphix
+# Copyright 2018,2020 Delphix
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -95,7 +95,10 @@
 #
 - lineinfile:
     path: /etc/default/nfs-kernel-server
-    regexp: '^RPCNFSDCOUNT='
-    line: 'RPCNFSDCOUNT=64'
+    regexp: "{{ item.regexp }}"
+    line: "{{ item.line }}"
+  with_items:
+    - { regexp: '^RPCNFSDCOUNT=', line: 'RPCNFSDCOUNT=64' }
+    - { regexp: '^RPCMOUNTDOPTS=', line: 'RPCMOUNTDOPTS="--num-threads=5 --manage-gids"' }
 
 - command: systemctl disable bind9.service


### PR DESCRIPTION
**Background**
Based on recent NFS latency investigations on DCoL, we found that having more `mountd` threads helps reduce the NFS latencies after the NFS caches are purged.  Each VM clone/destroy operation on DCoL is triggering a cache purge.

5 `mountd` threads seems to be the optimal count and adding more threads beyond 5 had a negative scaling effect.

**Testing**
We have already been running with 5 `mountd` threads on dcol1.
Built manually (i.e. `buildInternalDcenterKvm`) and tested that image
  confirmed that the `nfs-kernel-server` config file had the expected `RPCMOUNTDOPTS`
  confirmed that there were 5 `rpc.mountd` threads running
  confirmed that there were 64 `nfsd` threads running
