### PR TITLE
Remove unnecessary files from upgrade payload

### DIFF
--- a/scripts/build-upgrade-image.sh
+++ b/scripts/build-upgrade-image.sh
@@ -99,7 +99,7 @@ aptly publish repo -skip-contents -skip-signing upgrade-repository
 # be realtively small (and that file's size grows linearly with the
 # number of files contained in the "upgrade image" tarball).
 #
-tar -I pigz -cf "payload.tar.gz" -C upgrade-scripts . -C ~/.aptly .
+tar -I pigz -cf "payload.tar.gz" -C upgrade-scripts . -C ~/.aptly/public .
 
 cp version.info.template version.info
 

--- a/upgrade/upgrade-scripts/execute
+++ b/upgrade/upgrade-scripts/execute
@@ -115,7 +115,7 @@ if [[ -f /etc/apt/sources.list ]]; then
 fi
 
 cat <<EOF >/etc/apt/sources.list ||
-deb [trusted=yes] file://$IMAGE_PATH/public bionic delphix
+deb [trusted=yes] file://$IMAGE_PATH bionic delphix
 EOF
 	die "failed to configure apt sources"
 

--- a/upgrade/upgrade-scripts/upgrade-container
+++ b/upgrade/upgrade-scripts/upgrade-container
@@ -231,7 +231,7 @@ function create_upgrade_container() {
 		#
 		debootstrap --no-check-gpg \
 			--components=delphix --include=systemd-container \
-			bionic "$DIRECTORY" "file://$IMAGE_PATH/public" 1>&2 ||
+			bionic "$DIRECTORY" "file://$IMAGE_PATH" 1>&2 ||
 			die "failed to debootstrap upgrade filesystem"
 
 		#


### PR DESCRIPTION
Currently, when we generate an upgrade image, we include the entire
contents of "\~/.aptly" in the image. It turns out, this causes us to
include two identical copies of each package, one under "\~/.aptly/pool"
and another under "\~/.aptly/public/pool".

For the upgrade image, we only need the contents of the "~/.aptly/public"
directory, so this change modifies the upgrade image generation logic,
as well as the upgrade image application logic, to take this into
account. As a result, this significantly reduces the size of the upgrade
image (roughly a 50% reduction in size).