### PR TITLE
Checkout the master branch instead of projects/dx4linux on dcol.

### DIFF
--- a/live-build/misc/ansible-roles/appliance-build.dcenter/tasks/main.yml
+++ b/live-build/misc/ansible-roles/appliance-build.dcenter/tasks/main.yml
@@ -46,7 +46,7 @@
 
 - git:
     repo: 'https://gitlab.delphix.com/devops/dcenter-gate.git'
-    version: projects/dx4linux
+    version: master
     dest: /opt/dcenter/lib/dcenter-gate
     accept_hostkey: yes
     update: no


### PR DESCRIPTION
This is a clean cherry-pick of #474 to 6.0/stage.

The projects/dx4linux branch in dcenter-gate is no longer used. All work
is being done on master, and so that's the branch that needs to be
checked out on deployed dcol instances.