### PR TITLE
dcenter image should increase mountd thread count [Backport of TOOL-9…

### DIFF
--- a/live-build/misc/ansible-roles/appliance-build.dcenter/tasks/main.yml
+++ b/live-build/misc/ansible-roles/appliance-build.dcenter/tasks/main.yml
@@ -1,5 +1,5 @@
 #
-# Copyright 2018 Delphix
+# Copyright 2018,2020 Delphix
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -86,5 +86,18 @@
     path: /etc/cloud/cloud.cfg
     regexp: '^preserve_hostname: false'
     line: 'preserve_hostname: true'
+
+#
+# The default setting for the number of nfs threads is too low. To
+# improve performance we reset the value to 64 which mimics what
+# we use on the delphix engine.
+#
+- lineinfile:
+    path: /etc/default/nfs-kernel-server
+    regexp: "{{ item.regexp }}"
+    line: "{{ item.line }}"
+  with_items:
+    - { regexp: '^RPCNFSDCOUNT=', line: 'RPCNFSDCOUNT=64' }
+    - { regexp: '^RPCMOUNTDOPTS=', line: 'RPCMOUNTDOPTS="--num-threads=5 --manage-gids"' }
 
 - command: systemctl disable bind9.service


### PR DESCRIPTION
semi-clean cherry-pick of #468 to 6.0/stage
(previous change also touched the last line of the same file)

**Background**
Based on NFS latency investigations on DCoL, we found that having more `mountd` threads helps reduce the NFS latencies after the NFS caches are purged.  Each VM clone/destroy operation on DCoL is triggering a cache purge.

5 `mountd` threads seems to be the optimal count and adding more threads beyond 5 had a negative scaling effect.