### PR TITLE
backport tenacity requirement (part of TOOL-9418)

### DIFF
--- a/live-build/misc/ansible-roles/appliance-build.dcenter/tasks/main.yml
+++ b/live-build/misc/ansible-roles/appliance-build.dcenter/tasks/main.yml
@@ -30,6 +30,7 @@
       - python-paramiko
       - python-pip
       - python-requests
+      - python-tenacity
       - python2.7
       - telnet
     state: present


### PR DESCRIPTION
This is required for dcol1 which will track 6.0/stage and 6.0/release