### PR TITLE
Install recovery env

### DIFF
--- a/live-build/misc/ansible-roles/appliance-build.recovery-environment/meta/main.yml
+++ b/live-build/misc/ansible-roles/appliance-build.recovery-environment/meta/main.yml
@@ -1,5 +1,5 @@
 #
-# Copyright 2018 Delphix
+# Copyright 2020 Delphix
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,14 +15,5 @@
 #
 
 ---
-- hosts: all
-  gather_facts: no
-  vars:
-    ansible_python_interpreter: /usr/bin/python3
-  roles:
-    - appliance-build.minimal-common
-    - appliance-build.minimal-internal
-    - appliance-build.masking-common
-    - appliance-build.qa-internal
-    - appliance-build.virtualization-common
-    - appliance-build.recovery-environment
+dependencies:
+  - role: appliance-build.virtualization-common

--- a/live-build/misc/ansible-roles/appliance-build.recovery-environment/tasks/main.yml
+++ b/live-build/misc/ansible-roles/appliance-build.recovery-environment/tasks/main.yml
@@ -1,5 +1,5 @@
 #
-# Copyright 2018 Delphix
+# Copyright 2020 Delphix
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,14 +15,7 @@
 #
 
 ---
-- hosts: all
-  gather_facts: no
-  vars:
-    ansible_python_interpreter: /usr/bin/python3
-  roles:
-    - appliance-build.minimal-common
-    - appliance-build.minimal-internal
-    - appliance-build.masking-common
-    - appliance-build.qa-internal
-    - appliance-build.virtualization-common
-    - appliance-build.recovery-environment
+- apt:
+    name: recovery-environment
+    state: present
+

--- a/live-build/variants/external-standard/ansible/playbook.yml
+++ b/live-build/variants/external-standard/ansible/playbook.yml
@@ -23,3 +23,4 @@
     - appliance-build.minimal-common
     - appliance-build.masking-common
     - appliance-build.virtualization-common
+    - appliance-build.recovery-environment

--- a/live-build/variants/internal-dev/ansible/playbook.yml
+++ b/live-build/variants/internal-dev/ansible/playbook.yml
@@ -48,3 +48,4 @@
     - appliance-build.virtualization-common
     - appliance-build.virtualization-development
     - appliance-build.zfsonlinux-development
+    - appliance-build.recovery-environment


### PR DESCRIPTION
http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/3774/

We add a new role to install the recovery environment so that we can maintain a clearer dependency ordering between the recovery environment package and the app-stack; the recovery environment package currently relies on the app-stack, while the app-stack can function without the recovery environment.