### PR TITLE
DLPX-71245 [Backport of DLPX-71244 to 6.0.3.0] fix for DLPX-69049 needs to also update grub for migrations

### DIFF
--- a/live-build/misc/migration-scripts/dx_apply
+++ b/live-build/misc/migration-scripts/dx_apply
@@ -275,6 +275,7 @@ LX_CMDLINE=(
 	'zfsforce=1'
 	'mitigations=off'
 	'elevator=noop'
+	'init_on_alloc=0'
 )
 
 #


### PR DESCRIPTION
The root-cause of this bug is two-fold:

1. We have two locations for Grub configuration in 6.0.X. For fresh installs and upgrades, it lives in the delphix-platform repo. For migrations, it lives in this repo. The two must be kept in sync. It's easy to miss the latter.
2. We don't do performance testing on migrated engines; only on freshly installed ones.

ab-pre-push: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/3797/

I did a 5.3.9.0 to 6.0.3.0 migration using the image generated by this build, and verified that the `init_on_alloc` setting was correct post migration:
```
delphix@ip-10-110-242-36:~$ cat /proc/cmdline
root=ZFS=rpool/ROOT/delphix.9GQlImi/root console=tty0 console=ttyS0,115200n8 ipv6.disable=1 crashkernel=256M,high crashkernel=256M,low zfsforce=1 mitigations=off elevator=noop init_on_alloc=0
```