### PR TITLE
DLPX-69447 Fixed hotfixes should be removed from /etc/hotfix during upgrade application

### DIFF
--- a/upgrade/upgrade-scripts/common.sh
+++ b/upgrade/upgrade-scripts/common.sh
@@ -18,6 +18,7 @@
 # shellcheck disable=SC2034
 UPDATE_DIR="/var/dlpx-update"
 LOG_DIRECTORY="/var/tmp/delphix-upgrade"
+HOTFIX_PATH="/etc/hotfix"
 
 #
 # We embed information as dataset properties in our rootfs containers.

--- a/upgrade/upgrade-scripts/upgrade
+++ b/upgrade/upgrade-scripts/upgrade
@@ -446,6 +446,10 @@ function finalize() {
 	rm -rf "$IMAGE_PATH" || die "failed to remove unpacked upgrade image"
 
 	remove_upgrade_properties
+
+	if [[ -f "$HOTFIX_PATH" ]]; then
+		rm -f "$HOTFIX_PATH" || die "failed to remove hotfix file"
+	fi
 }
 
 [[ "$EUID" -ne 0 ]] && die "must be run as root"


### PR DESCRIPTION
remove the hotfix file post-upgrade.

ab-pre-push : http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/3831/

Testing : tested deferred upgrade of an engine with a non-empty hotfix file using upgrade image from above build. The hotfix file was removed post-upgrade.