### PR TITLE
DLPX-70914 [Backport of DLPX-70835 to 6.0.4.0] disable usb-storage device module loading in delphix 6.x (5.3 migration part)

### DIFF
--- a/live-build/misc/migration-scripts/dx_apply
+++ b/live-build/misc/migration-scripts/dx_apply
@@ -276,6 +276,7 @@ LX_CMDLINE=(
 	'mitigations=off'
 	'elevator=noop'
 	'init_on_alloc=0'
+	'usbcore.nousb=1'
 )
 
 #


### PR DESCRIPTION
This is the sibling PR of https://github.com/delphix/delphix-platform/pull/243. This appliance-build change sets the grub menu for migrations, whereas the delphix-platform PR deals with fresh installs and upgrades.

ab-pre-push (includes migration testing): http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/3813/