### PR TITLE
DLPX-71311 [Backport of DLPX-69447 to 6.0.4.0] Fixed hotfixes should be removed from /etc/hotfix during upgrade application

### DIFF
--- a/upgrade/upgrade-scripts/common.sh
+++ b/upgrade/upgrade-scripts/common.sh
@@ -18,6 +18,7 @@
 # shellcheck disable=SC2034
 UPDATE_DIR="/var/dlpx-update"
 LOG_DIRECTORY="/var/tmp/delphix-upgrade"
+HOTFIX_PATH="/etc/hotfix"
 
 #
 # We embed information as dataset properties in our rootfs containers.

--- a/upgrade/upgrade-scripts/upgrade
+++ b/upgrade/upgrade-scripts/upgrade
@@ -446,6 +446,10 @@ function finalize() {
 	rm -rf "$IMAGE_PATH" || die "failed to remove unpacked upgrade image"
 
 	remove_upgrade_properties
+
+	if [[ -f "$HOTFIX_PATH" ]]; then
+		rm -f "$HOTFIX_PATH" || die "failed to remove hotfix file"
+	fi
 }
 
 [[ "$EUID" -ne 0 ]] && die "must be run as root"


### PR DESCRIPTION
clean cherry-pick of https://github.com/delphix/appliance-build/pull/482

git ab-pre-push: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/3839/