### PR TITLE
Related to TOOL-9835: Add py-six to DCenter appliance-build ansible role

### DIFF
--- a/live-build/misc/ansible-roles/appliance-build.dcenter/tasks/main.yml
+++ b/live-build/misc/ansible-roles/appliance-build.dcenter/tasks/main.yml
@@ -30,6 +30,7 @@
       - python-paramiko
       - python-pip
       - python-requests
+      - python-six
       - python-tenacity
       - python2.7
       - telnet


### PR DESCRIPTION
Related to [TOOL-9835](https://jira.delphix.com/browse/TOOL-9835) to add linting to dcenter-gate, Python's `six` module is being added as a dependency. Currently `six` is already installed on original DCenter, DCoL1, DCoL2, and scale-dc2, but to ensure this module is imported in future DCenter builds I would like to add `six` as part of the Ansible role.