### PR TITLE
Update DCenter Python package list

### DIFF
--- a/live-build/misc/ansible-roles/appliance-build.dcenter/tasks/main.yml
+++ b/live-build/misc/ansible-roles/appliance-build.dcenter/tasks/main.yml
@@ -26,13 +26,26 @@
       - libldap2-dev
       - libsasl2-dev
       - nfs-kernel-server
+      - python-dbg
+      - python-dev
       - python-ldap
       - python-paramiko
       - python-pip
-      - python-requests
+      - python-pyvmomi
       - python-six
       - python-tenacity
+      - python-virtualenv
       - python2.7
+      - python3
+      - python3-dbg
+      - python3-dev
+      - python3-ldap
+      - python3-paramiko
+      - python3-pip
+      - python3-pyvmomi
+      - python3-six
+      - python3-tenacity
+      - python3-virtualenv
       - telnet
     state: present
   register: result


### PR DESCRIPTION
### Summary

Updates the DCenter Python package list to adapt to recent changes in `dcenter-gate` and prepare for future work to migrate to Python 3 and pyVmomi.

### Details

- Add `python-dbg` and `python-dev` for use with GDB.
- Remove `python-requests`, since we no longer depend on it as of TOOL-9913.
- Add `python-pyvmomi`, because we eventually plan to migrate from PySphere to pyVmomi. Installing the package now enables us to begin preliminary testing with pyVmomi.
- Add `python-virtualenv`, because we eventually plan to deploy our dependencies in a virtual environment. Installing the package now enables us to begin preliminary testing of virtual environments.
- Add Python 3 versions of all Python 2 packages, because we eventually plan to migrate from Python 2 to Python 3. Installing Python 3 now enables us to begin preliminary testing with Python 3.

Note that the existing `dc(1)` command explicitly invokes `/usr/bin/python2.7`, so the existing deployment will remain on the Python 2.7 runtime until we decide to cut over to Python 3. At that point, we can remove the explicit installation of any Python 2.7-related DCoL packages.

### Testing Done

Built the image and imported to AWS: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/3891/

Logged into the image and ensured that the relevant packages were installed.

### Deployment Plan

Will ensure that all existing DCoL hosts are updated with this set of packages.