### PR TITLE
DLPX-71833 ui-precommit fails to start ChromeHeadless

### DIFF
--- a/live-build/misc/ansible-roles/appliance-build.unittest-internal/tasks/main.yml
+++ b/live-build/misc/ansible-roles/appliance-build.unittest-internal/tasks/main.yml
@@ -25,6 +25,7 @@
       - git
       - python-minimal
       - chromium-browser
+      - libxss1
     state: present
 
 - user:


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Build was run locally and any changes were pushed
- [ ] Lint has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
HeadlessChrome cannot be started, thus `ui-precommit` runs are failing.

Issue Number: DLPX-71833


## What is the new behavior?
We use `apt-get install chromium-browser` to install Chromium and its dependencies, so when running the UI unit tests, Puppeteer can start the headless chrome.

But in the new version of chromium-browser, `apt-get install chromium-browser` doesn't install all necessary dependencies. libXss.so.1 is missing. So the headless chrome cannot be started.

The fix is to manually add libXss.so.1 to the list of `apt-get install` to make sure it is installed.

This build shows with this fix, headless chrome can be started to run the tests.

[Build](http://selfservice.jenkins.delphix.com/job/dlpx-app-gate/job/master/job/integration-tests/job/ui-precommit/8656/)

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
