### PR TITLE
TOOL-10160 linux-pkg rework: main appliance-build change

### DIFF
--- a/live-build/build.gradle
+++ b/live-build/build.gradle
@@ -21,14 +21,7 @@ apply from: "${rootProject.projectDir}/gradle-lib/util.gradle"
 task ancillaryRepository(type: Exec) {
     inputs.file "${rootProject.projectDir}/scripts/build-ancillary-repository.sh"
 
-    for (envVar in ["AWS_S3_URI_VIRTUALIZATION",
-                    "AWS_S3_URI_USERLAND_PKGS",
-                    "AWS_S3_URI_MASKING",
-                    "AWS_S3_URI_ZFS",
-                    "AWS_S3_PREFIX_VIRTUALIZATION",
-                    "AWS_S3_PREFIX_MASKING",
-                    "AWS_S3_PREFIX_USERLAND_PKGS",
-                    "AWS_S3_PREFIX_KERNEL_PKGS"]) {
+    for (envVar in ["COMBINED_PACKAGES_S3_URL"]) {
         inputs.property(envVar, System.getenv(envVar)).optional(true)
     }
 

--- a/scripts/build-ancillary-repository.sh
+++ b/scripts/build-ancillary-repository.sh
@@ -116,8 +116,7 @@ fi
 echo "Running with UPSTREAM_BRANCH set to ${UPSTREAM_BRANCH}"
 
 AWS_S3_URI_COMBINED_PACKAGES=$(resolve_s3_uri \
-	"$AWS_S3_URI_COMBINED_PACKAGES" \
-	"$AWS_S3_URI_COMBINED_PACKAGES" \
+	"$AWS_S3_URI_COMBINED_PACKAGES" "" \
 	"devops-gate/master/linux-pkg/${UPSTREAM_BRANCH}/combine-packages/post-push/latest")
 
 #

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -71,3 +71,24 @@ function download_delphix_s3_debs() {
 	popd &>/dev/null
 	rm -rf "$tmp_directory"
 }
+
+function download_delphix_s3_debs_multidir() {
+	local pkg_directory="$1"
+	local S3_URI="$2"
+	local tmp_directory
+
+	tmp_directory=$(mktemp -d -p "$TOP/build" tmp.s3-debs.XXXXXXXXXX)
+	pushd "$tmp_directory" &>/dev/null
+
+	aws s3 sync --only-show-errors "$S3_URI" .
+
+	for subdir in */; do
+		pushd "$subdir" &>/dev/null
+		sha256sum -c --strict SHA256SUMS
+		mv ./*deb "$pkg_directory/"
+		popd &>/dev/null
+	done
+
+	popd &>/dev/null
+	rm -rf "$tmp_directory"
+}


### PR DESCRIPTION
This is the main linux-pkg commit in the linux-pkg rework project (TOOL-9778).

**See [design document](https://docs.google.com/document/d/1wD5VZGhTLac7xzKZSJyKkJq72ailorCivJwppP0tkWQ) for more information.** 

The summary is that the new `combine-packages` job will gather the artifacts for all the packages except upgrade-verification into a single S3 location, which will now be consumed by appliance-build.

## Dependenies

See [work plan](https://docs.google.com/document/d/1wD5VZGhTLac7xzKZSJyKkJq72ailorCivJwppP0tkWQ/edit#heading=h.st5bs7ygy0q6) for info on dependencies on PRs in other repositories.

## Testing
See [test worksheet](https://docs.google.com/spreadsheets/d/1PXy6vk92tnhI9B1FHTrR1Ay7YR2_qVRyga46WYKfwwQ)