### PR TITLE
Backports of Python package changes

### DIFF
--- a/live-build/misc/ansible-roles/appliance-build.dcenter/tasks/main.yml
+++ b/live-build/misc/ansible-roles/appliance-build.dcenter/tasks/main.yml
@@ -30,6 +30,7 @@
       - python-paramiko
       - python-pip
       - python-requests
+      - python-six
       - python-tenacity
       - python2.7
       - telnet

--- a/live-build/misc/ansible-roles/appliance-build.dcenter/tasks/main.yml
+++ b/live-build/misc/ansible-roles/appliance-build.dcenter/tasks/main.yml
@@ -26,13 +26,26 @@
       - libldap2-dev
       - libsasl2-dev
       - nfs-kernel-server
+      - python-dbg
+      - python-dev
       - python-ldap
       - python-paramiko
       - python-pip
-      - python-requests
+      - python-pyvmomi
       - python-six
       - python-tenacity
+      - python-virtualenv
       - python2.7
+      - python3
+      - python3-dbg
+      - python3-dev
+      - python3-ldap
+      - python3-paramiko
+      - python3-pip
+      - python3-pyvmomi
+      - python3-six
+      - python3-tenacity
+      - python3-virtualenv
       - telnet
     state: present
   register: result


### PR DESCRIPTION
Clean backports of #485 and #488 to `6.0/release`.