### PR TITLE
DCenter package updates

### DIFF
--- a/live-build/misc/ansible-roles/appliance-build.dcenter/tasks/main.yml
+++ b/live-build/misc/ansible-roles/appliance-build.dcenter/tasks/main.yml
@@ -25,7 +25,9 @@
       - isc-dhcp-server
       - libldap2-dev
       - libsasl2-dev
+      - nfs-common-dbgsym
       - nfs-kernel-server
+      - nfs-kernel-server-dbgsym
       - python-dbg
       - python-dev
       - python-ldap
@@ -34,18 +36,17 @@
       - python-pyvmomi
       - python-six
       - python-tenacity
-      - python-virtualenv
       - python2.7
       - python3
       - python3-dbg
       - python3-dev
       - python3-ldap
-      - python3-paramiko
       - python3-pip
       - python3-pyvmomi
       - python3-six
       - python3-tenacity
-      - python3-virtualenv
+      - python3-venv
+      - targetcli-fb
       - telnet
     state: present
   register: result


### PR DESCRIPTION
## Abstract

Amends #488. Updates the DCenter package list to improve debuggability, adapt to recent changes in `dcenter-gate`, and prepare for future work.

## Details

- Adding debug symbols via `nfs-common-dbgsym` and `nfs-kernel-server-dbgsym` to improve debuggability.
- Removing `python3-paramiko`, as it is no longer needed when running `dcenter-gate` with pyVmomi. Note that Paramiko must remain installed for Python 2 until we drop support for PySphere (scheduled for later this month).
- Removing `virtualenv` in favor of `venv` as in [QI-1699](https://jira.delphix.com/browse/QI-1699). Note that we do not currently use a virtual environment, but we plan to start using one in future packaging and deployment work. We will likely be Python 3 only by the time that work is begun, so it makes more sense to use the native Python 3 `venv` than `virtualenv`.
- Adding `targetcli-fb` in order to support prototyping `dc volume`.

## Testing Done

`git ab-pre-push`: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/4309/consoleFull

Booted the image and ran various tests to ensure the changes were present:

```
$ dpkg -L nfs-common-dbgsym
/.
/usr
/usr/lib
/usr/lib/debug
/usr/lib/debug/.build-id
/usr/lib/debug/.build-id/25
/usr/lib/debug/.build-id/25/f21510b61343f691c0f31edb3f192b8a8cd3f3.debug
/usr/lib/debug/.build-id/2c
/usr/lib/debug/.build-id/2c/6dc4a5afcd69c0b0663bc44836611fbf8fce81.debug
/usr/lib/debug/.build-id/35
/usr/lib/debug/.build-id/35/35fdedf836a3a9a686690e24da4647211671a0.debug
/usr/lib/debug/.build-id/39
/usr/lib/debug/.build-id/39/1801b04d7d4c5db063abb1f878c5f223c77174.debug
/usr/lib/debug/.build-id/3b
/usr/lib/debug/.build-id/3b/b0cbab67f36062759b6588f385f2e09b31d68d.debug
/usr/lib/debug/.build-id/50
/usr/lib/debug/.build-id/50/8cabc3e131aa2d3aaa2ddc9553297d9d73f778.debug
/usr/lib/debug/.build-id/52
/usr/lib/debug/.build-id/52/05ec110990575df3021dd0c74175ff3322ad3b.debug
/usr/lib/debug/.build-id/64
/usr/lib/debug/.build-id/64/c764831c61c663aeb920f2a4c61745adaac26d.debug
/usr/lib/debug/.build-id/a3
/usr/lib/debug/.build-id/a3/55693526350162aee505382e3c513d636ff816.debug
/usr/lib/debug/.build-id/cb
/usr/lib/debug/.build-id/cb/cd0643154b3ab9321613058347b00f78de27ea.debug
/usr/lib/debug/.build-id/e8
/usr/lib/debug/.build-id/e8/6ce97e694ed2a78175d20c822c3835bc3ca886.debug
/usr/share
/usr/share/doc
/usr/share/doc/nfs-common-dbgsym
$ dpkg -L nfs-kernel-server-dbgsym
/.
/usr
/usr/lib
/usr/lib/debug
/usr/lib/debug/.build-id
/usr/lib/debug/.build-id/0a
/usr/lib/debug/.build-id/0a/f4d327283f2fcfd5ca21608f31479671254bcc.debug
/usr/lib/debug/.build-id/31
/usr/lib/debug/.build-id/31/39d2a6b94e82f801cdba5e8d4c692aca52f9af.debug
/usr/lib/debug/.build-id/3d
/usr/lib/debug/.build-id/3d/795fad40dc8d87d7032c5e7ccccb698fac82e3.debug
/usr/lib/debug/.build-id/cc
/usr/lib/debug/.build-id/cc/58b1ae38849f4b0a68a51f0a2ae99586f5a39b.debug
/usr/share
/usr/share/doc
/usr/share/doc/nfs-kernel-server-dbgsym
$ python2.7 -m virtualenv
/usr/bin/python2.7: No module named virtualenv
$ python3 -m paramiko
/usr/bin/python3: No module named paramiko
$ python3 -m virtualenv
/usr/bin/python3: No module named virtualenv
$ python3 -m venv /tmp/venv
$ sudo systemctl status rtslib-fb-targetctl.service
● rtslib-fb-targetctl.service - LSB: Start LIO targets
   Loaded: loaded (/etc/init.d/rtslib-fb-targetctl; generated)
  Drop-In: /lib/systemd/system/rtslib-fb-targetctl.service.d
           └─override.conf
   Active: inactive (dead)
     Docs: man:systemd-sysv-generator(8)
$ dpkg --get-selections | grep rtslib
python-rtslib-fb                                install
python3-rtslib-fb                               install
$ python3
Python 3.6.9 (default, Oct  8 2020, 12:12:24) 
[GCC 8.4.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import rtslib_fb
>>> 
$
```

Furthermore, ensured that [our customizations to `rtslib-fb-targetctl.service`](https://github.com/delphix/delphix-platform/blob/db4d0fbf037a32aeb059ea8d6235bd106dfe6480/files/common/lib/systemd/system/rtslib-fb-targetctl.service.d/override.conf) were present:

```
$ cat /lib/systemd/system/rtslib-fb-targetctl.service.d/override.conf
[Unit]
#
# ZFS Volumes (zvols) must be ready when we start this service.
#
Requires=zfs-volumes.target
After=zfs-volumes.target

#
# During upgrade verification, the root filesystem will be booted as a
# container using systemd-nspawn. When the rtslib-fb-targetctl service
# runs in this container, it can cause corruption of the iSCSI volumes
# on the host (due to us allowing all capabilities to the container).
# Thus, to workaround this problem, we explicitly disable this service
# from running when inside of the container.
#
ConditionVirtualization=!container
```

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build was run locally and any changes were pushed
- [x] Lint has passed locally and any fixes were made for failures


## Pull request type

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?

Unneeded packages are installed and needed packages are not installed.

## What is the new behavior?


Unneeded packages are no longer and installed and needed packages are installed.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No