### PR TITLE
TOOL-10595 [Backport of TOOL-10160 to 6.0.6.0] linux-pkg rework: main appliance-build change

### DIFF
--- a/live-build/build.gradle
+++ b/live-build/build.gradle
@@ -21,14 +21,7 @@ apply from: "${rootProject.projectDir}/gradle-lib/util.gradle"
 task ancillaryRepository(type: Exec) {
     inputs.file "${rootProject.projectDir}/scripts/build-ancillary-repository.sh"
 
-    for (envVar in ["AWS_S3_URI_VIRTUALIZATION",
-                    "AWS_S3_URI_USERLAND_PKGS",
-                    "AWS_S3_URI_MASKING",
-                    "AWS_S3_URI_ZFS",
-                    "AWS_S3_PREFIX_VIRTUALIZATION",
-                    "AWS_S3_PREFIX_MASKING",
-                    "AWS_S3_PREFIX_USERLAND_PKGS",
-                    "AWS_S3_PREFIX_KERNEL_PKGS"]) {
+    for (envVar in ["COMBINED_PACKAGES_S3_URL"]) {
         inputs.property(envVar, System.getenv(envVar)).optional(true)
     }
 

--- a/scripts/build-ancillary-repository.sh
+++ b/scripts/build-ancillary-repository.sh
@@ -62,12 +62,12 @@ function build_ancillary_repository() {
 }
 
 #
-# The first-party packages produced by Delphix are stored in Amazon S3.
+# The packages produced by Delphix are stored in Amazon S3.
 # Thus, in order to populate the ancillary repository with these
 # packages, they must be downloaded from S3, so they can be then
 # inserted into the Aptly repository.
 #
-# Here, we determine the URI of each of the first-party packages, and
+# Here, we determine the URI of each of the Delphix packages, and
 # then use these URIs to download the packages later. Making this
 # determination is a little complex, and is dependent on the policy set
 # forth by the teams producing and storing the packages.
@@ -76,12 +76,12 @@ function build_ancillary_repository() {
 # which the packages are downloaded:
 #
 # 1. If the package specific AWS_S3_URI environment variable is provided
-#    (e.g. AWS_S3_URI_VIRTUALIZATION), then this URI will be used to
+#    (e.g. AWS_S3_URI_UPGRADE_VERIFICATION), then this URI will be used to
 #    download the package. This is the simplest case, and enables the
 #    user of this script to directly influence this script.
 #
 # 2. If the package specific AWS_S3_PREFIX environment variable is
-#    provided (e.g. AWS_S3_PREFIX_VIRTUALIZATION), then this value is
+#    provided (e.g. AWS_S3_PREFIX_UPGRADE_VERIFICATION), then this value is
 #    used to build the URI that will be used based on the default S3
 #    bucket that is used.
 #
@@ -115,25 +115,9 @@ else
 fi
 echo "Running with UPSTREAM_BRANCH set to ${UPSTREAM_BRANCH}"
 
-AWS_S3_URI_VIRTUALIZATION=$(resolve_s3_uri \
-	"$AWS_S3_URI_VIRTUALIZATION" \
-	"$AWS_S3_PREFIX_VIRTUALIZATION" \
-	"dlpx-app-gate/${UPSTREAM_BRANCH}/build-package/post-push/latest")
-
-AWS_S3_URI_MASKING=$(resolve_s3_uri \
-	"$AWS_S3_URI_MASKING" \
-	"$AWS_S3_PREFIX_MASKING" \
-	"dms-core-gate/${UPSTREAM_BRANCH}/build-package/post-push/latest")
-
-AWS_S3_URI_USERLAND_PKGS=$(resolve_s3_uri \
-	"$AWS_S3_URI_USERLAND_PKGS" \
-	"$AWS_S3_PREFIX_USERLAND_PKGS" \
-	"devops-gate/master/linux-pkg-build/${UPSTREAM_BRANCH}/userland/post-push/latest")
-
-AWS_S3_URI_KERNEL_PKGS=$(resolve_s3_uri \
-	"$AWS_S3_URI_KERNEL_PKGS" \
-	"$AWS_S3_PREFIX_KERNEL_PKGS" \
-	"devops-gate/master/linux-pkg-build/${UPSTREAM_BRANCH}/kernel/post-push/latest")
+AWS_S3_URI_COMBINED_PACKAGES=$(resolve_s3_uri \
+	"$AWS_S3_URI_COMBINED_PACKAGES" "" \
+	"devops-gate/master/linux-pkg/${UPSTREAM_BRANCH}/combine-packages/post-push/latest")
 
 #
 # All package files will be placed into this temporary directory, such
@@ -144,13 +128,10 @@ mkdir -p "$TOP/build"
 PKG_DIRECTORY=$(mktemp -d -p "$TOP/build" tmp.pkgs.XXXXXXXXXX)
 
 #
-# Now that we've determined the URI of all first-party packages, we can
-# proceed to download these packages.
+# Now that we've determined the URI of the Delphix-built packages, we can
+# download them.
 #
-download_delphix_s3_debs "$PKG_DIRECTORY" "$AWS_S3_URI_VIRTUALIZATION"
-download_delphix_s3_debs "$PKG_DIRECTORY" "$AWS_S3_URI_MASKING"
-download_delphix_s3_debs "$PKG_DIRECTORY" "$AWS_S3_URI_USERLAND_PKGS"
-download_delphix_s3_debs "$PKG_DIRECTORY" "$AWS_S3_URI_KERNEL_PKGS"
+download_delphix_s3_debs_multidir "$PKG_DIRECTORY" "$AWS_S3_URI_COMBINED_PACKAGES/packages"
 
 #
 # Now that our temporary package directory has been populated with all

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -66,3 +66,24 @@ function download_delphix_s3_debs() {
 	popd &>/dev/null
 	rm -rf "$tmp_directory"
 }
+
+function download_delphix_s3_debs_multidir() {
+	local pkg_directory="$1"
+	local S3_URI="$2"
+	local tmp_directory
+
+	tmp_directory=$(mktemp -d -p "$TOP/build" tmp.s3-debs.XXXXXXXXXX)
+	pushd "$tmp_directory" &>/dev/null
+
+	aws s3 sync --only-show-errors "$S3_URI" .
+
+	for subdir in */; do
+		pushd "$subdir" &>/dev/null
+		sha256sum -c --strict SHA256SUMS
+		mv ./*deb "$pkg_directory/"
+		popd &>/dev/null
+	done
+
+	popd &>/dev/null
+	rm -rf "$tmp_directory"
+}


### PR DESCRIPTION
This is a clean backport of #490 to get the linux-pkg rework on 6.0/stage and 6.0/release. Once this lands on 6.0/stage I'll merge this change into 6.0/release.

## Dependencies

This change will have to be pushed along with a bunch of other changes. See the [work plan](https://docs.google.com/document/d/1wD5VZGhTLac7xzKZSJyKkJq72ailorCivJwppP0tkWQ/edit#heading=h.20tnd5kqm8eg) for more info.

## Testing
See https://docs.google.com/document/d/1wD5VZGhTLac7xzKZSJyKkJq72ailorCivJwppP0tkWQ/edit#heading=h.czqhgs5qmlfa