### PR TITLE
DLPX-72869 Patch VMDK generation tool to mark that the vmdk contains a vmtools install

### DIFF
--- a/bootstrap/roles/appliance-build.bootstrap/tasks/main.yml
+++ b/bootstrap/roles/appliance-build.bootstrap/tasks/main.yml
@@ -44,6 +44,20 @@
       - zfsutils-linux
     state: present
 
+#
+# See DLPX-72860 for more info on the custom package.
+#
+- name: Custom livecd-rootfs package | Download
+  get_url:
+    url: 'https://artifactory.delphix.com:443/artifactory/linux-pkg/livecd-rootfs/6.0.6.0/livecd-rootfs_2.525.47-delphix1_amd64.deb'
+    dest: '/var/tmp/livecd-rootfs_2.525.47-delphix1_amd64.deb'
+    checksum: 'sha256:9f090adf288d115b2eb10d2dced2a76113339eb95dc5db91fac4b89b2bef07a0'
+
+- name: Custom livecd-rootfs package | Install
+  apt:
+    deb: '/var/tmp/livecd-rootfs_2.525.47-delphix1_amd64.deb'
+    state: present
+
 - modprobe:
     name: zfs
     state: present


### PR DESCRIPTION
I've downloaded the original livecd-rootfs package, manually applied the patch (attached in JIRA) and repackaged the package.

An alternative approach would be to patch the installed package after its installation (see https://github.com/pzakha/appliance-build/commit/99c88ca4121e3c6f3d44e56a6edba6dffb1cf034). However the patch could fail to apply in the future if Ubuntu was to update the package with some changes in that file.

We will need to create a bug in JIRA to remember to revert back to the default Ubuntu package once that patch is integrated upstream and pulled into bionic. This bug is being tracked upstream by https://bugs.launchpad.net/ubuntu/+source/open-vm-tools/+bug/1893898.

## Motivation
Without this fix, Guest OS Customizations cannot be applied when cloning this OVA as ESX thinks that open-vm-tools is not installed on the Guest image and so GOSC would fail (See https://communities.vmware.com/t5/VMware-vCenter-Discussions/VM-customization-does-not-work-until-booted-once/m-p/522372). Without this fix, the VM must be booted at least once, at which point ESX will detect that open-vm-tools is running, and store the version of the open-vm-tools package inside the vmdk file; however we want to be able to apply GOSC on a clone of an OVA that has never been booted, as the Delphix Appliance does a bunch of customizations on first boot.

## Open Questions
Do we want to find another place for the package in artifactory? I've put it under linux-pkg because that's the bucket I had write access to, but it might not be the best place for it.

## Testing
- ab-pre-push: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/4361/
- Checked appliance-build output and made sure custom package was installed.
- Manually cloned produced OVA and verified that GOSC works.