### PR TITLE
DLPX-73044 [Backport of DLPX-72860 to 6.0.6.0] Patch VMDK generation tool to mark that the vmdk contains a vmtools install

### DIFF
--- a/bootstrap/roles/appliance-build.bootstrap/tasks/main.yml
+++ b/bootstrap/roles/appliance-build.bootstrap/tasks/main.yml
@@ -44,6 +44,20 @@
       - zfsutils-linux
     state: present
 
+#
+# See DLPX-72860 for more info on the custom package.
+#
+- name: Custom livecd-rootfs package | Download
+  get_url:
+    url: 'https://artifactory.delphix.com:443/artifactory/linux-pkg/livecd-rootfs/6.0.6.0/livecd-rootfs_2.525.47-delphix1_amd64.deb'
+    dest: '/var/tmp/livecd-rootfs_2.525.47-delphix1_amd64.deb'
+    checksum: 'sha256:9f090adf288d115b2eb10d2dced2a76113339eb95dc5db91fac4b89b2bef07a0'
+
+- name: Custom livecd-rootfs package | Install
+  apt:
+    deb: '/var/tmp/livecd-rootfs_2.525.47-delphix1_amd64.deb'
+    state: present
+
 - modprobe:
     name: zfs
     state: present


### PR DESCRIPTION
Clean cherry-pick of https://github.com/delphix/appliance-build/pull/497

## Testing
ab-pre-push: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/4384/