### PR TITLE
Github Action "::set-env" is no longer supported

### DIFF
--- a/.github/scripts/install-ansible-lint.sh
+++ b/.github/scripts/install-ansible-lint.sh
@@ -6,10 +6,10 @@ git checkout v3.4.21
 git branch -D master
 
 #
-# GitHub Actions exposes some "debugging commands" that can be used to
+# GitHub Actions exposes the GITHUB_ENV file that can be used to
 # manipulate the environment of the job that's running. In this case, we
-# use the "set-env" command to modify the environment of the job, to
-# edit the PATH and PYTHONPATH global variables.
+# use it to modify the environment of the job, to edit the PATH and
+# PYTHONPATH global variables.
 #
-echo "::set-env name=PATH::${PATH}:/opt/ansible-lint/bin"
-echo "::set-env name=PYTHONPATH::${PYTHONPATH}:/opt/ansible-lint/lib"
+echo "PATH=${PATH}:/opt/ansible-lint/bin" >> ${GITHUB_ENV}
+echo "PYTHONPATH=${PYTHONPATH}:/opt/ansible-lint/lib" >> ${GITHUB_ENV}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,7 +6,7 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - run: sudo ./.github/scripts/install-gradle.sh
-      - run: sudo ./.github/scripts/install-ansible-lint.sh
+      - run: sudo -E ./.github/scripts/install-ansible-lint.sh
       - run: /opt/gradle-5.1/bin/gradle ansibleCheck
   check-shellcheck:
     runs-on: ubuntu-18.04


### PR DESCRIPTION
The Github Action "::set-env" command is no longer supported and results
in failures when it is used. This change updates our scripts to remove
the usage of that command, and use the "GITHUB_ENV" interface instead.