### PR TITLE
Remove dangling references to dcenter.conf

### DIFF
--- a/live-build/misc/ansible-roles/appliance-build.dcenter/tasks/main.yml
+++ b/live-build/misc/ansible-roles/appliance-build.dcenter/tasks/main.yml
@@ -67,11 +67,6 @@
     accept_hostkey: yes
     update: no
 
-- copy:
-    dest: "/etc/dcenter.conf"
-    content: |
-      [[ -z "$DC_ROOT" ]] && export DC_ROOT="dcenter"
-
 #
 # By default, ubuntu restricts directories where dhcpd and named
 # can operate. For dcenter, we maintain the dhcp configuration


### PR DESCRIPTION
As of TOOL-10692, this is dead code and can be deleted.