### PR TITLE
Backports of DCenter package updates

### DIFF
--- a/live-build/misc/ansible-roles/appliance-build.dcenter/tasks/main.yml
+++ b/live-build/misc/ansible-roles/appliance-build.dcenter/tasks/main.yml
@@ -25,7 +25,9 @@
       - isc-dhcp-server
       - libldap2-dev
       - libsasl2-dev
+      - nfs-common-dbgsym
       - nfs-kernel-server
+      - nfs-kernel-server-dbgsym
       - python-dbg
       - python-dev
       - python-ldap
@@ -34,18 +36,17 @@
       - python-pyvmomi
       - python-six
       - python-tenacity
-      - python-virtualenv
       - python2.7
       - python3
       - python3-dbg
       - python3-dev
       - python3-ldap
-      - python3-paramiko
       - python3-pip
       - python3-pyvmomi
       - python3-six
       - python3-tenacity
-      - python3-virtualenv
+      - python3-venv
+      - targetcli-fb
       - telnet
     state: present
   register: result
@@ -65,11 +66,6 @@
     dest: /opt/dcenter/lib/dcenter-gate
     accept_hostkey: yes
     update: no
-
-- copy:
-    dest: "/etc/dcenter.conf"
-    content: |
-      [[ -z "$DC_ROOT" ]] && export DC_ROOT="dcenter"
 
 #
 # By default, ubuntu restricts directories where dhcpd and named


### PR DESCRIPTION
## Abstract

Backports of #494 and #503 to `6.0/release` in preparation for the next scheduled upgrade of our production systems.

## Testing Done

Repeated the testing from the original changes.

`git ab-pre-push`: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/4486/consoleFull

Booted the image and ran various tests to ensure the changes were present:

```
$ dpkg -L nfs-common-dbgsym
/.
/usr
/usr/lib
/usr/lib/debug
/usr/lib/debug/.build-id
/usr/lib/debug/.build-id/0c
/usr/lib/debug/.build-id/0c/2167c30e99c1bc229ce3618e77f7e650706104.debug
/usr/lib/debug/.build-id/10
/usr/lib/debug/.build-id/10/487e7dc455dd86b267a1a12625fc6b63fb032e.debug
/usr/lib/debug/.build-id/1a
/usr/lib/debug/.build-id/1a/14ab844da9900ecde197db5daa998818f58652.debug
/usr/lib/debug/.build-id/1d
/usr/lib/debug/.build-id/1d/b8e41cb0293d6b993f71a6c13946eeb685be32.debug
/usr/lib/debug/.build-id/28
/usr/lib/debug/.build-id/28/b13069ff86ac71a9bfc2a45107dd1308107924.debug
/usr/lib/debug/.build-id/3b
/usr/lib/debug/.build-id/3b/27ef3eda510992b39d6c6234a7bc27e5883841.debug
/usr/lib/debug/.build-id/44
/usr/lib/debug/.build-id/44/2c8a2847072683bb58852469d1024ca3e55179.debug
/usr/lib/debug/.build-id/46
/usr/lib/debug/.build-id/46/e317f713336156baee34cc47e624680a2af3c7.debug
/usr/lib/debug/.build-id/7e
/usr/lib/debug/.build-id/7e/7fdcc6badd7f968ffc04b6da9ab00e5b946928.debug
/usr/lib/debug/.build-id/91
/usr/lib/debug/.build-id/91/bfb7d65b953a1870566706930e3eb1fd847d28.debug
/usr/lib/debug/.build-id/fa
/usr/lib/debug/.build-id/fa/ef2f37fa170050f10a0a88ec52c4dd29465e3d.debug
/usr/share
/usr/share/doc
/usr/share/doc/nfs-common-dbgsym
$ dpkg -L nfs-kernel-server-dbgsym
/.
/usr
/usr/lib
/usr/lib/debug
/usr/lib/debug/.build-id
/usr/lib/debug/.build-id/45
/usr/lib/debug/.build-id/45/3c4c592e95c023f1f5be9734036a4560733167.debug
/usr/lib/debug/.build-id/5f
/usr/lib/debug/.build-id/5f/8a1d2034c7c78b1216cd99be1723e011fed98c.debug
/usr/lib/debug/.build-id/cd
/usr/lib/debug/.build-id/cd/82ef5d362ce8db86ded9f8becd3de81f9d08ca.debug
/usr/lib/debug/.build-id/d6
/usr/lib/debug/.build-id/d6/94710a6201a6b55e48fa51105663f1c1c389a5.debug
/usr/share
/usr/share/doc
/usr/share/doc/nfs-kernel-server-dbgsym
$ python2.7 -m virtualenv
/usr/bin/python2.7: No module named virtualenv
$ python3 -m paramiko
/usr/bin/python3: No module named paramiko
$ python3 -m virtualenv
/usr/bin/python3: No module named virtualenv
$ python3 -m venv /tmp/venv
$ sudo systemctl status rtslib-fb-targetctl.service
● rtslib-fb-targetctl.service - LSB: Start LIO targets
   Loaded: loaded (/etc/init.d/rtslib-fb-targetctl; generated)
  Drop-In: /lib/systemd/system/rtslib-fb-targetctl.service.d
           └─override.conf
   Active: inactive (dead)
     Docs: man:systemd-sysv-generator(8)
$ dpkg --get-selections | grep rtslib
python-rtslib-fb                                install
python3-rtslib-fb                               install
$ python3
Python 3.6.9 (default, Oct  8 2020, 12:12:24) 
[GCC 8.4.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import rtslib_fb
>>> 
$
```

Furthermore, ensured that [our customizations to `rtslib-fb-targetctl.service`](https://github.com/delphix/delphix-platform/blob/e20b76f9fc66afd639628f80f69aca1e56f1a39e/files/common/lib/systemd/system/rtslib-fb-targetctl.service.d/override.conf) were present:

```
$ cat /lib/systemd/system/rtslib-fb-targetctl.service.d/override.conf
[Unit]
#
# ZFS Volumes (zvols) must be ready when we start this service.
#
Requires=zfs-volumes.target
After=zfs-volumes.target

#
# During upgrade verification, the root filesystem will be booted as a
# container using systemd-nspawn. When the rtslib-fb-targetctl service
# runs in this container, it can cause corruption of the iSCSI volumes
# on the host (due to us allowing all capabilities to the container).
# Thus, to workaround this problem, we explicitly disable this service
# from running when inside of the container.
#
ConditionVirtualization=!container

[Service]
#
# Although delphix-migration already defines a RequiredBy dependency on
# rtslib-fb-targetctl, that dependency is only honored when delphix-migration
# is enabled. If delphix-migration was manually disabled before migration
# completed, we still want to prevent rtslib-fb-targetctl from running, so
# it is done with this check. Note that "ConditionPathExists" is not a
# valid alternative since the result of the check doesn't prevent
# rtslib-fb-targetctl's dependencies from running.
#
ExecStartPre=/bin/bash -xc "test ! -e /var/delphix/migration/perform-migration"
$
```

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build was run locally and any changes were pushed
- [x] Lint has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?

Unneeded packages are installed and needed packages are not installed.

## What is the new behavior?

Unneeded packages are no longer and installed and needed packages are installed.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No