### PR TITLE
DLPX-73299 appliance-build: Fetch upgrade-verify package from combined-packages bundle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,8 +53,7 @@ for (variant in allVariants) {
 
         for (envVar in ["DELPHIX_PLATFORMS", 
                         "AWS_S3_URI_LIVEBUILD_ARTIFACTS",
-                        "AWS_S3_URI_UPGRADE_VERIFICATION",
-                        "AWS_S3_PREFIX_UPGRADE_VERIFICATION"]) {
+                        "AWS_S3_URI_COMBINED_PACKAGES"]) {
             inputs.property(envVar, System.getenv(envVar)).optional(true)
         }
 

--- a/live-build/build.gradle
+++ b/live-build/build.gradle
@@ -21,7 +21,7 @@ apply from: "${rootProject.projectDir}/gradle-lib/util.gradle"
 task ancillaryRepository(type: Exec) {
     inputs.file "${rootProject.projectDir}/scripts/build-ancillary-repository.sh"
 
-    for (envVar in ["COMBINED_PACKAGES_S3_URL"]) {
+    for (envVar in ["AWS_S3_URI_COMBINED_PACKAGES"]) {
         inputs.property(envVar, System.getenv(envVar)).optional(true)
     }
 

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -15,6 +15,7 @@
 # limitations under the License.
 #
 
+# shellcheck disable=SC2034
 TOP=$(git rev-parse --show-toplevel 2>/dev/null)
 
 function die() {
@@ -24,8 +25,7 @@ function die() {
 
 function resolve_s3_uri() {
 	local pkg_uri="$1"
-	local pkg_prefix="$2"
-	local latest_subprefix="$3"
+	local latest_subprefix="$2"
 
 	local bucket="snapshot-de-images"
 	local jenkinsid="jenkins-ops"
@@ -33,10 +33,6 @@ function resolve_s3_uri() {
 
 	if [[ -n "$pkg_uri" ]]; then
 		resolved_uri="$pkg_uri"
-	elif [[ "$pkg_prefix" == s3* ]]; then
-		resolved_uri="$pkg_prefix"
-	elif [[ -n "$pkg_prefix" ]]; then
-		resolved_uri="s3://$bucket/$pkg_prefix"
 	elif [[ -n "$latest_subprefix" ]]; then
 		aws s3 cp --quiet \
 			"s3://$bucket/builds/$jenkinsid/$latest_subprefix" .
@@ -55,40 +51,87 @@ function resolve_s3_uri() {
 	fi
 }
 
-function download_delphix_s3_debs() {
-	local pkg_directory="$1"
-	local S3_URI="$2"
-	local tmp_directory
+#
+# Given an S3 URI pointing to combined-packages artifacts, download all of its
+# artifacts to target directory. If a package name is passed as an argument,
+# then only copy the artifacts for that package.
+#
+# When the combine-packages Jenkins job generates artifacts, it does not
+# copy around the artifacts for individual packages. Rather, it creates a
+# COMPONENTS file that has links to each package's artifacts.
+#
+# When appliance-build is ran via Jenkins, the Jenkins job copies the original
+# combined-packages artifacts to a new S3 location, then dereferences the
+# COMPONENTS file and copies all individual package artifacts into a
+# "packages" directory created under that new S3 location. Jenkins then passes
+# that combined-packages URI to live-build.
+#
+# Thus if a "packages" directory is found under the combined-packages S3 URI,
+# we assume that the dereferencing has already been done and so we just sync
+# the whole directory. Otherwise, we must dereference the COMPONENTS file here
+# and fetch the artifacts for each package.
+#
+# Here are the files that are expected to be found after the download.
+# <combined packages base directory>/
+#   COMPONENTS
+#   ... (some other metadata files)
+#   packages/
+#     package1/
+#       ... (package 1 artifacts)
+#     package2/
+#       ... (package 2 artifacts)
+#     ... (remaining packages' artifacts)
+#
+# shellcheck disable=SC2164
+function download_combined_packages_artifacts() {
+	local combined_pkgs_uri="$1"
+	local target_dir="$2"
+	local pkg="$3"
 
-	tmp_directory=$(mktemp -d -p "$TOP/build" tmp.s3-debs.XXXXXXXXXX)
-	pushd "$tmp_directory" &>/dev/null
+	pushd "$target_dir" &>/dev/null
 
-	aws s3 sync --only-show-errors "$S3_URI" .
-	sha256sum -c --strict SHA256SUMS
+	if [[ -n "$pkg" ]]; then
+		aws s3 sync --exclude 'packages/*' --include "packages/$pkg/*" \
+			--only-show-errors "$combined_pkgs_uri" .
+	else
+		aws s3 sync --only-show-errors "$combined_pkgs_uri" .
+	fi
 
-	mv ./*deb "$pkg_directory/"
+	if [[ -d packages ]]; then
+		popd &>/dev/null
+		return
+	fi
+
+	[[ -f COMPONENTS ]] || die "COMPONENTS file missing."
+	mkdir packages
+	pushd packages &>/dev/null
+
+	local pkgname s3uri
+	while read -r line; do
+		pkgname=$(echo "$line" | cut -d: -f 1 | tr -d '[:space:]')
+		s3uri=$(echo "$line" | cut -d: -f 2- | tr -d '[:space:]')
+		[[ -n "$pkg" ]] && [[ "$pkg" != "$pkgname" ]] && continue
+		mkdir "$pkgname"
+		pushd "$pkgname" &>/dev/null
+		aws s3 sync --only-show-errors "$s3uri" .
+		sha256sum -c --strict SHA256SUMS
+		popd &>/dev/null
+	done <../COMPONENTS
 
 	popd &>/dev/null
-	rm -rf "$tmp_directory"
+	popd &>/dev/null
 }
 
-function download_delphix_s3_debs_multidir() {
-	local pkg_directory="$1"
-	local S3_URI="$2"
-	local tmp_directory
+#
+# Find all .deb and .ddeb packages in source directory tree and move them
+# to target directory.
+#
+function extract_debs_into_dir() {
+	local source_dir="$1"
+	local target_dir="$2"
 
-	tmp_directory=$(mktemp -d -p "$TOP/build" tmp.s3-debs.XXXXXXXXXX)
-	pushd "$tmp_directory" &>/dev/null
-
-	aws s3 sync --only-show-errors "$S3_URI" .
-
-	for subdir in */; do
-		pushd "$subdir" &>/dev/null
-		sha256sum -c --strict SHA256SUMS
-		mv ./*deb "$pkg_directory/"
-		popd &>/dev/null
-	done
-
-	popd &>/dev/null
-	rm -rf "$tmp_directory"
+	[[ -d "$target_dir" ]] ||
+		die "'$target_dir' must be an existing directory"
+	find "$source_dir" -name '*.deb' -exec mv {} "$target_dir" \;
+	find "$source_dir" -name '*.ddeb' -exec mv {} "$target_dir" \;
 }


### PR DESCRIPTION
This is a follow-up to http://reviews.delphix.com/r/64085/, which adds the upgrade-verify package to the combine-packages bundle.

Fixes #509

## Dependencies
Must be pushed after http://reviews.delphix.com/r/64085/

## Testing
- See comments in https://jira.delphix.com/browse/TOOL-10766 for the testing that was done
- Manually tested that this fixes issue #509 