### PR TITLE
Stop installing PySphere

### DIFF
--- a/live-build/misc/ansible-roles/appliance-build.dcenter/tasks/main.yml
+++ b/live-build/misc/ansible-roles/appliance-build.dcenter/tasks/main.yml
@@ -48,12 +48,6 @@
   retries: 3
   delay: 60
 
-- pip:
-    name: pysphere
-    extra_args: --index-url http://artifactory.delphix.com/artifactory/api/pypi/delphix-virtual-pypi/simple/ --trusted-host artifactory.delphix.com --no-cache-dir
-    version: 0.1.8
-    executable: pip2
-
 - git:
     repo: 'https://gitlab.delphix.com/devops/dcenter-gate.git'
     version: master


### PR DESCRIPTION
Amends #523. In that change, we stopped installing Python 2 but neglected to also stop installing PySphere with the Python 2 version of `pip`. We no longer use PySphere, so we can stop installing it as well.