### PR TITLE
TOOL-10813 appliance-build unnecessarily sets preserve_hostname: true

### DIFF
--- a/live-build/misc/ansible-roles/appliance-build.dcenter/tasks/main.yml
+++ b/live-build/misc/ansible-roles/appliance-build.dcenter/tasks/main.yml
@@ -84,15 +84,6 @@
       /tmp/dcenter_dhcp_config/named.pid w,
 
 #
-# Dcenter systems use static addresses so modify cloud.cfg to preserve
-# their hostname.
-#
-- lineinfile:
-    path: /etc/cloud/cloud.cfg
-    regexp: '^preserve_hostname: false'
-    line: 'preserve_hostname: true'
-
-#
 # The default setting for the number of nfs threads is too low. To
 # improve performance we reset the value to 64 which mimics what
 # we use on the delphix engine.


### PR DESCRIPTION
See [TOOL-10813](https://jira.delphix.com/browse/TOOL-10813).