### PR TITLE
Disable default DHCP service units

### DIFF
--- a/live-build/misc/ansible-roles/appliance-build.dcenter/tasks/main.yml
+++ b/live-build/misc/ansible-roles/appliance-build.dcenter/tasks/main.yml
@@ -105,4 +105,4 @@
     - { regexp: '^RPCNFSDCOUNT=', line: 'RPCNFSDCOUNT=64' }
     - { regexp: '^RPCMOUNTDOPTS=', line: 'RPCMOUNTDOPTS="--num-threads=5 --manage-gids"' }
 
-- command: systemctl disable bind9.service
+- command: systemctl disable bind9.service isc-dhcp-server.service isc-dhcp-server6.service


### PR DESCRIPTION
These service units are unused (we have our own service unit for DHCP and DNS) and perpetually in the failed state:

```
$ systemctl list-units --failed
  UNIT                     LOAD   ACTIVE SUB    DESCRIPTION                                                                                                                                                                          
● isc-dhcp-server.service  loaded failed failed ISC DHCP IPv4 server                                                                                                                                                                 
● isc-dhcp-server6.service loaded failed failed ISC DHCP IPv6 server                                                                                                                                                                 
```

We already disable the default DNS service unit in favor of our own. We should do the same for the default DHCP service units to be consistent.