### PR TITLE
Backport of #523, #524, #525, and #526 to 6.0/release

### DIFF
--- a/live-build/misc/ansible-roles/appliance-build.dcenter/tasks/main.yml
+++ b/live-build/misc/ansible-roles/appliance-build.dcenter/tasks/main.yml
@@ -28,23 +28,17 @@
       - nfs-common-dbgsym
       - nfs-kernel-server
       - nfs-kernel-server-dbgsym
-      - python-dbg
-      - python-dev
-      - python-ldap
-      - python-paramiko
-      - python-pip
-      - python-pyvmomi
-      - python-six
-      - python-tenacity
-      - python2.7
       - python3
       - python3-dbg
       - python3-dev
       - python3-ldap
+      - python3-marshmallow
+      - python3-marshmallow-doc
       - python3-pip
       - python3-pyvmomi
       - python3-six
       - python3-tenacity
+      - python3-toml
       - python3-venv
       - targetcli-fb
       - telnet
@@ -53,12 +47,6 @@
   until: result is not failed
   retries: 3
   delay: 60
-
-- pip:
-    name: pysphere
-    extra_args: --index-url http://artifactory.delphix.com/artifactory/api/pypi/delphix-virtual-pypi/simple/ --trusted-host artifactory.delphix.com --no-cache-dir
-    version: 0.1.8
-    executable: pip2
 
 - git:
     repo: 'https://gitlab.delphix.com/devops/dcenter-gate.git'
@@ -90,15 +78,6 @@
       /tmp/dcenter_dhcp_config/named.pid w,
 
 #
-# Dcenter systems use static addresses so modify cloud.cfg to preserve
-# their hostname.
-#
-- lineinfile:
-    path: /etc/cloud/cloud.cfg
-    regexp: '^preserve_hostname: false'
-    line: 'preserve_hostname: true'
-
-#
 # The default setting for the number of nfs threads is too low. To
 # improve performance we reset the value to 64 which mimics what
 # we use on the delphix engine.
@@ -111,4 +90,4 @@
     - { regexp: '^RPCNFSDCOUNT=', line: 'RPCNFSDCOUNT=64' }
     - { regexp: '^RPCMOUNTDOPTS=', line: 'RPCMOUNTDOPTS="--num-threads=5 --manage-gids"' }
 
-- command: systemctl disable bind9.service
+- command: systemctl disable bind9.service isc-dhcp-server.service isc-dhcp-server6.service


### PR DESCRIPTION
Omnibus backport of #523, #524, #525, and #526 to `6.0/release`. As of this change, `live-build/misc/ansible-roles/appliance-build.dcenter/tasks/main.yml` is identical on `master`, `6.0/stage`, and `6.0/release`.