### PR TITLE
DLPX-71882 [Backport of DLPX-71833 to 6.0.8.0] ui-precommit fails to start ChromeHeadless

### DIFF
--- a/live-build/misc/ansible-roles/appliance-build.unittest-internal/tasks/main.yml
+++ b/live-build/misc/ansible-roles/appliance-build.unittest-internal/tasks/main.yml
@@ -25,6 +25,7 @@
       - git
       - python-minimal
       - chromium-browser
+      - libxss1
     state: present
 
 - user:


### PR DESCRIPTION
clean cherry-pick of https://github.com/delphix/appliance-build/pull/489

ab-pre-push: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/4883/