### PR TITLE
DLPX-73923 Persist iSCSI initiator files during not-in-place upgrade

### DIFF
--- a/upgrade/upgrade-scripts/upgrade-container
+++ b/upgrade/upgrade-scripts/upgrade-container
@@ -631,6 +631,7 @@ function migrate_configuration() {
 		/etc/hostid
 		/etc/hostname
 		/etc/hosts
+		/etc/iscsi/initiatorname.iscsi
 		/etc/machine-id
 		/etc/netplan/10-delphix.yaml
 		/etc/resolv.conf
@@ -691,6 +692,7 @@ function migrate_configuration() {
 	while read -r dir; do
 		migrate_dir "$dir"
 	done <<-EOF
+		/etc/iscsi/nodes
 		/var/lib/nfs
 		/var/target/pr
 	EOF


### PR DESCRIPTION
## Testing:

```
# iscsiadm data in VM:
~$ sudo cat /etc/iscsi/initiatorname.iscsi
InitiatorName=iqn.2021-09.org.serapheim:01:42a11723a8fb
~$ sudo tree /etc/iscsi/nodes/
/etc/iscsi/nodes/
└── iqn.2021-03.bogus.com
    └── bogus.com,3260

1 directory, 1 file

# Downloaded the latest image
~$ download-latest-image
download: s3://snapshot-de-images/builds/jenkins-ops/devops-gate/master/appliance-build/master/post-push/latest to ./latest
download: s3://snapshot-de-images/builds/jenkins-ops/devops-gate/master/appliance-build/master/post-push/4997/upgrade-artifacts/internal-dev.upgrade.tar to ./internal-dev.upgrade.tar
~$ ls internal-dev.upgrade.tar
internal-dev.upgrade.tar

# Unpacked it
~$ sudo unpack-image -x internal-dev.upgrade.tar
Progress increment: 15:17:21:422147680+0000, 10, Extracting upgrade image.
Progress increment: 15:20:03:362647124+0000, 40, Verifying format.
Progress increment: 15:20:48:855753313+0000, 50, Handoff unpack to prepare script.
Progress increment: 15:23:31:355961735+0000, 90, Prepare completed successfully.
Progress increment: 15:23:31:357943489+0000, 100, Unpacking successful.

# Downloaded the script from my PR
~$ wget https://raw.githubusercontent.com/delphix/appliance-build/e369fe2f4cb16f70d6eca292c6c7e88ad0f44435/upgrade/upgrade-scripts/upgrade-container
--2021-03-25 15:26:59--  https://raw.githubusercontent.com/delphix/appliance-build/e369fe2f4cb16f70d6eca292c6c7e88ad0f44435/upgrade/upgrade-scripts/upgrade-container
Resolving raw.githubusercontent.com (raw.githubusercontent.com)... 185.199.108.133, 185.199.110.133, 185.199.111.133, ...
Connecting to raw.githubusercontent.com (raw.githubusercontent.com)|185.199.108.133|:443... connected.
HTTP request sent, awaiting response... 200 OK
Length: 28785 (28K) [text/plain]
Saving to: ‘upgrade-container.1’

upgrade-container.1                           100%[==============================================================================================>]  28.11K  --.-KB/s    in 0.001s

2021-03-25 15:27:00 (52.0 MB/s) - ‘upgrade-container.1’ saved [28785/28785]

# Replaced the script of the image with the one I just downloaded above (the code from my PR)
~$ sudo cp upgrade-container /var/dlpx-update/latest/upgrade-container
~$ sudo grep iscsi /var/dlpx-update/latest/upgrade-container
		/etc/iscsi/initiatorname.iscsi
		/etc/iscsi/nodes

# applied upgrade:
~$ sudo /var/dlpx-update/latest/upgrade -v full
...<cropped out output>..
I: Base system installed successfully.
...<cropped out output>..
Installing for i386-pc platform.
Installation finished. No error reported.
...<cropped out output>..
Generating grub configuration file ...
Found linux image: /boot/vmlinuz-5.4.0-65-dx2021030905-3e6ea35a1-generic
Found initrd image: /boot/initrd.img-5.4.0-65-dx2021030905-3e6ea35a1-generic
done
...<reboot takes place>..
```

zfs-list before:
```
$ sudo zfs list
NAME                              USED  AVAIL     REFER  MOUNTPOINT
rpool                            27.7G  39.7G       64K  none
rpool/ROOT                       21.0G  39.7G       64K  none
rpool/ROOT/delphix.wcUt3Lh       21.0G  39.7G       65K  none
rpool/ROOT/delphix.wcUt3Lh/data  29.5M  39.7G     29.5M  legacy
rpool/ROOT/delphix.wcUt3Lh/home  13.2G  39.7G     13.2G  legacy
rpool/ROOT/delphix.wcUt3Lh/log   5.95M  39.7G     5.95M  legacy
rpool/ROOT/delphix.wcUt3Lh/root  7.68G  39.7G     7.68G  /
rpool/crashdump                  67.5K  34.7G     67.5K  legacy
rpool/grub                       5.76M  39.7G     5.76M  legacy
rpool/public                       64K  39.7G       64K  /public
rpool/update                     6.71G  23.3G     6.71G  /var/dlpx-update
rpool/upgrade-logs                 65K  39.7G       65K  /var/tmp/delphix-upgrade
```

zfs-list after:
```
$ sudo zfs list
NAME                              USED  AVAIL     REFER  MOUNTPOINT
rpool                            35.0G  32.3G       64K  none
rpool/ROOT                       28.3G  32.3G       64K  none
rpool/ROOT/delphix.bOIZM0R       7.32G  32.3G       64K  none
rpool/ROOT/delphix.bOIZM0R/data   230K  32.3G     29.8M  legacy
rpool/ROOT/delphix.bOIZM0R/home    52K  32.3G     13.2G  legacy
rpool/ROOT/delphix.bOIZM0R/log   7.90M  32.3G     13.6M  legacy
rpool/ROOT/delphix.bOIZM0R/root  7.31G  32.3G     7.31G  /
rpool/ROOT/delphix.wcUt3Lh       21.0G  32.3G       65K  none
rpool/ROOT/delphix.wcUt3Lh/data  34.1M  32.3G     33.2M  legacy
rpool/ROOT/delphix.wcUt3Lh/home  13.2G  32.3G     13.2G  legacy
rpool/ROOT/delphix.wcUt3Lh/log   45.0M  32.3G     42.9M  legacy
rpool/ROOT/delphix.wcUt3Lh/root  7.68G  32.3G     7.68G  /
rpool/crashdump                  67.5K  32.3G     67.5K  legacy
rpool/grub                       5.76M  32.3G     5.76M  legacy
rpool/public                       64K  32.3G       64K  /public
rpool/update                     6.71G  23.3G     6.71G  /var/dlpx-update
rpool/upgrade-logs                 65K  32.3G       65K  /var/tmp/delphix-upgrade
```

iscsiadm data from before are still there and look identical