### PR TITLE
DLPX-75229 finalize() should not rely on properties in upgrade.properties

### DIFF
--- a/upgrade/upgrade-scripts/upgrade
+++ b/upgrade/upgrade-scripts/upgrade
@@ -375,20 +375,6 @@ function finalize() {
 		return
 	fi
 
-	source_upgrade_properties
-
-	[[ -n "$UPGRADE_TYPE" ]] ||
-		die "variable UPGRADE_TYPE is not set; is upgrade in progress?"
-	[[ -n "$UPGRADE_BASE_VERSION" ]] ||
-		die "variable UPGRADE_BASE_VERSION is not set"
-
-	case "$UPGRADE_TYPE" in
-	DEFERRED | FULL | ROLLBACK) ;;
-	*)
-		die "finalize is not supported for upgrade type: '$UPGRADE_TYPE'"
-		;;
-	esac
-
 	#
 	# If we've reached this point, it means we're finalizing an
 	# ugprade from a linux-based release, to another linux-based


### PR DESCRIPTION
Problem : The properties in upgrade.properties gets cleared in a finally block in StackStartup.java whereas the finalize() function is invoked asynchronously in the context of a job. The properties cannot be expected to still be present in the finalize() function.
Solution : The finalize() function is only called in the context of post-upgrade, so it does not need to check the upgrade.properties once again. The file itself gets cleaned up by the finalize() function during the removal of the entire unpack directory, so the risk of a re-execution is minimal. Even if re-executed, there does not seem to be any detrimental effects of the statements that are presently in the finalize() function.

git ab-pre-push: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/5033/
