### PR TITLE
DLPX-75232 [Backport of DLPX-75229 to 6.0.8.0] finalize() should not rely on properties in upgrade.properties

### DIFF
--- a/upgrade/upgrade-scripts/upgrade
+++ b/upgrade/upgrade-scripts/upgrade
@@ -375,20 +375,6 @@ function finalize() {
 		return
 	fi
 
-	source_upgrade_properties
-
-	[[ -n "$UPGRADE_TYPE" ]] ||
-		die "variable UPGRADE_TYPE is not set; is upgrade in progress?"
-	[[ -n "$UPGRADE_BASE_VERSION" ]] ||
-		die "variable UPGRADE_BASE_VERSION is not set"
-
-	case "$UPGRADE_TYPE" in
-	DEFERRED | FULL | ROLLBACK) ;;
-	*)
-		die "finalize is not supported for upgrade type: '$UPGRADE_TYPE'"
-		;;
-	esac
-
 	#
 	# If we've reached this point, it means we're finalizing an
 	# ugprade from a linux-based release, to another linux-based


### PR DESCRIPTION
Clean cherry-pick of https://github.com/delphix/appliance-build/pull/538

git ab-pre-push: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/5038/