### PR TITLE
DLPX-75258 [Backport of DLPX-73923 to 6.0.9.0] Persist iSCSI initiator files during not-in-place upgrade

### DIFF
--- a/upgrade/upgrade-scripts/upgrade-container
+++ b/upgrade/upgrade-scripts/upgrade-container
@@ -648,6 +648,7 @@ function migrate_configuration() {
 		/etc/hostid
 		/etc/hostname
 		/etc/hosts
+		/etc/iscsi/initiatorname.iscsi
 		/etc/machine-id
 		/etc/netplan/10-delphix.yaml
 		/etc/resolv.conf
@@ -708,6 +709,7 @@ function migrate_configuration() {
 	while read -r dir; do
 		migrate_dir "$dir"
 	done <<-EOF
+		/etc/iscsi/nodes
 		/var/lib/nfs
 		/var/target/pr
 	EOF


### PR DESCRIPTION
### Original PR

https://github.com/delphix/appliance-build/pull/532

### Testing

```
# iscsiadm data in VM:
delphix@sd-60-upgrade:~$ sudo tail -n 1 /etc/iscsi/initiatorname.iscsi
InitiatorName=iqn.1993-08.org.debian:01:58d010e548ec
delphix@sd-60-upgrade:~$ sudo tree /etc/iscsi/nodes/
/etc/iscsi/nodes/
└── iqn.2021-03.bogus.com
    └── bogus.com,3260

1 directory, 1 file

# Downloaded the latest image
delphix@sd-60-upgrade:~$ download-latest-image
download: s3://snapshot-de-images/builds/jenkins-ops/devops-gate/master/appliance-build/master/post-push/latest to ./latest
download: s3://snapshot-de-images/builds/jenkins-ops/devops-gate/master/appliance-build/master/post-push/5189/upgrade-artifacts/internal-dev.upgrade.tar to ./internal-dev.upgrade.tar
delphix@sd-60-upgrade:~$ ls internal-dev.upgrade.tar
internal-dev.upgrade.tar

# Unpacked it
delphix@sd-60-upgrade:~$ sudo unpack-image -x internal-dev.upgrade.tar
Progress increment: 17:56:22:984083900+0000, 10, Extracting upgrade image.
Progress increment: 17:59:02:840254867+0000, 40, Verifying format.
Progress increment: 17:59:54:075742447+0000, 50, Handoff unpack to prepare script.
Progress increment: 18:02:37:055148539+0000, 90, Prepare completed successfully.
Progress increment: 18:02:37:058039410+0000, 100, Unpacking successful.

# Downloaded the script from my PR
delphix@sd-60-upgrade:~$ wget https://raw.githubusercontent.com/delphix/appliance-build/72e7e9334a6787c92dd517a434e5038438d8bf16/upgrade/upgrade-scripts/upgrade-container
--2021-04-20 18:05:11--  https://raw.githubusercontent.com/delphix/appliance-build/72e7e9334a6787c92dd517a434e5038438d8bf16/upgrade/upgrade-scripts/upgrade-container
Resolving raw.githubusercontent.com (raw.githubusercontent.com)... 185.199.109.133, 185.199.110.133, 185.199.108.133, ...
Connecting to raw.githubusercontent.com (raw.githubusercontent.com)|185.199.109.133|:443... connected.
HTTP request sent, awaiting response... 200 OK
Length: 29388 (29K) [text/plain]
Saving to: ‘upgrade-container’

upgrade-container                          100%[=====================================================================================>]  28.70K  --.-KB/s    in 0.001s

2021-04-20 18:05:11 (35.3 MB/s) - ‘upgrade-container’ saved [29388/29388]

# Replaced the script of the image with the one I just downloaded above (the code from my PR)
delphix@sd-60-upgrade:~$ sudo cp upgrade-container /var/dlpx-update/latest/upgrade-container
delphix@sd-60-upgrade:~$ sudo grep iscsi /var/dlpx-update/latest/upgrade-container
		/etc/iscsi/initiatorname.iscsi
		/etc/iscsi/nodes

# applied upgrade
delphix@sd-60-upgrade:~$ sudo /var/dlpx-update/latest/upgrade -v full
...<cropped out output>..
I: Base system installed successfully.
...<cropped out output>..
Installing for i386-pc platform.
Installation finished. No error reported.
Sourcing file `/etc/default/grub'
Sourcing file `/etc/default/grub.d/kdump-tools.cfg'
Sourcing file `/etc/default/grub.d/override.cfg'
Generating grub configuration file ...
Found linux image: /boot/vmlinuz-5.4.0-71-dx2021041620-9efe259c5-generic
Found initrd image: /boot/initrd.img-5.4.0-71-dx2021041620-9efe259c5-generic
done
...<reboot takes place>..
```

zfs-list before:
```
delphix@sd-60-upgrade:~$ sudo zfs list
NAME                              USED  AVAIL     REFER  MOUNTPOINT
rpool                            27.7G  39.7G       64K  none
rpool/ROOT                       20.9G  39.7G       64K  none
rpool/ROOT/delphix.rg0iYOQ       20.9G  39.7G       64K  none
rpool/ROOT/delphix.rg0iYOQ/data  30.6M  39.7G     30.6M  legacy
rpool/ROOT/delphix.rg0iYOQ/home  13.3G  39.7G     13.3G  legacy
rpool/ROOT/delphix.rg0iYOQ/log   6.29M  39.7G     6.29M  legacy
rpool/ROOT/delphix.rg0iYOQ/root  7.59G  39.7G     7.59G  /
rpool/crashdump                  65.5K  34.7G     65.5K  legacy
rpool/grub                       5.76M  39.7G     5.76M  legacy
rpool/public                       64K  39.7G       64K  /public
rpool/update                     6.75G  23.3G     6.75G  /var/dlpx-update
rpool/upgrade-logs                 64K  39.7G       64K  /var/tmp/delphix-upgrade
```

zfs-list after:
```
delphix@sd-60-upgrade:~$ sudo zfs list
NAME                              USED  AVAIL     REFER  MOUNTPOINT
rpool                            35.1G  32.3G       64K  none
rpool/ROOT                       28.3G  32.3G       64K  none
rpool/ROOT/delphix.8VlnWYa       7.37G  32.3G       64K  none
rpool/ROOT/delphix.8VlnWYa/data   258K  32.3G     31.4M  legacy
rpool/ROOT/delphix.8VlnWYa/home   166K  32.3G     13.3G  legacy
rpool/ROOT/delphix.8VlnWYa/log   7.60M  32.3G     13.9M  legacy
rpool/ROOT/delphix.8VlnWYa/root  7.36G  32.3G     7.36G  /
rpool/ROOT/delphix.rg0iYOQ       21.0G  32.3G       64K  none
rpool/ROOT/delphix.rg0iYOQ/data  35.7M  32.3G     34.4M  legacy
rpool/ROOT/delphix.rg0iYOQ/home  13.3G  32.3G     13.3G  legacy
rpool/ROOT/delphix.rg0iYOQ/log   41.6M  32.3G     39.6M  legacy
rpool/ROOT/delphix.rg0iYOQ/root  7.59G  32.3G     7.59G  /
rpool/crashdump                  65.5K  32.3G     65.5K  legacy
rpool/grub                       5.77M  32.3G     5.77M  legacy
rpool/public                       64K  32.3G       64K  /public
rpool/update                     6.75G  23.3G     6.75G  /var/dlpx-update
rpool/upgrade-logs                 64K  32.3G       64K  /var/tmp/delphix-upgrade
```

iscsiadm data from before are still there and look identical