### PR TITLE
DLPX-75091 DLPX-75122 Make upgrade image prepare script hotfix aware

### DIFF
--- a/upgrade/prepare
+++ b/upgrade/prepare
@@ -107,7 +107,7 @@ fi
 popd &>/dev/null || die "'popd' failed"
 
 if [[ -n "$HOTFIX" ]]; then
-        VERSION="$VERSION-$HOTFIX"
+	VERSION="$VERSION-$HOTFIX"
 fi
 
 $opt_f && rm -rf "${UPDATE_DIR:?}/$VERSION" >/dev/null 2>&1

--- a/upgrade/prepare
+++ b/upgrade/prepare
@@ -14,7 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
 UPDATE_DIR=${UPDATE_DIR:-/var/dlpx-update}
 
 function die() {
@@ -106,6 +105,10 @@ if $opt_x; then
 fi
 
 popd &>/dev/null || die "'popd' failed"
+
+if [[ -n "$HOTFIX" ]]; then
+        VERSION="$VERSION-$HOTFIX"
+fi
 
 $opt_f && rm -rf "${UPDATE_DIR:?}/$VERSION" >/dev/null 2>&1
 

--- a/upgrade/upgrade-scripts/common.sh
+++ b/upgrade/upgrade-scripts/common.sh
@@ -142,7 +142,14 @@ function get_image_path() {
 }
 
 function get_image_version() {
-	basename "$(get_image_path)"
+#	basename "$(get_image_path)"
+  source_version_information
+  echo "$VERSION"
+}
+
+function get_image_hotfix() {
+  source_version_information
+  echo "$HOTFIX"
 }
 
 function get_mounted_rootfs_container_dataset() {
@@ -256,9 +263,6 @@ function source_version_information() {
 	local IMAGE_PATH="${IMAGE_PATH:-$(get_image_path)}"
 	[[ -n "$IMAGE_PATH" ]] || die "failed to determine image path"
 
-	local IMAGE_VERSION="${IMAGE_VERSION:-$(get_image_version)}"
-	[[ -n "$IMAGE_VERSION" ]] || die "failed to determine image version"
-
 	[[ -f "$IMAGE_PATH/version.info" ]] ||
 		die "image for version '$IMAGE_VERSION' missing version.info"
 	. "$IMAGE_PATH/version.info" ||
@@ -268,6 +272,7 @@ function source_version_information() {
 	[[ -n "$MINIMUM_VERSION" ]] || die "MINIMUM_VERSION is empty"
 	[[ -n "$MINIMUM_REBOOT_OPTIONAL_VERSION" ]] ||
 		die "MINIMUM_REBOOT_OPTIONAL_VERSION is empty"
+	IMAGE_VERSION="$VERSION"
 }
 
 function verify_upgrade_is_allowed() {

--- a/upgrade/upgrade-scripts/common.sh
+++ b/upgrade/upgrade-scripts/common.sh
@@ -141,17 +141,6 @@ function get_image_path() {
 	readlink -f "${BASH_SOURCE%/*}"
 }
 
-function get_image_version() {
-#	basename "$(get_image_path)"
-  source_version_information
-  echo "$VERSION"
-}
-
-function get_image_hotfix() {
-  source_version_information
-  echo "$HOTFIX"
-}
-
 function get_mounted_rootfs_container_dataset() {
 	dirname "$(zfs list -Hpo name /)"
 }
@@ -264,15 +253,14 @@ function source_version_information() {
 	[[ -n "$IMAGE_PATH" ]] || die "failed to determine image path"
 
 	[[ -f "$IMAGE_PATH/version.info" ]] ||
-		die "image for version '$IMAGE_VERSION' missing version.info"
+		die "image missing version.info for $IMAGE_PATH"
 	. "$IMAGE_PATH/version.info" ||
-		die "failed to source version.info for version '$IMAGE_VERSION'"
+		die "failed to source version.info for $IMAGE_PATH"
 
 	[[ -n "$VERSION" ]] || die "VERSION is empty"
 	[[ -n "$MINIMUM_VERSION" ]] || die "MINIMUM_VERSION is empty"
 	[[ -n "$MINIMUM_REBOOT_OPTIONAL_VERSION" ]] ||
 		die "MINIMUM_REBOOT_OPTIONAL_VERSION is empty"
-	IMAGE_VERSION="$VERSION"
 }
 
 function verify_upgrade_is_allowed() {

--- a/upgrade/upgrade-scripts/upgrade
+++ b/upgrade/upgrade-scripts/upgrade
@@ -20,7 +20,6 @@
 IMAGE_PATH=$(get_image_path)
 [[ -n "$IMAGE_PATH" ]] || die "failed to determine image path"
 
-
 #
 # This variable is used to determine if a "dry run" of the upgrade
 # should be performed, as opposed to an actual upgrade of the system.

--- a/upgrade/upgrade-scripts/upgrade
+++ b/upgrade/upgrade-scripts/upgrade
@@ -323,7 +323,7 @@ function rollback() {
 		die "failed setting 'ROLLBACK_BASE_CONTAINER' property"
 	set_upgrade_property "ROLLBACK_BASE_VERSION" "$ROLLBACK_BASE_VERSION" ||
 		die "failed setting 'ROLLBACK_BASE_VERSION' property"
-	set_upgrade_property "ROLLBACK_BASE_HOTFIX" "ROLLBACK_BASE_HOTFIX" ||
+	set_upgrade_property "ROLLBACK_BASE_HOTFIX" "$ROLLBACK_BASE_HOTFIX" ||
 		die "failed setting 'ROLLBACK_BASE_HOTFIX' property"
 
 	if [[ "$UPGRADE_BASE_CONTAINER" == "$ROLLBACK_BASE_CONTAINER" ]]; then

--- a/upgrade/upgrade-scripts/upgrade
+++ b/upgrade/upgrade-scripts/upgrade
@@ -317,11 +317,14 @@ function rollback() {
 	ROLLBACK_BASE_VERSION="$(get_current_version)"
 	[[ -n "$ROLLBACK_BASE_VERSION" ]] ||
 		die "unable to determine current appliance version"
+	ROLLBACK_BASE_HOTFIX="$(get_current_hotfix)"
 
 	set_upgrade_property "ROLLBACK_BASE_CONTAINER" "$ROLLBACK_BASE_CONTAINER" ||
 		die "failed setting 'ROLLBACK_BASE_CONTAINER' property"
 	set_upgrade_property "ROLLBACK_BASE_VERSION" "$ROLLBACK_BASE_VERSION" ||
 		die "failed setting 'ROLLBACK_BASE_VERSION' property"
+	set_upgrade_property "ROLLBACK_BASE_HOTFIX" "ROLLBACK_BASE_HOTFIX" ||
+		die "failed setting 'ROLLBACK_BASE_HOTFIX' property"
 
 	if [[ "$UPGRADE_BASE_CONTAINER" == "$ROLLBACK_BASE_CONTAINER" ]]; then
 		#

--- a/upgrade/upgrade-scripts/upgrade
+++ b/upgrade/upgrade-scripts/upgrade
@@ -20,8 +20,6 @@
 IMAGE_PATH=$(get_image_path)
 [[ -n "$IMAGE_PATH" ]] || die "failed to determine image path"
 
-IMAGE_VERSION=$(get_image_version)
-[[ -n "$IMAGE_VERSION" ]] || die "failed to determine image version"
 
 #
 # This variable is used to determine if a "dry run" of the upgrade

--- a/upgrade/upgrade-scripts/verify-jar
+++ b/upgrade/upgrade-scripts/verify-jar
@@ -18,11 +18,16 @@
 # shellcheck disable=SC1090
 . "${BASH_SOURCE%/*}/common.sh"
 
-IMAGE_VERSION=$(get_image_version)
-[[ -n "$IMAGE_VERSION" ]] || die "failed to determine image version"
+# We source the version information to bring in values from
+# the version.info file, such as
+#   - VERSION : the appliance version
+#   - HOTFIX : the hotfix version if any
+
+source_version_information
+
+[[ -n "$VERSION" ]] || die "failed to determine image version"
 IMAGE_PATH=$(get_image_path)
 [[ -n "$IMAGE_PATH" ]] || die "failed to determine image path"
-HOTFIX=$(get-hotfix-version)
 
 function verify_jar_verify_cleanup() {
 	local rc="$?"
@@ -183,7 +188,7 @@ VERIFY_OPTIONS=(
 	"-d" "${opt_o:-${LOG_DIRECTORY}/${CONTAINER}/upgrade_verify.json}"
 	"-f" "${opt_f:-1}"
 	"-l" "${opt_l:-en-US}"
-	"-v" "$IMAGE_VERSION"
+	"-v" "$VERSION"
 	"-h" "$HOTFIX"
 	"-pl" "25"
 	"-ph" "80"

--- a/upgrade/upgrade-scripts/verify-jar
+++ b/upgrade/upgrade-scripts/verify-jar
@@ -22,6 +22,7 @@ IMAGE_VERSION=$(get_image_version)
 [[ -n "$IMAGE_VERSION" ]] || die "failed to determine image version"
 IMAGE_PATH=$(get_image_path)
 [[ -n "$IMAGE_PATH" ]] || die "failed to determine image path"
+HOTFIX=$(get-hotfix-version)
 
 function verify_jar_verify_cleanup() {
 	local rc="$?"
@@ -183,6 +184,7 @@ VERIFY_OPTIONS=(
 	"-f" "${opt_f:-1}"
 	"-l" "${opt_l:-en-US}"
 	"-v" "$IMAGE_VERSION"
+	"-h" "$HOTFIX"
 	"-pl" "25"
 	"-ph" "80"
 )


### PR DESCRIPTION
DLPX-75122 Use delphix version and hotfix in version.info in verify-jar script
DLPX-75091 Make upgrade image prepare script hotfix aware

The hotfix id needs to be passed into delphix-upgrade-verification/SUV so that SUV may operate on the correct version. Only works with corresponding [SUV changes](http://reviews.delphix.com/r/68590), otherwise verification will fail when an older SUV is given the hotfix value and does not know what to do with it.

Also refactored how version is determined. Instead of relying on a value in the filesytem path, the version is entirely sourced from version.info (and literally sourced via bash, pun intended). 

Tested with upgrade images and hotfix images with the corresponding SUV changes.
