### PR TITLE
Add rust to dev environment

### DIFF
--- a/live-build/misc/ansible-roles/appliance-build.zfsonlinux-development/tasks/main.yml
+++ b/live-build/misc/ansible-roles/appliance-build.zfsonlinux-development/tasks/main.yml
@@ -23,6 +23,7 @@
       - alien
       - autoconf
       - build-essential
+      - cargo
       - cppcheck
       - curl
       - emacs-nox
@@ -43,7 +44,9 @@
       - mandoc
       - nfs-kernel-server
       - parted
+      - pkg-config
       - python-minimal
+      - rustc
       - shellcheck
       - targetcli-fb
       - unzip


### PR DESCRIPTION
In support of the Object Storage project, we should install the rust devtools on development engines.

While the recommended way to install rust is using rustup, we use the ubuntu packaged version of rust for a more repeatable build process with fewer external dependencies. However, [these packages do not update frequently](https://answers.launchpad.net/ubuntu/+source/rustc/+question/696726). If in the future we find that we need to use more up-to-date versions of the rust compiler, we can either switch to using rustup, or build our own linux-pkg off of the stable rust releases.

http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/5108/console