### PR TITLE
Add "awscli" to dcenter variant

### DIFF
--- a/live-build/misc/ansible-roles/appliance-build.dcenter/tasks/main.yml
+++ b/live-build/misc/ansible-roles/appliance-build.dcenter/tasks/main.yml
@@ -19,6 +19,7 @@
 - apt:
     name:
       - adoptopenjdk-java8-jdk
+      - awscli
       - bind9
       - dnsutils
       - git


### PR DESCRIPTION
In order to make it easier to download upgrade images, this change adds
the awscli package to our dcenter images.