### PR TITLE
CP-5334 Add ufw package to appliance-build

### DIFF
--- a/live-build/misc/ansible-roles/appliance-build.qa-internal/tasks/main.yml
+++ b/live-build/misc/ansible-roles/appliance-build.qa-internal/tasks/main.yml
@@ -1,5 +1,5 @@
 #
-# Copyright 2018 Delphix
+# Copyright 2018, 2021 Delphix
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -22,6 +22,7 @@
     name:
       - nftables
       - snmptrapd
+      - ufw
     state: present
   register: result
   until: result is not failed


### PR DESCRIPTION
Context
The Uncomplicated Firewall (ufw) utility is a frontend for iptables which is well-suited for host-based firewalls. `ufw` aims to provide an easy to use interface for those unfamiliar with firewall concepts, while at the same time simplifying iptables commands to help an admin who knows what he or she is doing.

Problem
The AppData team wants to add testing around the docker plugin runtime without internet access. The build should target internal qa and dev builds, but should be excluded from customer engines.

Solution
The ufw utility should allow us to configure the engine to allow outgoing connections to SSH, DNS and specific source and target host environments while also restricting internet access elsewhere.

Testing
git ab-pre-push: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/5514/
I cloned from the snapshot of the aws image and found that the ufw pkg was installed on the delphix engine. The default state of ufw is inactive, which is expected.
```
delphix@ip-10-110-194-195:~$ sudo systemctl status ufw
● ufw.service - Uncomplicated firewall
   Loaded: loaded (/lib/systemd/system/ufw.service; enabled; vendor preset: enabled)
   Active: active (exited) since Tue 2021-06-15 16:30:10 UTC; 53min ago
     Docs: man:ufw(8)
 Main PID: 486 (code=exited, status=0/SUCCESS)
    Tasks: 0 (limit: 4915)
   CGroup: /system.slice/ufw.service

delphix@ip-10-110-194-195:~$ sudo ufw status
Status: inactive
```