### PR TITLE
COPS-277 Add IBM support to appliance-build-orchestrator

### DIFF
--- a/gradle-lib/util.gradle
+++ b/gradle-lib/util.gradle
@@ -19,7 +19,7 @@ import java.nio.file.Paths
 import java.nio.file.attribute.PosixFilePermissions
 import java.util.regex.Pattern
 
-ext.allPlatforms = ["aws", "azure", "esx", "gcp", "hyperv", "kvm", "oci"]
+ext.allPlatforms = ["aws", "azure", "esx", "gcp", "hyperv", "kvm", "oci", "ibm"]
 ext.allVariants = new File("${rootProject.projectDir}/live-build/variants").list()
 ext.allInternal = allVariants.findAll { it.startsWith("internal-") }
 ext.allExternal = allVariants.findAll { it.startsWith("external-") }

--- a/live-build/build.gradle
+++ b/live-build/build.gradle
@@ -41,7 +41,8 @@ def artifactTypes = ["aws": "vmdk",
                      "gcp": "gcp.tar.gz",
                      "hyperv": "vhdx",
                      "kvm": "qcow2",
-                     "oci": "qcow2"]
+                     "oci": "qcow2",
+                     "ibm": "qcow2"]
 
 def configDir = "configuration"
 

--- a/live-build/config/hooks/vm-artifacts/91-qcow2-disk-image.binary
+++ b/live-build/config/hooks/vm-artifacts/91-qcow2-disk-image.binary
@@ -21,7 +21,7 @@
 # assumed to be a "raw" disk image, into a qcow2 formated disk image.
 #
 
-[[ "$APPLIANCE_PLATFORM" == kvm ]] || [[ "$APPLIANCE_PLATFORM" == oci ]] ||
+[[ "$APPLIANCE_PLATFORM" == kvm ]] || [[ "$APPLIANCE_PLATFORM" == oci ]] || [[ "$APPLIANCE_PLATFORM" == ibm ]]
 	exit 0
 
 source /usr/share/livecd-rootfs/live-build/functions

--- a/live-build/config/hooks/vm-artifacts/91-qcow2-disk-image.binary
+++ b/live-build/config/hooks/vm-artifacts/91-qcow2-disk-image.binary
@@ -21,7 +21,7 @@
 # assumed to be a "raw" disk image, into a qcow2 formated disk image.
 #
 
-[[ "$APPLIANCE_PLATFORM" == kvm ]] || [[ "$APPLIANCE_PLATFORM" == oci ]] || [[ "$APPLIANCE_PLATFORM" == ibm ]]
+[[ "$APPLIANCE_PLATFORM" == kvm ]] || [[ "$APPLIANCE_PLATFORM" == oci ]] || [[ "$APPLIANCE_PLATFORM" == ibm ]] ||
 	exit 0
 
 source /usr/share/livecd-rootfs/live-build/functions

--- a/scripts/run-live-build.sh
+++ b/scripts/run-live-build.sh
@@ -242,6 +242,7 @@ gcp) vm_artifact_ext=gcp.tar.gz ;;
 hyperv) vm_artifact_ext=vhdx ;;
 kvm) vm_artifact_ext=qcow2 ;;
 oci) vm_artifact_ext=qcow2 ;;
+ibm) vm_artifact_ext=qcow2 ;;
 *)
 	echo "Invalid platform"
 	exit 1


### PR DESCRIPTION

# Context:
Need Jenkins job for building the image

# Problem:
http://collins.d.delphix.com:22294/job/devops-gate/job/master/job/appliance-build-stage1/job/post-push/46/consoleFull fails due to missing gradle task for imm image build
# Solution:
Updated the gradle tasks and scripts for adding a new platform IBM
# Testing
Testing using the appliance build orchestrator job 
# Implementation:
The implementation details of the solution.
-->
<!--
# Notes To Reviewers:
Any extra information a reviewer may need to know before reviewing
your change. For example here you might want to describe which files
should be looked at first or which files are auto-generated.
-->
<!--
# Deployment Plan:
Some changes get more complicated and may need changes in multiple
repositories or may require infrastructure changes. Describe how these
changes will be smoothly deployed.
-->
<!--
# Future work:
A description of what follow up work is explicitly not being done in
this change.
-->
<!--
# Bonus:
A description of extra problems you've solved in this change. Did you
reformat an unrelated docstring? Point it out here
-->
