### PR TITLE
DLPX-76329 [Backport of DLPX-76328 to 6.0.9.0] upgrade script obtains hotfix version incorrectly

### DIFF
--- a/upgrade/upgrade-scripts/upgrade
+++ b/upgrade/upgrade-scripts/upgrade
@@ -317,7 +317,7 @@ function rollback() {
 	ROLLBACK_BASE_VERSION="$(get_current_version)"
 	[[ -n "$ROLLBACK_BASE_VERSION" ]] ||
 		die "unable to determine current appliance version"
-	ROLLBACK_BASE_HOTFIX="$(get_current_hotfix)"
+	ROLLBACK_BASE_HOTFIX="$(get_hotfix_version)"
 
 	set_upgrade_property "ROLLBACK_BASE_CONTAINER" "$ROLLBACK_BASE_CONTAINER" ||
 		die "failed setting 'ROLLBACK_BASE_CONTAINER' property"


### PR DESCRIPTION
In commit e7dd85e2 we introduced the `get_hotfix_version` function for
obtaining the hotfix version of the currently running root filesystem.
The problem is that in c4357a4e we added logic that intended to use this
function, but instead tries to call the `get_current_hotfix` function,
which doesn't exist. This leads us to never retreiving the hotfix
version correctly via the `rollback` subcommand of the `upgrade` script.