### PR TITLE
DLPX-74045 adapt upgrade "execute" script to better handle new hotfix workflow (#520)

### DIFF
--- a/upgrade/upgrade-scripts/execute
+++ b/upgrade/upgrade-scripts/execute
@@ -303,8 +303,22 @@ dpkg-query -Wf '${Package}\n' "delphix-kernel-*" | xargs apt-mark manual ||
 #
 
 # shellcheck disable=SC2153
-apt_get install -y --allow-downgrades "delphix-entire-$platform=$VERSION" ||
+apt_get install \
+	-y --allow-downgrades --reinstall \
+	"delphix-entire-$platform=$VERSION" ||
 	die "upgrade failed; from '$CURRENT_VERSION' to '$VERSION'"
+
+#
+# Since we mark all currently installed packages as "auto" earlier in
+# this script, we need to ensure the delphix-entire package that we just
+# installed is marked "manual", to avoid it being removed later in this
+# script. We must explicitly do this here, as it seems this isn't
+# automatially done when installing or upgrading the package;
+# particularly in the case of "--reinstall", which replaces the current
+# package with a new package of the same version (i.e. for hotfixes).
+#
+apt-mark manual "delphix-entire-$platform" ||
+	die "failed to mark 'delphix-entire' package as 'manual' installed"
 
 [[ -f "/usr/share/doc/delphix-entire-$platform/packages.list.gz" ]] ||
 	die "delphix-entire's packages.list.gz file is missing"


### PR DESCRIPTION
Currently when applying a hotfix image generated by the new hotfix
workflow being developed in CP-4190, nothing will happen when the
upgrade is attempted. This is due to the "delphix-entire" package in the
hotfix being installed, matching the version of the package that's
already installed. Thus, the package manager chooses not to install the
new packagecontained in the upgrade/hotfix image, since it thinks the
same package is already installed, due to the two having the same
version.

We need to adapt the "execute" script that's used during upgrade, such
that we always install the new "delphix-entire" package contained in the
upgrade/hotfix image, even if the package versions are identical.