### PR TITLE
TOOL-11707 Install Java 11 on DCoL hosts

### DIFF
--- a/bootstrap/roles/appliance-build.bootstrap/tasks/main.yml
+++ b/bootstrap/roles/appliance-build.bootstrap/tasks/main.yml
@@ -1,5 +1,5 @@
 #
-# Copyright 2018-2019 Delphix
+# Copyright 2018-2021 Delphix
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -36,6 +36,7 @@
       - livecd-rootfs
       - make
       - man
+      - openjdk-11-jre-headless
       - openjdk-8-jre-headless
       - pigz
       - qemu

--- a/live-build/misc/ansible-roles/appliance-build.dcenter/tasks/main.yml
+++ b/live-build/misc/ansible-roles/appliance-build.dcenter/tasks/main.yml
@@ -1,5 +1,5 @@
 #
-# Copyright 2018,2020 Delphix
+# Copyright 2018,2021 Delphix
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -28,6 +28,7 @@
       - nfs-common-dbgsym
       - nfs-kernel-server
       - nfs-kernel-server-dbgsym
+      - openjdk-11-jdk-headless
       - python3
       - python3-dbg
       - python3-dev
@@ -47,6 +48,10 @@
   until: result is not failed
   retries: 3
   delay: 60
+
+- alternatives:
+    name: java
+    path: /usr/lib/jvm/adoptopenjdk-java8-jdk-amd64/bin/java
 
 - git:
     repo: 'https://gitlab.delphix.com/devops/dcenter-gate.git'


### PR DESCRIPTION
DCoL hosts are Jenkins agents and therefore has a Java 8 JDK installed (cf. [`appliance-build.dcenter`](https://github.com/delphix/appliance-build/blob/be1ecc9701ca18b05dec0ec6b6016bb39bc79b6c/live-build/misc/ansible-roles/appliance-build.dcenter/tasks/main.yml#L21)). In the coming months, the Jenkins project will start to recommend users move off Java 8 and to Java 11. With the move to Java 11, we need to also add a Java 11 JDK.

Note: `adoptopenjdk-java11-jdk` is technically before `adoptopenjdk-java8-jdk` alphabetically