### PR TITLE
Add rust to dev environment (#544)

### DIFF
--- a/live-build/misc/ansible-roles/appliance-build.zfsonlinux-development/tasks/main.yml
+++ b/live-build/misc/ansible-roles/appliance-build.zfsonlinux-development/tasks/main.yml
@@ -23,6 +23,7 @@
       - alien
       - autoconf
       - build-essential
+      - cargo
       - cppcheck
       - curl
       - emacs-nox
@@ -43,7 +44,9 @@
       - mandoc
       - nfs-kernel-server
       - parted
+      - pkg-config
       - python-minimal
+      - rustc
       - shellcheck
       - targetcli-fb
       - unzip


### PR DESCRIPTION
Backporting to 6.0/stage:
```
commit 923aa1320dc6963ef6c3b3da0cc466f2b03018b7
Author: Paul Dagnelie <paul.dagnelie@delphix.com>
Date:   Fri Apr 23 14:36:08 2021 -0700

    Add rust to dev environment (#544)
```

appliance-build: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/5787/console
