### PR TITLE
DLPX-76694 Failure to build DelphixConnector on Delphix Engine, causing gui_sanity testing to fail

### DIFF
--- a/live-build/misc/ansible-roles/appliance-build.virtualization-development/tasks/main.yml
+++ b/live-build/misc/ansible-roles/appliance-build.virtualization-development/tasks/main.yml
@@ -15,6 +15,19 @@
 #
 
 ---
+#
+# pkg-config is necessary for building the DelphixConnector, which is built
+# when running "ant all".
+#
+- apt:
+    name:
+      - pkg-config
+    state: present
+  register: result
+  until: result is not failed
+  retries: 3
+  delay: 60
+
 - file:
     path: "/etc/systemd/system/delphix-mgmt.service.d"
     owner: root


### PR DESCRIPTION
When testing changes to the front end blackbox ends up running `ant all` on a Delphix Engine (instead of `ant dev`), and that not only rebuilds the front end but also the Delphix Connector. To build the connector, the build installs a bunch of package dependencies from artifactory; and one of those package dependencies depends on another Ubuntu package, `pkg-config`, which is not present on the engine.

As it happens, `pkg-config` was already added on internal-dev engines on master by an unrelated change, #577, but that change was not yet backported to 6.0/stage when this failure happened. Given that #577 relates to zfs development and pkg-config is also needed for virtualization development, it seems appropriate to add it explicitly here.

## Additional observations
- Ideally we would move the Delphix Connector to a separate package, given that it has its own life cycle and dependencies, but this change would require some additional work.
- internal-dev VMs do use the default apt.sources files from Ubuntu, so technically pkg-config could have been installed during the build of the connector; however `apt update` is never run, therefore the apt cache is empty at the time where apt attempts to look for pkg-config.

## Testing
- ab-pre-push: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/5800/