### PR TITLE
DLPX-76769 [Backport of DLPX-76694 to 6.0.10.0] Failure to build DelphixConnector on Delphix Engine, causing gui_sanity testing to fail

### DIFF
--- a/live-build/misc/ansible-roles/appliance-build.virtualization-development/tasks/main.yml
+++ b/live-build/misc/ansible-roles/appliance-build.virtualization-development/tasks/main.yml
@@ -15,6 +15,19 @@
 #
 
 ---
+#
+# pkg-config is necessary for building the DelphixConnector, which is built
+# when running "ant all".
+#
+- apt:
+    name:
+      - pkg-config
+    state: present
+  register: result
+  until: result is not failed
+  retries: 3
+  delay: 60
+
 - file:
     path: "/etc/systemd/system/delphix-mgmt.service.d"
     owner: root


### PR DESCRIPTION
Clean cherry-pick of #578 

## Testing
ab-pre-push: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/5808/