### PR TITLE
DLPX-76770 [Backport of DLPX-68846] logic for determining device path for grub operations during upgrade is fragile

### DIFF
--- a/upgrade/upgrade-scripts/rootfs-container
+++ b/upgrade/upgrade-scripts/rootfs-container
@@ -87,7 +87,17 @@ function get_bootloader_devices() {
 	#
 	zpool list -vH rpool |
 		awk '! /rpool|mirror|replacing|spare/ {print $1}' |
-		sed 's/p\{0,1\}[0-9]*$//'
+		while read -r part; do
+			#
+			# If the rpool is not installed a parition, we throw
+			# an error. We expect this to never happen, and the
+			# calling code is likely untested in that case, so we
+			# throw an error rather than try to handle it.
+			#
+			[[ "$(lsblk --nodeps -no type "/dev/$part")" == "part" ]] ||
+				die "rpool installed on full disk \"$part\""
+			lsblk -no pkname "/dev/$part"
+		done
 }
 
 function set_bootfs_not_mounted_cleanup() {


### PR DESCRIPTION
Clean backport of the bug on master

http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/5803/ test failure appears unrelated