### PR TITLE
DLPX-76802 Starting Verification container enables IP forwarding on host

### DIFF
--- a/upgrade/upgrade-scripts/upgrade-container
+++ b/upgrade/upgrade-scripts/upgrade-container
@@ -443,6 +443,29 @@ function stop() {
 		sleep 1
 	done
 
+	#
+	# Starting the upgrade container would have enabled ip forwarding
+	# on the host (and in turn disabled LRO). Reset these settings
+	# on a best effor basis.
+	#
+	sysctl -w net.ipv4.ip_forward=0 || warn "failed to disable ip port forwarding"
+
+	#
+	# Find all the interfaces configured on the host and set
+	# lro on where possible. The sed command retrieves the names of the
+	# interfaces. The name of the virtual interfaces of containers could
+	# have an @ symbol followed by device name in the output of the ethtool
+	# and this needs to be trimmed off.
+	#
+
+	for i in $(ip -br link | sed 's/^\([^ @]\+\).*/\1/'); do
+		fixed=$(ethtool -k "$i" | grep large-receive-offload | grep -i fixed)
+		if [[ -z "$fixed" ]]; then
+			echo "updating lro setting for nic $i"
+			ethtool -K "$i" lro on || warn "failed to set lro ON for nic '$i'"
+		fi
+	done
+
 	machinectl status "$CONTAINER" &>/dev/null &&
 		die "timeout waiting for container termination: '$CONTAINER'"
 


### PR DESCRIPTION
It has been observed that simply starting the verification container enables ip forwarding on the host (and in turn disables LRO). This seems to persist post a DEFERRED upgrade, leading to potential performance regression in networking. Having attempted to prevent the container from setting ip forwarding to true at all (see PR https://github.com/delphix/delphix-platform/pull/314) and hit an issue when the upgrade needs to install a new version of systemd (see jira for more info on this), this PR attempts to leave the container properties as is, while attempting to reset the networking state post-verification. This is a relatively short window in which LRO gets disabled and should be tolerable.

The relevant properties can be viewed on the engine using below commands :

sudo sysctl net.ipv4.ip_forward
net.ipv4.ip_forward = 0

ethtool -k <nic> | grep large
large-receive-offload: on

Manual Testing :
Kevin Greene ran network performance benchmark tests pre and post verification using an upgrade image with the changes in this PR and found that there was no longer any performance regression. The LRO property is successfully reset to enabled post verification, and the change is immediately effective without needed a reboot.

git ab-pre-push: 
http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/5888/

http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/5898/ - building esx upgrade image.