### PR TITLE
Want variant-specific package lists for `live-build(7)`

### DIFF
--- a/live-build/misc/ansible-roles/appliance-build.dcenter/tasks/main.yml
+++ b/live-build/misc/ansible-roles/appliance-build.dcenter/tasks/main.yml
@@ -15,45 +15,16 @@
 #
 
 ---
-
-- apt:
-    name:
-      - adoptopenjdk-java8-jdk
-      - bind9
-      - dnsutils
-      - git
-      - isc-dhcp-server
-      - libldap2-dev
-      - libsasl2-dev
-      - nfs-common-dbgsym
-      - nfs-kernel-server
-      - nfs-kernel-server-dbgsym
-      - python3
-      - python3-dbg
-      - python3-dev
-      - python3-ldap
-      - python3-marshmallow
-      - python3-marshmallow-doc
-      - python3-pip
-      - python3-pyvmomi
-      - python3-six
-      - python3-tenacity
-      - python3-toml
-      - python3-venv
-      - targetcli-fb
-      - telnet
-    state: present
-  register: result
-  until: result is not failed
-  retries: 3
-  delay: 60
-
 - git:
     repo: 'https://gitlab.delphix.com/devops/dcenter-gate.git'
     version: master
     dest: /opt/dcenter/lib/dcenter-gate
     accept_hostkey: yes
     update: no
+
+- alternatives:
+    name: java
+    path: /usr/lib/jvm/adoptopenjdk-java8-jdk-amd64/bin/java
 
 #
 # By default, ubuntu restricts directories where dhcpd and named

--- a/live-build/variants/internal-dcenter/package-lists/dcenter.list.chroot
+++ b/live-build/variants/internal-dcenter/package-lists/dcenter.list.chroot
@@ -1,0 +1,41 @@
+#
+# Copyright 2021 Delphix
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+adoptopenjdk-java8-jdk
+bind9
+dnsutils
+git
+isc-dhcp-server
+libldap2-dev
+libsasl2-dev
+nfs-common-dbgsym
+nfs-kernel-server
+nfs-kernel-server-dbgsym
+openjdk-11-jdk-headless
+python3
+python3-dbg
+python3-dev
+python3-ldap
+python3-marshmallow
+python3-marshmallow-doc
+python3-pip
+python3-pyvmomi
+python3-six
+python3-tenacity
+python3-toml
+python3-venv
+targetcli-fb
+telnet

--- a/scripts/run-live-build.sh
+++ b/scripts/run-live-build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright 2018, 2020 Delphix
+# Copyright 2018, 2021 Delphix
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -93,13 +93,24 @@ if [[ "$RUN_TYPE" == "$ALL_RUN_TYPE" || "$RUN_TYPE" == "$VM_RUN_TYPE" ]]; then
 	cp -r "$TOP/live-build/config/hooks/$VM_RUN_TYPE/." "$build_dir/config/hooks"
 fi
 
+sed "s/@@PLATFORM@@/$APPLIANCE_PLATFORM/" \
+	<"$build_dir/config/package-lists/delphix-platform.list.chroot.in" \
+	>"$build_dir/config/package-lists/delphix-platform.list.chroot"
+
+if [[ -d "$TOP/live-build/variants/$APPLIANCE_VARIANT/package-lists" ]]; then
+	for list in "$TOP/live-build/variants/$APPLIANCE_VARIANT/package-lists/"*; do
+		[[ -f $list ]] || continue
+		if [[ -f "$build_dir/config/package-lists/$(basename "$list")" ]]; then
+			echo "Duplicate package list: $(basename "$list")" >&2
+			exit 1
+		fi
+		cp "$list" "$build_dir/config/package-lists"
+	done
+fi
+
 cp -r "$TOP/live-build/variants/$APPLIANCE_VARIANT/ansible" "$build_dir"
 
 cd "$build_dir"
-
-sed "s/@@PLATFORM@@/$APPLIANCE_PLATFORM/" \
-	<config/package-lists/delphix-platform.list.chroot.in \
-	>config/package-lists/delphix-platform.list.chroot
 
 #
 # The ancillary repository contains all of the first-party Delphix


### PR DESCRIPTION
Supersedes #576. Closes #582. Introduces support for variant-specific package lists in `live-build/variants/${APPLIANCE_VARIANT}/package-lists`, updating `scripts/run-live-build.sh` to merge them with the existing package lists that apply to all variants before plumbing through the result to `live-build(7)`. This allows us to move the list of packages for the `internal-dcenter` variant from the `appliance-build.dcenter` Ansible role to a new `dcenter.list.chroot` package list, which contains all of the original packages as well as `openjdk-11-jdk-headless`. These packages are installed in a context where `/proc` is mounted, which is necessary for `ca-certificates-java` (a dependency of `openjdk-11-jdk-headless`). We continue to use Java 8 as the default Java runtime to allow us to gradually migrate to Java 11. When we have fully migrated to Java 11, we can change the default Java runtime from Java 8 to Java 11.

### Implementation

`live-build(7)` uses a [flat](https://gitlab.com/debian-live/live-build/-/blob/489a09ba92328cef846598a15329e9ff91519e3c/scripts/build/binary_package-lists#L87-L88) [directory structure](https://gitlab.com/debian-live/live-build/-/blob/489a09ba92328cef846598a15329e9ff91519e3c/scripts/build/chroot_package-lists#L80-L82) for package lists, but there could still be problems if a variant has a package list of the same name as one that applies to all variants. To avoid such problems, we require all package lists to have unique names and fail fast if a variant has a package list of the same name as one that applies to all variants.

### Future work

Several of the existing Ansible roles install variant-specific packages and could be refactored to use this new subsystem if desired. For example, [this code in the `appliance-build.unittest-internal` role](https://github.com/delphix/appliance-build/blob/7cc8789445b73594b2265b70b86886b7ec262c5e/live-build/misc/ansible-roles/appliance-build.unittest-internal/tasks/main.yml#L18-L29) could easily be turned into a new package list for the `internal-unittest` variant. Others have suggested that the infrastructure introduced in this PR may overlap with the fix for [DLPX-76872](https://jira.delphix.com/browse/DLPX-76872).

### Testing done

#### Functional testing

Logged into an `internal-dcenter` VM with these changes and verified that Java 11 was installed:

```
$ /usr/lib/jvm/java-11-openjdk-amd64/bin/java -version
openjdk version "11.0.11" 2021-04-20
OpenJDK Runtime Environment (build 11.0.11+9-Ubuntu-0ubuntu2.18.04)
OpenJDK 64-Bit Server VM (build 11.0.11+9-Ubuntu-0ubuntu2.18.04, mixed mode, sharing)
```

Verified that Java 8 remained the default:

```
$ readlink -f /usr/bin/java
/usr/lib/jvm/adoptopenjdk-java8-jdk-amd64/bin/java
$ java -version
openjdk version "1.8.0_282"
OpenJDK Runtime Environment (AdoptOpenJDK)(build 1.8.0_282-b08)
OpenJDK 64-Bit Server VM (AdoptOpenJDK)(build 25.282-b08, mixed mode)
```

Finally, set up the VM as a Jenkins agent using the Java 11 runtime and verified that Jenkins could execute builds on that agent.

#### Negative testing

Intentionally introduced a naming conflict and verified that [the build failed as expected](http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-stage1/job/pre-push/10436/consoleFull):

```
+ echo 'Duplicate package list: delphix-platform.list.chroot'
Duplicate package list: delphix-platform.list.chroot
+ exit 1

FAILURE: Build failed with an exception.
```

#### Automated testing

- `git ab-pre-push -v internal-dcenter -p esx`: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/5883/
- `git ab-pre-push -v internal-qa -p aws`: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/5884/