### PR TITLE
DLPX-76907 obsolete conf file cleanup logic incorrectly removes conf files that were moved to another package

### DIFF
--- a/upgrade/upgrade-scripts/execute
+++ b/upgrade/upgrade-scripts/execute
@@ -382,6 +382,17 @@ dpkg-query -Wf '${Conffiles}\n' | awk '$3 == "obsolete" {print $1}' |
 		dpkg-query -W "$package" &>/dev/null ||
 			die "package '$package' is not installed"
 
+		#
+		# If the configuration file was moved to another package it
+		# will be listed for the original package as "obsolete" while
+		# also being listed as non-obsolete for the destination package.
+		#
+		if [[ $(dpkg-query -Wf '${Conffiles}\n' "$package" |
+			awk '$1 == "'"$file"'" {print $3}') != "obsolete" ]]; then
+			echo "configuration file '$file' has moved to package '$package'"
+			continue
+		fi
+
 		rm -f "$file" ||
 			die "failed to remove file '$file' of package '$package'"
 


### PR DESCRIPTION

Note that although this bug could affect any version it was found when doing upgrade to Ubuntu 20.04 on branch focal (See CP-3955)

The logic introduced in DLPX-66313 via https://github.com/delphix/appliance-build/pull/425 ends up deleting configuration files that should not be deleted.

The original intent of that logic was to delete unwanted configuration files (files in /etc) that were removed in a newer version of a package. However there is an issue for configuration files that were previously provided by one package but are now provided by another package, as those are also removed by that logic.

Here's an example.

The following system was upgraded from master (18.04) to focal (20.04):
```
$ dpkg-query -Wf '${Conffiles}\n' >/var/tmp/conffiles

$ cat /var/tmp/conffiles | grep obsolete | awk '{print $1}' >/var/tmp/obsolete

$ cat /var/tmp/obsolete
/etc/kernel/postrm.d/zz-update-grub
/etc/kernel/postinst.d/zz-update-grub
/etc/sensors.d/.placeholder
/etc/sensors3.conf
/etc/netconfig
/etc/init.d/rtslib-fb-targetctl
/etc/snmp/snmp.conf

$ cat /var/tmp/obsolete | while read file; do grep "$file" /var/tmp/conffiles; done
 /etc/kernel/postrm.d/zz-update-grub 536d9d45e3e547638db3c5d58a925b6c obsolete
 /etc/kernel/postrm.d/zz-update-grub 536d9d45e3e547638db3c5d58a925b6c
 /etc/kernel/postinst.d/zz-update-grub 536d9d45e3e547638db3c5d58a925b6c obsolete
 /etc/kernel/postinst.d/zz-update-grub 536d9d45e3e547638db3c5d58a925b6c
 /etc/sensors.d/.placeholder d41d8cd98f00b204e9800998ecf8427e
 /etc/sensors.d/.placeholder d41d8cd98f00b204e9800998ecf8427e obsolete
 /etc/sensors3.conf 41bd2b70a6ce64a21c2d1f70b9eed091
 /etc/sensors3.conf 2380011501bd2ad9e44f070c80a4c74d obsolete
 /etc/netconfig ca8db53e3af4d735335c2607d21c7195
 /etc/netconfig ca8db53e3af4d735335c2607d21c7195 obsolete
 /etc/init.d/rtslib-fb-targetctl e43bd8e309da8f4e44911b0b95dbeaa9 obsolete
 /etc/init.d/rtslib-fb-targetctl a15bf568c5a294d5f032c8341e3c1d99
 /etc/snmp/snmp.conf 72b4d550c66b2221e3c418c34395cc66
 /etc/snmp/snmp.conf 9709b4edd1a32741ab24ecc560ed9e28 obsolete
```
Note that all those conf files are listed twice: once as "obsolete" and once as regular. It appears that all the "obsolete" conf files aren't actually obsolete but have been moved to a different package, which is why they are marked as "obsolete" for their original package, and listed as regular conf files for their new package.
```
On master:
$ cat /var/tmp/obsolete | xargs dpkg -S
grub-pc: /etc/kernel/postrm.d/zz-update-grub
grub-pc: /etc/kernel/postinst.d/zz-update-grub
libsensors4:amd64: /etc/sensors.d/.placeholder
libsensors4:amd64: /etc/sensors3.conf
libtirpc1:amd64: /etc/netconfig
python-rtslib-fb: /etc/init.d/rtslib-fb-targetctl
snmp: /etc/snmp/snmp.conf

On focal:
$ cat /var/tmp/obsolete | xargs dpkg -S
grub2-common: /etc/kernel/postrm.d/zz-update-grub
grub2-common: /etc/kernel/postinst.d/zz-update-grub
libsensors-config: /etc/sensors.d/.placeholder
libsensors-config: /etc/sensors3.conf
libtirpc-common: /etc/netconfig
python3-rtslib-fb: /etc/init.d/rtslib-fb-targetctl
libsnmp-base: /etc/snmp/snmp.con
```
 


## Testing
- ab-pre-push --test-upgrade-from 6.0.0.0 (on master): http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/5900/
- ab-pre-push (on focal): http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/5901/
- Checked that obsolete config files are deleted as expected when upgrading from 6.0.0.0
- Confirmed that moved config files are handled properly during the upgrade to focal