### PR TITLE
install-ansible-lint is failing

### DIFF
--- a/.github/scripts/install-ansible-lint.sh
+++ b/.github/scripts/install-ansible-lint.sh
@@ -5,7 +5,6 @@ sudo apt-get install ansible
 git clone https://github.com/willthames/ansible-lint /opt/ansible-lint
 cd /opt/ansible-lint
 git checkout v3.4.21
-git branch -D master
 
 #
 # GitHub Actions exposes the GITHUB_ENV file that can be used to


### PR DESCRIPTION
`check-ansible` is failing because `install-ansible-lint` is failing with:
```
HEAD is now at 5d5ff0b Update version to 3.4.21
+ git branch -D master
error: branch 'master' not found.
Error: Process completed with exit code 1.
```
See https://github.com/delphix/appliance-build/pull/586/checks?check_run_id=3265249798