### PR TITLE
TOOL-12005 Enable ntp on dcenter-internal variant

### DIFF
--- a/live-build/misc/ansible-roles/appliance-build.dcenter/tasks/main.yml
+++ b/live-build/misc/ansible-roles/appliance-build.dcenter/tasks/main.yml
@@ -62,3 +62,17 @@
     - { regexp: '^RPCMOUNTDOPTS=', line: 'RPCMOUNTDOPTS="--num-threads=5 --manage-gids"' }
 
 - command: systemctl disable bind9.service isc-dhcp-server.service isc-dhcp-server6.service
+
+#
+# delphix-platform installs ntp in a disabled state by default.
+# We want to enable ntp to keep the time in sync on DCenter as clock skew
+# can cause operational problems.
+#
+# For example, we run awscli on DCenter hosts, and some preliminary searching
+# shows that aws s3 commands can return RequestTimeTooSkewed errors if there
+# is clock skew.
+#
+# We also have cleanup jobs that run on DCenter hosts that rely on filesystem
+# timestamps being accurate.
+#
+- command: systemctl enable ntp.service


### PR DESCRIPTION
This work should be integrated after DLPX-76874 (https://github.com/delphix/delphix-platform/pull/323), which will have ntp installed on the internal-dcenter variant, but in a disabled state.

There are 2 different time daemons available on Ubuntu: systemd-timesyncd and ntp, which are exclusive.

On Ubuntu 18.04 systemd-timesyncd.service is installed by default with the systemd package. Installing ntp does not prevent systemd-timesyncd.service from running, and so this fix is not required. systemd-timesyncd.service would start first, which will prevent ntp.service from later starting whether it is enabled or not. Therefore on Ubuntu 18.04 systemd-timesyncd will be syncing the time on the internal-dcenter variant regardless.

However, on Ubuntu 20.04 systemd-timesyncd.service is provided by a separate package, which conflicts with the ntp package. As such, if the ntp package is installed, then we should also make sure that ntp.service is enabled and running, otherwise the time would not be kept in sync.

## Testing
ab-pre-push -v internal-dcenter -p esx (+ change from DLPX-76874):
- On master: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/5925/
- On focal: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/5928/
- Spun up a dcenter-internal VM (pzakha-dcenter-1.dcol1) from the master build and verified that systemd-timesyncd is running.
- Spun up a dcenter-internal VM (pzakha-dcenter-2.dcol1) from the focal build and verified that ntp is running.