### PR TITLE
Use HTTPS URL for Artifactory

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 distributionSha256Sum=7506638a380092a0406364c79d6c87d03d23017fc25a5770379d1ce23c3fcd4d
-distributionUrl=http://artifactory.delphix.com/artifactory/gradle-distributions/gradle-5.1-bin.zip
+distributionUrl=https://artifactory.delphix.com/artifactory/gradle-distributions/gradle-5.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Clean backport of #598 to 6.0/stage.