### PR TITLE
Want variant-specific package lists for `live-build(7)`

### DIFF
--- a/live-build/misc/ansible-roles/appliance-build.dcenter/tasks/main.yml
+++ b/live-build/misc/ansible-roles/appliance-build.dcenter/tasks/main.yml
@@ -15,45 +15,16 @@
 #
 
 ---
-
-- apt:
-    name:
-      - adoptopenjdk-java8-jdk
-      - bind9
-      - dnsutils
-      - git
-      - isc-dhcp-server
-      - libldap2-dev
-      - libsasl2-dev
-      - nfs-common-dbgsym
-      - nfs-kernel-server
-      - nfs-kernel-server-dbgsym
-      - python3
-      - python3-dbg
-      - python3-dev
-      - python3-ldap
-      - python3-marshmallow
-      - python3-marshmallow-doc
-      - python3-pip
-      - python3-pyvmomi
-      - python3-six
-      - python3-tenacity
-      - python3-toml
-      - python3-venv
-      - targetcli-fb
-      - telnet
-    state: present
-  register: result
-  until: result is not failed
-  retries: 3
-  delay: 60
-
 - git:
     repo: 'https://gitlab.delphix.com/devops/dcenter-gate.git'
     version: master
     dest: /opt/dcenter/lib/dcenter-gate
     accept_hostkey: yes
     update: no
+
+- alternatives:
+    name: java
+    path: /usr/lib/jvm/adoptopenjdk-java8-jdk-amd64/bin/java
 
 #
 # By default, ubuntu restricts directories where dhcpd and named

--- a/live-build/variants/internal-dcenter/package-lists/dcenter.list.chroot
+++ b/live-build/variants/internal-dcenter/package-lists/dcenter.list.chroot
@@ -1,0 +1,41 @@
+#
+# Copyright 2021 Delphix
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+adoptopenjdk-java8-jdk
+bind9
+dnsutils
+git
+isc-dhcp-server
+libldap2-dev
+libsasl2-dev
+nfs-common-dbgsym
+nfs-kernel-server
+nfs-kernel-server-dbgsym
+openjdk-11-jdk-headless
+python3
+python3-dbg
+python3-dev
+python3-ldap
+python3-marshmallow
+python3-marshmallow-doc
+python3-pip
+python3-pyvmomi
+python3-six
+python3-tenacity
+python3-toml
+python3-venv
+targetcli-fb
+telnet

--- a/scripts/run-live-build.sh
+++ b/scripts/run-live-build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright 2018, 2020 Delphix
+# Copyright 2018, 2021 Delphix
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -93,13 +93,24 @@ if [[ "$RUN_TYPE" == "$ALL_RUN_TYPE" || "$RUN_TYPE" == "$VM_RUN_TYPE" ]]; then
 	cp -r "$TOP/live-build/config/hooks/$VM_RUN_TYPE/." "$build_dir/config/hooks"
 fi
 
+sed "s/@@PLATFORM@@/$APPLIANCE_PLATFORM/" \
+	<"$build_dir/config/package-lists/delphix-platform.list.chroot.in" \
+	>"$build_dir/config/package-lists/delphix-platform.list.chroot"
+
+if [[ -d "$TOP/live-build/variants/$APPLIANCE_VARIANT/package-lists" ]]; then
+	for list in "$TOP/live-build/variants/$APPLIANCE_VARIANT/package-lists/"*; do
+		[[ -f $list ]] || continue
+		if [[ -f "$build_dir/config/package-lists/$(basename "$list")" ]]; then
+			echo "Duplicate package list: $(basename "$list")" >&2
+			exit 1
+		fi
+		cp "$list" "$build_dir/config/package-lists"
+	done
+fi
+
 cp -r "$TOP/live-build/variants/$APPLIANCE_VARIANT/ansible" "$build_dir"
 
 cd "$build_dir"
-
-sed "s/@@PLATFORM@@/$APPLIANCE_PLATFORM/" \
-	<config/package-lists/delphix-platform.list.chroot.in \
-	>config/package-lists/delphix-platform.list.chroot
 
 #
 # The ancillary repository contains all of the first-party Delphix


### PR DESCRIPTION
Clean backport of #585 to `6.0/release`.

* http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/6006/
* http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/6007/