### PR TITLE
TOOL-12101 ui-precommit fails with missing necessary HEADLESS chrome …

### DIFF
--- a/live-build/misc/ansible-roles/appliance-build.unittest-internal/tasks/main.yml
+++ b/live-build/misc/ansible-roles/appliance-build.unittest-internal/tasks/main.yml
@@ -15,6 +15,9 @@
 #
 
 ---
+# libxss1 and libgtk-3-0 are required dependencies for 
+# chromium-browser. They are missing in the chromium-browser
+# package. Manually install them here.
 - apt:
     name:
       - adoptopenjdk-java8-jdk
@@ -25,9 +28,6 @@
       - git
       - python-minimal
       - chromium-browser
-      # libxss1 and libgtk-3-0 are required dependencies for 
-      # chromium-browser. They are missing in the chromium-browser
-      # package. Manually install them here.
       - libxss1
       - libgtk-3-0
     state: present

--- a/live-build/misc/ansible-roles/appliance-build.unittest-internal/tasks/main.yml
+++ b/live-build/misc/ansible-roles/appliance-build.unittest-internal/tasks/main.yml
@@ -25,6 +25,9 @@
       - git
       - python-minimal
       - chromium-browser
+      # libxss1 and libgtk-3-0 are required dependencies for 
+      # chromium-browser. They are missing in the chromium-browser
+      # package. Manually install them here.
       - libxss1
       - libgtk-3-0
     state: present

--- a/live-build/misc/ansible-roles/appliance-build.unittest-internal/tasks/main.yml
+++ b/live-build/misc/ansible-roles/appliance-build.unittest-internal/tasks/main.yml
@@ -26,6 +26,7 @@
       - python-minimal
       - chromium-browser
       - libxss1
+      - libgtk-3-0
     state: present
 
 - user:

--- a/live-build/misc/ansible-roles/appliance-build.unittest-internal/tasks/main.yml
+++ b/live-build/misc/ansible-roles/appliance-build.unittest-internal/tasks/main.yml
@@ -15,9 +15,11 @@
 #
 
 ---
-# libxss1 and libgtk-3-0 are required dependencies for 
+#
+# libxss1 and libgtk-3-0 are required dependencies for
 # chromium-browser. They are missing in the chromium-browser
 # package. Manually install them here.
+#
 - apt:
     name:
       - adoptopenjdk-java8-jdk


### PR DESCRIPTION
…dependency

<!--
# Context:
A clear description of the high level effort that this pull request is
a part of. Anyone in the organization can see this change and may not
have the same context as you.
-->
ui-precommit uses HEADLESS chromium-browser to run unit tests. chromium-browser is installed by Ansible.

# Problem:
<!--
A clear description of the problem. The problem statement should be
written in terms of a specific symptom that affects users or the
business. The problem statement should not be written in terms of the
solution.
-->
ui-precommit starts failing with chromium-browser version `92.0.4515.159-0ubuntu0.18.04.1`. http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/integration-tests/job/ui-precommit/job/pre-push/1080/console
It complains about `libgtk-3.so.0` is missing.
Though on the page for chromium-browser https://packages.ubuntu.com/bionic/chromium-browser, it declares that `libgtk-3` is included, that is not true:
```
$ apt show chromium-browser
Package: chromium-browser
Version: 92.0.4515.159-0ubuntu0.18.04.1
Status: install ok installed
Priority: optional
Section: web
Maintainer: Ubuntu Developers <ubuntu-devel-discuss@lists.ubuntu.com>
Installed-Size: 274 MB
Provides: chromium-browser-inspector, www-browser
Pre-Depends: dpkg (>= 1.15.6)
Depends: libasound2 (>= 1.0.16), libatk-bridge2.0-0 (>= 2.5.3), libatk1.0-0 (>= 2.2.0), libatspi2.0-0 (>= 2.9.90), libc6 (>= 2.27), libcairo2 (>= 1.6.0), libcups2 (>= 1.7.0), libdbus-1-3 (>= 1.9.14), libdrm2 (>= 2.4.38), libexpat1 (>= 2.0.1), libgbm1 (>= 17.1.0~rc2), libgcc1 (>= 1:3.0), libglib2.0-0 (>= 2.39.4), libnspr4 (>= 2:4.9-2~), libnss3 (>= 2:3.22), libpango-1.0-0 (>= 1.14.0), libwayland-client0 (>= 1.0.2), libx11-6 (>= 2:1.4.99.1), libxcb1 (>= 1.9.2), libxcomposite1 (>= 1:0.3-1), libxdamage1 (>= 1:1.1), libxext6, libxfixes3, libxkbcommon0 (>= 0.5.0), libxrandr2, libxshmfence1, libxtst6, bash (>= 4), libx11-xcb1, xdg-utils, chromium-codecs-ffmpeg-extra (= 92.0.4515.159-0ubuntu0.18.04.1) | chromium-codecs-ffmpeg (= 92.0.4515.159-0ubuntu0.18.04.1)
Recommends: chromium-browser-l10n
Suggests: webaccounts-chromium-extension, unity-chromium-extension
Conflicts: chromium-browser-inspector
Replaces: chromium-browser-inspector
Homepage: https://chromium.googlesource.com/chromium/src/
Download-Size: unknown
APT-Manual-Installed: yes
APT-Sources: /var/lib/dpkg/status
Description: Chromium web browser, open-source version of Chrome
 An open-source browser project that aims to build a safer, faster, and more
 stable way for all Internet users to experience the web.
```



# Solution:
<!--
A clear description of the high-level solution you have chosen. If
there were other possible solutions that you considered and rejected,
please mention those as well. Please do not describe implementation
details when writing about the solution, those should go into the
implementation section.
-->
This is a similar issue as missing `libxss1` before. We need to add these missing libs in the list for Ansible to install. So `libgtk-3-0` is added this time.

# Testing
<!--
Describe explicitly how this change was tested. Were we able to
recreate the issue? Were we able to write a test case that failed
before that passes now?
-->
Test manually on a unittest VM and verify HEADLESS chrome can be started.

[build](http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/6050/)
<!--
# Implementation:
The implementation details of the solution.
-->
<!--
# Notes To Reviewers:
Any extra information a reviewer may need to know before reviewing
your change. For example here you might want to describe which files
should be looked at first or which files are auto-generated.
-->
<!--
# Deployment Plan:
Some changes get more complicated and may need changes in multiple
repositories or may require infrastructure changes. Describe how these
changes will be smoothly deployed.
-->
<!--
# Future work:
A description of what follow up work is explicitly not being done in
this change.
-->
<!--
# Bonus:
A description of extra problems you've solved in this change. Did you
reformat an unrelated docstring? Point it out here
-->
