### PR TITLE
CP-5946 Enable Java debug mode for sso app

### DIFF
--- a/live-build/misc/ansible-roles/appliance-build.virtualization-development/tasks/main.yml
+++ b/live-build/misc/ansible-roles/appliance-build.virtualization-development/tasks/main.yml
@@ -44,6 +44,21 @@
       Environment=DLPX_DEBUG=true
 
 - file:
+    path: "/etc/systemd/system/delphix-sso-app.service.d"
+    owner: root
+    group: root
+    state: directory
+    recurse: yes
+
+- copy:
+    dest: "/etc/systemd/system/delphix-sso-app.service.d/override.conf"
+    owner: root
+    group: root
+    content: |
+      [Service]
+      Environment=DLPX_DEBUG=true
+
+- file:
     path: "/etc/systemd/system/delphix-postgres@.service.d"
     owner: root
     group: root


### PR DESCRIPTION
To facilitate development for SSO and OAuth2, we want to define DLPX_DEBUG for the SSO app in development engines, just like we do for the management stack, in the same way as we do for the stack -- by adding a systemd configuration override to the development variant.

ab-pre-push with tests: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/6089/