### PR TITLE
DLPX-77901 Prevent services from being re-enabled on upgrade

### DIFF
--- a/live-build/misc/ansible-roles/appliance-build.virtualization-common/tasks/main.yml
+++ b/live-build/misc/ansible-roles/appliance-build.virtualization-common/tasks/main.yml
@@ -39,17 +39,93 @@
     state: link
 
 #
+# The section below deals with disabling and masking services that need to be
+# disabled on initial install. Some of those services will remain disabled
+# forever, while others could be enabled by the various applications running
+# on the Delphix Appliance.
+#
+# Our approach is to mask services that need to be disabled. Masking a service
+# instead of just disabling it has 2 advantages:
+#  1. A service that is just disabled will not be started automatically by
+#     systemd on boot, however it can be started by another service if it has
+#     a certain set of dependencies on it (such as "Requires", "PartOf"). A
+#     service that is masked cannot be started in any case (although a
+#     service that is already running and has just been masked will not be
+#     stopped automatically).
+#  2. A service that is disabled can get re-enabled by dpkg maintenance scripts
+#     when the package that provides that service is upgraded. A service that
+#     is masked will not be unmasked.
+#
+# While masking a service is sufficient, we also disable most of the services
+# that we mask. This is not strictly necessary, but is done to remain
+# consistent with how we did things in the past. Our current logic that deals
+# with re-enabling those services will both unmask and enable # them.
+#
+# We have divided the disabling and masking of the services in multiple
+# code blocks to group together services that are handled in the same way by
+# the appliance.
+#
+# Note that if you want to modify this list make sure to also update
+# the logic in fix_and_migrate_services() that is invoked during upgrade.
+# You may also want to look at the logic that handles enabling disabling
+# services in dlpx-app-gate.
+#
+
+#
+# The services in this section should always remain disabled & masked.
+#
+- name: Disable services that should never run
+  command: "systemctl disable {{ item }}"
+  with_items:
+    - nginx.service
+    - postgresql.service
+    - systemd-timesyncd.service
+
+- name: Mask services that should never run
+  command: "systemctl mask {{ item }}"
+  with_items:
+    - nginx.service
+    - postgresql.service
+    - systemd-timesyncd.service
+
+#
+# The services in this section should be disabled & masked initially, but
+# can be later dynamically enabled by the appliance.
+#
+- name: Disable services that should not be running by default
+  command: "systemctl disable {{ item }}"
+  with_items:
+    - delphix-fluentd.service
+    - delphix-masking.service
+    - ntp.service
+    - snmpd.service
+
+- name: Mask services that should not be running by default
+  command: "systemctl mask {{ item }}"
+  with_items:
+    - delphix-fluentd.service
+    - delphix-masking.service
+    - ntp.service
+    - snmpd.service
+
+#
 # Because we want an NFSv4-only configuration out of the box, we need to mask
 # NFSv3 services so that they don't get automatically started at boot via
 # dependencies. The virtualization software is responsible for unmasking and
 # starting these services if NFSv3 needed at runtime.
 #
-- name: Mask NFSv3 services
-  file:
-    src: "/dev/null"
-    dest: "/etc/systemd/system/{{ item }}"
-    state: link
+- name: Mask NFSv3 services that should not be started automatically
+  command: "systemctl mask {{ item }}"
   with_items:
-      - rpc-statd.service
-      - rpcbind.service
-      - rpcbind.socket
+    - rpcbind.service
+    - rpcbind.socket
+    - snmpd.service
+
+#
+# We disable docker. Instead of being started automatically by systemd, it
+# gets started via a dependency of delphix-virtualization.
+#
+- name: Disable docker
+  command: "systemctl disable {{ item }}"
+  with_items:
+    - docker.service

--- a/live-build/misc/ansible-roles/appliance-build.virtualization-common/tasks/main.yml
+++ b/live-build/misc/ansible-roles/appliance-build.virtualization-common/tasks/main.yml
@@ -74,15 +74,10 @@
 #
 # The services in this section should always remain disabled & masked.
 #
-- name: Disable services that should never run
-  command: "systemctl disable {{ item }}"
-  with_items:
-    - nginx.service
-    - postgresql.service
-    - systemd-timesyncd.service
-
-- name: Mask services that should never run
-  command: "systemctl mask {{ item }}"
+- name: Disable and mask services that should never run
+  shell: |
+    systemctl disable {{ item }}
+    systemctl mask {{ item }}
   with_items:
     - nginx.service
     - postgresql.service
@@ -92,16 +87,10 @@
 # The services in this section should be disabled & masked initially, but
 # can be later dynamically enabled by the appliance.
 #
-- name: Disable services that should not be running by default
-  command: "systemctl disable {{ item }}"
-  with_items:
-    - delphix-fluentd.service
-    - delphix-masking.service
-    - ntp.service
-    - snmpd.service
-
-- name: Mask services that should not be running by default
-  command: "systemctl mask {{ item }}"
+- name: Disable and mask services that should not be running by default
+  shell: |
+    systemctl disable {{ item }}
+    systemctl mask {{ item }}
   with_items:
     - delphix-fluentd.service
     - delphix-masking.service
@@ -119,7 +108,7 @@
   with_items:
     - rpcbind.service
     - rpcbind.socket
-    - snmpd.service
+    - rpc-statd.service
 
 #
 # We disable docker. Instead of being started automatically by systemd, it

--- a/upgrade/upgrade-scripts/common.sh
+++ b/upgrade/upgrade-scripts/common.sh
@@ -431,20 +431,6 @@ function fix_and_migrate_services() {
 	fi
 
 	#
-	# docker is a special case. It needs to be masked for the duration
-	# of the upgrade so that it does not get restarted automatically on
-	# upgrade, which would also force a restart of the delphix-mgmt
-	# service (since the latter has a dependency on docker.service), and
-	# thus interrupt the upgrade.
-	#
-	# Once the upgrade is done we restart delphix.target, which will
-	# attempt to restart both delphix-mgmt and docker, so docker
-	# needs to be unmasked before that point. As such, docker is
-	# unmasked at the end of the execute script.
-	#
-	mask_service docker.service "$container"
-
-	#
 	# The services listed below are either permanently disabled or can be
 	# dynamically modified by the application(s) running on the appliance,
 	# so we need to ensure we migrate the state of these services when

--- a/upgrade/upgrade-scripts/execute
+++ b/upgrade/upgrade-scripts/execute
@@ -124,6 +124,8 @@ EOF
 start_stdout_redirect_to_system_log
 start_stderr_redirect_to_system_log
 
+fix_and_migrate_services
+
 #
 # Older versions (i.e. the 6.0.0.0 release) of the "nfs-kernel-server"
 # package had "etab" file delivered as part of the package. Thus, when
@@ -159,18 +161,6 @@ start_stderr_redirect_to_system_log
 #
 [[ -e /var/lib/dpkg/info/nfs-kernel-server.list ]] &&
 	sed -i '/\/var\/lib\/nfs\/etab/d' /var/lib/dpkg/info/nfs-kernel-server.list
-
-#
-# Older versions (i.e. the 6.0.0.0 release) of the virtualization
-# package would disable the "delphix-fluentd" service in that package's
-# "prerm" package hook. This meant that if the service was enabled prior
-# to the upgrade, it would be disabled after the upgrade. Since we can't
-# easily stop this behavior on systems already running 6.0.0.0, we have
-# to workaround this issue. Thus, before we upgrade the packages below,
-# we check to see if this service is currently enabled, and will
-# re-enable it after all packages have been upgraded.
-#
-DELPHIX_FLUENTD_IS_ENABLED=$(systemctl is-enabled delphix-fluentd.service)
 
 apt_get update || die "failed to update apt sources"
 
@@ -304,17 +294,6 @@ zcat "/usr/share/doc/delphix-entire-$platform/packages.list.gz" |
 apt_get autoremove --purge -y || die "autoremove after upgrade failed"
 
 #
-# As mentioned in a comment above, if the "delphix-fluentd" service is
-# enabled prior to upgrading all of the packages, we need to ensure it
-# remains enabled after upgrading all of the packages. Due to a bug in
-# 6.0.0.0 this might not be the case, so we explicitly enable it here.
-#
-if [[ "$DELPHIX_FLUENTD_IS_ENABLED" == "enabled" ]]; then
-	systemctl enable "delphix-fluentd.service" ||
-		die "failed to enable 'delphix-fluend.service'"
-fi
-
-#
 # Package configuration files are only automatically removed by the
 # package manager when the package that "owns" the file is "purged".
 # Thus, when upgrading a package to a new version that no longer
@@ -374,6 +353,12 @@ dpkg-query -Wf '${Conffiles}\n' | awk '$3 == "obsolete" {print $1}' |
 		apt_get install -y --reinstall "$package" ||
 			die "failed to reinstall package '$package'"
 	done || die "failed to remove obsolete package configuration files"
+
+#
+# Unmask docker, which was masked at the beginning of the upgrade in
+# fix_and_migrate_services().
+#
+systemctl unmask docker.service
 
 stop_stdout_redirect_to_system_log
 stop_stderr_redirect_to_system_log

--- a/upgrade/upgrade-scripts/execute
+++ b/upgrade/upgrade-scripts/execute
@@ -127,6 +127,20 @@ start_stderr_redirect_to_system_log
 fix_and_migrate_services
 
 #
+# Due to DLPX-77949, docker needs to be masked for the duration
+# of the upgrade so that it does not get restarted automatically on
+# upgrade, which would also force a restart of the delphix-mgmt
+# service (since the latter has a dependency on docker.service), and
+# thus interrupt the upgrade.
+#
+# Once the upgrade is done we restart delphix.target, which will
+# attempt to restart both delphix-mgmt and docker, so docker
+# needs to be unmasked before that point. As such, docker is
+# unmasked at the end of this script.
+#
+systemctl mask docker.service
+
+#
 # Older versions (i.e. the 6.0.0.0 release) of the "nfs-kernel-server"
 # package had "etab" file delivered as part of the package. Thus, when
 # upgrading the package, the existing "etab" file would get replaced
@@ -355,8 +369,8 @@ dpkg-query -Wf '${Conffiles}\n' | awk '$3 == "obsolete" {print $1}' |
 	done || die "failed to remove obsolete package configuration files"
 
 #
-# Unmask docker, which was masked at the beginning of the upgrade in
-# fix_and_migrate_services().
+# Unmask docker, which was masked at the beginning of the upgrade due
+# to DLPX-77949.
 #
 systemctl unmask docker.service
 

--- a/upgrade/upgrade-scripts/upgrade-container
+++ b/upgrade/upgrade-scripts/upgrade-container
@@ -395,6 +395,8 @@ function create_upgrade_container() {
 	EOF
 		die "failed to create container service override file"
 
+	fix_and_migrate_services "$CONTAINER"
+
 	echo "$CONTAINER"
 }
 
@@ -613,33 +615,6 @@ function migrate_dir() {
 	fi
 }
 
-#
-# Preserve the persistent service state of the service named as an argument.
-#
-function migrate_svc() {
-	local svc="$1"
-	local state
-	state=$(systemctl is-enabled "$svc")
-
-	if [[ $state == "masked" ]]; then
-		chroot "/var/lib/machines/$CONTAINER" systemctl mask "$svc"
-	else
-		#
-		# The service may be masked by default, so always unmask before
-		# doing anything else. Otherwise, systemctl will ignore the new
-		# setting.
-		#
-		chroot "/var/lib/machines/$CONTAINER" systemctl unmask "$svc"
-		if systemctl is-enabled -q "$svc"; then
-			chroot "/var/lib/machines/$CONTAINER" systemctl \
-				enable "$svc"
-		else
-			chroot "/var/lib/machines/$CONTAINER" systemctl \
-				disable "$svc"
-		fi
-	fi
-}
-
 function migrate_configuration() {
 	#
 	# When performing a not-in-place upgrade, the root and delphix
@@ -650,26 +625,6 @@ function migrate_configuration() {
 	#
 	migrate_password_for_user delphix
 	migrate_password_for_user root
-
-	#
-	# The services listed here can be dynamically modified by the
-	# application(s) running on the appliance, so we need to ensure
-	# we migrate the state of these services when performing a
-	# not-in-place upgrade. Otherwise, we'd wind up with the default
-	# state of these services after the upgrade, which could be
-	# different than the current state of these services.
-	#
-	while read -r svc; do
-		migrate_svc "$svc"
-	done <<-EOF
-		delphix-fluentd.service
-		delphix-masking.service
-		nfs-mountd.service
-		ntp.service
-		rpc-statd.service
-		rpcbind.service
-		rpcbind.socket
-	EOF
 
 	#
 	# These files are generic OS files that are required for the


### PR DESCRIPTION
The main idea behind this change is to make it easier to control which services get to run and which services should not run. In short, the solution is to mask services instead of just disabling them when we want them to not run, and then unmask them when we want them to run again.

This work is split up into 3 reviews which must all be pushed together. The 2 other PRs are:
- dlpx-app-gate: http://reviews.delphix.com/r/74397/
- delphix-platform: https://github.com/delphix/delphix-platform/pull/333

This addresses the following issues:
1. Some services that we want to never run end up getting re-enabled when some packages are upgraded / re-installed.
2. Other services that we want to be disabled / enabled conditionally end up in the wrong state after / during an upgrade.

One of the reasons for those issues is that the previous approach of relying on preinst and postinst scripts relies on a specific order for those scripts to be executed with respect to different packages, which did not hold anymore once we switched to Ubuntu 20.04. The other reason is that sometimes packages are re-installed or upgraded and end up re-enabling themselves unexpectedly.

The new approach does not rely on preinst/postinst scripts anymore, and instead performs operations that modify the state of services at certain specific times:
1. On initial install, after all packages have been installed
2. During the normal operation of the appliance, outside of upgrade
3. On upgrade, before packages are upgraded, and after all packages have been upgraded (must consider: in-place upgrade, not-in-place upgrade, inside container, outside container)

This review takes care of masking services that need to be masked on initial install (1) and on upgrade (3), while the app-gate review takes care of masking/unmasking services during the normal operation of the appliance (2).

The old preinst/postinst logic that is now made obsolete by this review is removed both by the delphix-platform and the dlpx-app-gate reviews.

## Additional Notes
 - Remove the DELPHIX_FLUENTD_IS_ENABLED fix since the minimum upgrade version is now way past 6.0.0.0, so that fix is not necessary anymore
 - snmpd.service should have been disabled on initial install, but it wasn't so for systems where the SNMP functionality is not in use, we disable (mask) that service during the upgrade. This fixes DLPX-77197 and DLPX-76796.
 - docker.service is a special case. It appears that we need to mask it for the duration of the upgrade (see comment in the code). This was previously "accidentally" done in the preinst/postinst hooks of delphix-virtualization since docker.service comes disabled out of the box, and remains disabled forever. Note that the fact that it is disabled doesn't prevent it from being started by the delphix-mgmt service as it is listed as `Requires=docker.service`. I keep the same behaviour here (keep docker disabled), however we may look into enabling it in the future instead.
- The reason why `fix_and_migrate_services()` both fixes service states and also migrates them in the case of not-in-place upgrade is to keep all the logic related to services in the same place, so it is easier to reason about it in its ensemble. 

## Testing
- Checked that the snmpd service is masked on upgrade when it was supposed to be disabled.
- ab-pre-push on master: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/6368
- ab-pre-push on focal: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/6371/
- ab-pre-push on focal (forced not-in-place upgrade): http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/6372/

Note that some of the upgrade runs have hit known failures: QA-30927, QA-30764, DLPX-72032