### PR TITLE
TOOL-12324 appliance-build: add a retry when unmount fails with EBUSY

### DIFF
--- a/live-build/config/hooks/vm-artifacts/90-raw-disk-image.binary
+++ b/live-build/config/hooks/vm-artifacts/90-raw-disk-image.binary
@@ -299,7 +299,12 @@ chroot "$DIRECTORY" grub-mkconfig -o /mnt/boot/grub/grub.cfg
 chroot "$DIRECTORY" umount /mnt
 
 for dir in /dev /proc /sys; do
-	umount -R "${DIRECTORY}${dir}"
+	for attempt in {1..5}; do
+		umount -R "${DIRECTORY}${dir}" && break
+		[[ "$attempt" == 5 ]] && die "Too many failed attempts, aborting."
+		echo "Attempt $attempt failed, trying again after a small nap."
+		sleep 10
+	done
 done
 
 umount "$DIRECTORY/var/log"


### PR DESCRIPTION
This is a workaround to an unmount EBUSY issue when creating our appliance images. This issue is being hit consistently when building the appliance on focal, and this fix has worked consistently.

We should eventually spend some time to figure out what causes this issue, but in the meanwhile this workaround has been reliable.

## Testing
- ab-pre-push: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/6353/
- This change soaked on focal for several months.