### PR TITLE
TOOL-12323 Remove libnss3-dbg package as it is missing on Ubuntu 20.04

### DIFF
--- a/live-build/misc/ansible-roles/appliance-build.qa-internal/tasks/main.yml
+++ b/live-build/misc/ansible-roles/appliance-build.qa-internal/tasks/main.yml
@@ -48,7 +48,6 @@
       - git
       - libcrypt-blowfish-dev
       - libcurl4-openssl-dev
-      - libnss3-dbg
       - libnss3-dev
       - libnss3-tools
       - libpam0g-dev


### PR DESCRIPTION
libnss3-dbg was added for debugging purposes, on internal systems only, in case we want to debug a process linked with libnss3 via gdb, so removing this package has a very low impact.

## Testing
- ab-pre-push: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/6354/