### PR TITLE
DLPX-77974 Add minimum version property to root dataset

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,6 +53,7 @@ for (variant in allVariants) {
 
         for (envVar in ["DELPHIX_PLATFORMS",
                         "DELPHIX_HOTFIX_VERSION",
+                        "DELPHIX_MINIMUM_VERSION",
                         "AWS_S3_URI_LIVEBUILD_ARTIFACTS",
                         "AWS_S3_URI_COMBINED_PACKAGES"]) {
             inputs.property(envVar, System.getenv(envVar)).optional(true)

--- a/live-build/build.gradle
+++ b/live-build/build.gradle
@@ -105,7 +105,8 @@ for (variant in allVariants) {
                                 "DELPHIX_PACKAGE_MIRROR_MAIN",
                                 "DELPHIX_PACKAGE_MIRROR_SECONDARY",
                                 "DELPHIX_SIGNATURE_URL",
-                                "DELPHIX_SIGNATURE_TOKEN"]) {
+                                "DELPHIX_SIGNATURE_TOKEN",
+                                "DELPHIX_MINIMUM_VERSION"]) {
                     inputs.property(envVar, System.getenv(envVar)).optional(true)
                 }
 

--- a/live-build/config/hooks/vm-artifacts/90-raw-disk-image.binary
+++ b/live-build/config/hooks/vm-artifacts/90-raw-disk-image.binary
@@ -142,6 +142,12 @@ if [[ -n "$DELPHIX_HOTFIX_VERSION" ]]; then
 		"rpool/ROOT/$FSNAME"
 fi
 
+if [[ -n "$DELPHIX_MINIMUM_VERSION" ]]; then
+	zfs set \
+		"com.delphix:minimum-version=$DELPHIX_MINIMUM_VERSION" \
+		"rpool/ROOT/$FSNAME"
+fi
+
 zfs create \
 	-o canmount=noauto \
 	-o mountpoint=/ \

--- a/upgrade/upgrade-scripts/common.sh
+++ b/upgrade/upgrade-scripts/common.sh
@@ -48,6 +48,7 @@ umask 0022
 PROP_CURRENT_VERSION="com.delphix:current-version"
 PROP_INITIAL_VERSION="com.delphix:initial-version"
 PROP_HOTFIX_VERSION="com.delphix:hotfix-version"
+PROP_MINIMUM_VERSION="com.delphix:minimum-version"
 
 #
 # To better enable root cause analysis of any upgrade failures, we

--- a/upgrade/upgrade-scripts/execute
+++ b/upgrade/upgrade-scripts/execute
@@ -444,6 +444,10 @@ zfs set "$PROP_CURRENT_VERSION=$VERSION" "$ROOTFS_CONTAINER" ||
 	die "failed to set property '$PROP_CURRENT_VERSION'" \
 		"to '$VERSION' for '$ROOTFS_CONTAINER'"
 
+zfs set "$PROP_MINIMUM_VERSION=$MINIMUM_VERSION" "$ROOTFS_CONTAINER" ||
+	die "failed to set property '$PROP_MINIMUM_VERSION'" \
+		"to '$MINIMUM_VERSION' for '$ROOTFS_CONTAINER'"
+
 if [[ -n "$HOTFIX" ]]; then
 	zfs set "$PROP_HOTFIX_VERSION=$HOTFIX" "$ROOTFS_CONTAINER" ||
 		die "failed to set property '$PROP_HOTFIX_VERSION'" \

--- a/upgrade/upgrade-scripts/upgrade-container
+++ b/upgrade/upgrade-scripts/upgrade-container
@@ -119,6 +119,13 @@ function create_upgrade_container() {
 			"$ROOTFS_DATASET" "$ROOTFS_DATASET@$SNAPSHOT_NAME"
 		copy_optional_dataset_property "$PROP_HOTFIX_VERSION" \
 			"$ROOTFS_DATASET" "$ROOTFS_DATASET@$SNAPSHOT_NAME"
+		#
+		# The minimum version property was introduced in 6.0.12.0.
+		#
+		if compare_versions "$(get_current_version)" ge "6.0.12.0"; then
+			copy_required_dataset_property "$PROP_MINIMUM_VERSION" \
+				"$ROOTFS_DATASET" "$ROOTFS_DATASET@$SNAPSHOT_NAME"
+		fi
 		;;
 	rollback)
 		#
@@ -149,6 +156,13 @@ function create_upgrade_container() {
 			"$ROOTFS_DATASET@$SNAPSHOT_NAME" "rpool/ROOT/$CONTAINER"
 		copy_optional_dataset_property "$PROP_HOTFIX_VERSION" \
 			"$ROOTFS_DATASET@$SNAPSHOT_NAME" "rpool/ROOT/$CONTAINER"
+		#
+		# The minimum version property was introduced in 6.0.12.0.
+		#
+		if compare_versions "$(get_current_version)" ge "6.0.12.0"; then
+			copy_required_dataset_property "$PROP_MINIMUM_VERSION" \
+				"$ROOTFS_DATASET@$SNAPSHOT_NAME" "rpool/ROOT/$CONTAINER"
+		fi
 
 		zfs clone \
 			-o canmount=noauto \


### PR DESCRIPTION
Adding minimum version property to root dataset

The minimum version property is used for
1. Upgrade: to determine minimum version needed for this image
2. Replication, FCR: minimum FCR version compatible

Test:
http://collins.d.delphix.com:20855/job/devops-gate/job/master/job/appliance-build/job/master/job/pre-push/29/console
Verified the upgrade image for the property.

New Job: http://collins.d.delphix.com:20855/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/1/console
