### PR TITLE
TOOL-12368 appliance-build: update some python2 package dependencies to python3

### DIFF
--- a/live-build/misc/ansible-roles/appliance-build.qa-internal/tasks/main.yml
+++ b/live-build/misc/ansible-roles/appliance-build.qa-internal/tasks/main.yml
@@ -53,7 +53,7 @@
       - libnss3-tools
       - libpam0g-dev
       - libssl-dev
-      - python-pip
+      - python3-pip
     state: present
   register: result
   until: result is not failed

--- a/live-build/misc/ansible-roles/appliance-build.unittest-internal/tasks/main.yml
+++ b/live-build/misc/ansible-roles/appliance-build.unittest-internal/tasks/main.yml
@@ -28,7 +28,7 @@
       - build-essential
       - docker.io
       - git
-      - python-minimal
+      - python3-minimal
       - chromium-browser
       - libxss1
       - libgtk-3-0

--- a/live-build/misc/ansible-roles/appliance-build.zfsonlinux-development/tasks/main.yml
+++ b/live-build/misc/ansible-roles/appliance-build.zfsonlinux-development/tasks/main.yml
@@ -45,7 +45,7 @@
       - nfs-kernel-server
       - parted
       - pkg-config
-      - python-minimal
+      - python3-minimal
       - shellcheck
       - targetcli-fb
       - unzip


### PR DESCRIPTION
This is required for the transition to Ubuntu 20.04

## Testing
- ab-pre-push on master: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/6417/ (Failure is unrelated)
- This has been soaking on focal branch for several months