### PR TITLE
TOOL-12369 appliance-build: changes for Ubuntu 20.04

### DIFF
--- a/live-build/auto/config
+++ b/live-build/auto/config
@@ -35,7 +35,7 @@ lb config noauto \
 	--bootstrap-flavour minimal \
 	--chroot-filesystem none \
 	--architectures amd64 \
-	--distribution bionic \
+	--distribution focal \
 	--binary-images none \
 	--bootloader none \
 	--system normal \

--- a/live-build/config/archives/delphix-secondary-mirror.list.in
+++ b/live-build/config/archives/delphix-secondary-mirror.list.in
@@ -14,5 +14,6 @@
 # limitations under the License.
 #
 
-deb @@URL@@ bionic main multiverse universe
-deb @@URL@@ bionic-updates main multiverse universe
+deb @@URL@@ focal main multiverse universe
+deb @@URL@@ focal-updates main multiverse universe
+deb @@URL@@ focal-pgdg main

--- a/live-build/config/archives/localhost.list
+++ b/live-build/config/archives/localhost.list
@@ -22,4 +22,4 @@
 # used to serve the repository.
 #
 
-deb [trusted=yes] http://localhost:8080 bionic main
+deb [trusted=yes] http://localhost:8080 focal main

--- a/live-build/misc/ansible-roles/appliance-build.virtualization-common/tasks/main.yml
+++ b/live-build/misc/ansible-roles/appliance-build.virtualization-common/tasks/main.yml
@@ -81,7 +81,6 @@
   with_items:
     - nginx.service
     - postgresql.service
-    - systemd-timesyncd.service
 
 #
 # The services in this section should be disabled & masked initially, but

--- a/scripts/aptly-repo-from-debs.sh
+++ b/scripts/aptly-repo-from-debs.sh
@@ -81,6 +81,6 @@ rm -rf "$WORK_DIRECTORY"
 #
 # Generate an Aptly/APT repository
 #
-aptly repo create -distribution=bionic -component=delphix upgrade-repository
+aptly repo create -distribution=focal -component=delphix upgrade-repository
 aptly repo add upgrade-repository debs
 aptly publish repo -skip-contents -skip-signing upgrade-repository

--- a/scripts/aptly-repo-from-image-diff.sh
+++ b/scripts/aptly-repo-from-image-diff.sh
@@ -93,7 +93,7 @@ popd &>/dev/null || die "'popd' failed"
 # system (e.g. "upgrade-image-from-aptly-repo.sh").
 #
 
-aptly repo create -distribution=bionic -component=delphix upgrade-repository ||
+aptly repo create -distribution=focal -component=delphix upgrade-repository ||
 	die "failed to create repository: 'upgrade-repository'"
 aptly repo search image-a | xargs aptly repo copy image-a upgrade-repository ||
 	die "failed to copy packages to repository: 'upgrade-repository'"

--- a/scripts/build-ancillary-repository.sh
+++ b/scripts/build-ancillary-repository.sh
@@ -47,7 +47,7 @@ function build_ancillary_repository() {
 
 	rm -rf "$HOME/.aptly"
 	aptly repo create \
-		-distribution=bionic -component=main ancillary-repository
+		-distribution=focal -component=main ancillary-repository
 	aptly repo add ancillary-repository "$pkg_directory"
 	aptly publish repo -skip-contents -skip-signing ancillary-repository
 

--- a/scripts/run-live-build.sh
+++ b/scripts/run-live-build.sh
@@ -127,7 +127,7 @@ APTLY_SERVE_PID=$!
 set +o errexit
 attempts=0
 while ! curl --output /dev/null --silent --head --fail \
-	"http://localhost:8080/dists/bionic/Release"; do
+	"http://localhost:8080/dists/focal/Release"; do
 	((attempts++))
 	if [[ $attempts -gt 30 ]]; then
 		echo "Timed out waiting for ancillary repository." 1>&2

--- a/upgrade/upgrade-scripts/execute
+++ b/upgrade/upgrade-scripts/execute
@@ -117,7 +117,7 @@ if [[ -f /etc/apt/sources.list ]]; then
 fi
 
 cat <<EOF >/etc/apt/sources.list ||
-deb [trusted=yes] file://$IMAGE_PATH bionic delphix
+deb [trusted=yes] file://$IMAGE_PATH focal delphix
 EOF
 	die "failed to configure apt sources"
 

--- a/upgrade/upgrade-scripts/upgrade-container
+++ b/upgrade/upgrade-scripts/upgrade-container
@@ -261,7 +261,7 @@ function create_upgrade_container() {
 		#
 		debootstrap --no-check-gpg --variant=minbase \
 			--components=delphix --include=ntp,systemd-container \
-			bionic "$DIRECTORY" "file://$IMAGE_PATH" 1>&2 ||
+			focal "$DIRECTORY" "file://$IMAGE_PATH" 1>&2 ||
 			die "failed to debootstrap upgrade filesystem"
 
 		#


### PR DESCRIPTION
Note: this will only be integrated when transitioning master to Ubuntu 20.04.

Here's a summary of the changes:
- Update live-build distribution from bionic to focal
- Update the distribution of our upgrade images from bionic to focal (note that I don't believe that the name we use there matters at all and that we could simply use "delphix" as the distribution, that said it's something to be tested out)
- Update the secondary mirrors distribution list
- Remove mentions of `systemd-timesyncd.service` since that service is not installed on 20.04

## Testing
- This code has been soaking on focal for a few months.
- Note that I've reverted focal commit https://github.com/delphix/appliance-build/commit/b142de40b9b741158e9049eb7ec938fc66ac5911 which I don't think is necessary now that DLPX-77901 has been integrated. Link to ab-pre-push with that logic removed: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/6434/