### PR TITLE
QI-3191 dlpx-qa-gate not installing on DCoLs as Jenkins agents

### DIFF
--- a/live-build/variants/internal-dcenter/package-lists/dcenter.list.chroot
+++ b/live-build/variants/internal-dcenter/package-lists/dcenter.list.chroot
@@ -39,3 +39,4 @@ python3-toml
 python3-venv
 targetcli-fb
 telnet
+unixodbc-dev


### PR DESCRIPTION
**Background:**

The DCoLs could be used as Jenkins agents. This is useful because dcol-dev could be used as an isolated test agent since not much runs on dcol-dev. Having an isolated test agent would be useful for determining Jenkins performance. In my case, I need to determine whether some ideas I have to make BB Parallel more efficient will actually work.

**Problem:**

I tried to run a BB Parallel job on the dcol-dev agent but received this stack trace during the dlpx-qa-gate installation:

```
13:48:49    Running setup.py install for pyodbc: started
13:48:49      Running setup.py install for pyodbc: finished with status 'error'
13:48:49      ERROR: Complete output from command /var/tmp/jenkins*slaves/developer/jenkins-selfservice.brandon.lim/workspace/devops-gate/qi-3040-bb-parallel-pipeline/blackbox-parallel/blackbox-parallel-pre-push/dlpx-qa-gate/build/py-envs/run3/bin/python -u -c 'import setuptools, tokenize;__file__='"'"'/tmp/pip-install-csu1ym40/pyodbc/setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' install --record /tmp/pip-record-rcev9vfc/install-record.txt --single-version-externally-managed --compile --install-headers /var/tmp/jenkins*slaves/developer/jenkins-selfservice.brandon.lim/workspace/devops-gate/qi-3040-bb-parallel-pipeline/blackbox-parallel/blackbox-parallel-pre-push/dlpx-qa-gate/build/py-envs/run3/include/site/python3.6/pyodbc:
13:48:49      ERROR: /usr/lib/python3.6/distutils/dist.py:261: UserWarning: Unknown distribution option: 'long*description_content*type'
13:48:49        warnings.warn(msg)
13:48:49      running install
13:48:49      running build
13:48:49      running build_ext
13:48:49      building 'pyodbc' extension
13:48:49      creating build
13:48:49      creating build/temp.linux-x86_64-3.6
13:48:49      creating build/temp.linux-x86_64-3.6/src
13:48:49      x86*64-linux-gnu-gcc -pthread -DNDEBUG -g -fwrapv -O2 -Wall -g -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -fPIC -DPYODBC_VERSION=4.0.32 -I/var/tmp/jenkins_slaves/developer/jenkins-selfservice.brandon.lim/workspace/devops-gate/qi-3040-bb-parallel-pipeline/blackbox-parallel/blackbox-parallel-pre-push/dlpx-qa-gate/build/py-envs/run3/include -I/usr/include/python3.6m -c src/buffer.cpp -o build/temp.linux-x86*64-3.6/src/buffer.o -Wno-write-strings
13:48:49      In file included from src/buffer.cpp:12:0:
13:48:49      src/pyodbc.h:56:10: fatal error: sql.h: No such file or directory
13:48:49       #include <sql.h>
13:48:49                ^<sub></sub><sub></sub><sub></sub>
13:48:49      compilation terminated.
13:48:49      error: command 'x86_64-linux-gnu-gcc' failed with exit status 1
13:48:49      ----------------------------------------
13:48:50  ERROR: Command "/var/tmp/jenkins*slaves/developer/jenkins-selfservice.brandon.lim/workspace/devops-gate/qi-3040-bb-parallel-pipeline/blackbox-parallel/blackbox-parallel-pre-push/dlpx-qa-gate/build/py-envs/run3/bin/python -u -c 'import setuptools, tokenize;__file__='"'"'/tmp/pip-install-csu1ym40/pyodbc/setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' install --record /tmp/pip-record-rcev9vfc/install-record.txt --single-version-externally-managed --compile --install-headers /var/tmp/jenkins*slaves/developer/jenkins-selfservice.brandon.lim/workspace/devops-gate/qi-3040-bb-parallel-pipeline/blackbox-parallel/blackbox-parallel-pre-push/dlpx-qa-gate/build/py-envs/run3/include/site/python3.6/pyodbc" failed with error code 1 in /tmp/pip-install-csu1ym40/pyodbc/
13:48:50  WARNING: You are using pip version 19.1.1, however version 21.3.1 is available.
13:48:50  You should consider upgrading via the 'pip install --upgrade pip' command.
13:48:50  
13:48:50  > Task :InstallRequirementsrun3 FAILED
13:48:50  :InstallRequirementsrun3 (Thread<Execution worker for ':' Thread 13,5,main>) completed. Took 49.595 secs.
13:48:50  
13:48:50  FAILURE: Build failed with an exception.
13:48:50  
13:48:50  * What went wrong:
13:48:50  Execution failed for task ':InstallRequirementsrun3'.
13:48:50  > Process 'command '/var/tmp/jenkins_slaves/developer/jenkins-selfservice.brandon.lim/workspace/devops-gate/qi-3040-bb-parallel-pipeline/blackbox-parallel/blackbox-parallel-pre-push/dlpx-qa-gate/build/py-envs/run3/bin/python'' finished with non-zero exit value 1
```

After some quick Google searching it turns out this issue is happening because `unixodbc-dev` needs to be installed.

**Solution:**

Add `unixodbc-dev` to the internal-dcenter variant.

**Testing:**

```
% git ab-pre-push -v internal-dcenter -p esx
http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/6459/console
```
Associated sync-ova-into-dcenter job:
http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/sync-ova-into-dcenter/1621/console

I was able to run `./gradlew InstallBlackboxrun3 --no-daemon` on my DCoL1 VM with the changes applied dlpx-brandon-lim-master-1621-8a5cd044.dcol1.delphix.com