### PR TITLE
TOOL-12434 Need to use devops-bot token to fetch some repositories during appliance-build

### DIFF
--- a/live-build/misc/ansible-roles/appliance-build.zfsonlinux-development/tasks/main.yml
+++ b/live-build/misc/ansible-roles/appliance-build.zfsonlinux-development/tasks/main.yml
@@ -59,12 +59,13 @@
   delay: 60
 
 - git:
-    repo: "https://github.com/delphix/zfs.git"
+    repo: "https://{{ lookup('env', 'GITHUB_TOKEN') }}@github.com/delphix/zfs.git"
     dest:
       "/export/home/delphix/zfs"
     version: master
     accept_hostkey: yes
     update: no
+  when: lookup('env', 'GITHUB_TOKEN') != ''
 
 - file:
     path: "/export/home/delphix/zfs"


### PR DESCRIPTION
Note that this will also require a change in devops-gate to pass GITHUB_TOKEN, until then the zfs repo will not be fetched on internal-dev VMs.

## Testing
- ab-pre-push: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/6524/
- ab-pre-push, with devops changes to pass GITHUB_TOKEN to build: http://collins.d.delphix.com:21968/job/devops-gate/job/master/job/appliance-build/job/master/job/pre-push/104/