### PR TITLE
Backports to 6.0/stage

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 distributionSha256Sum=7506638a380092a0406364c79d6c87d03d23017fc25a5770379d1ce23c3fcd4d
-distributionUrl=http://artifactory.delphix.com/artifactory/gradle-distributions/gradle-5.1-bin.zip
+distributionUrl=https://artifactory.delphix.com/artifactory/gradle-distributions/gradle-5.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/live-build/config/hooks/vm-artifacts/90-raw-disk-image.binary
+++ b/live-build/config/hooks/vm-artifacts/90-raw-disk-image.binary
@@ -299,7 +299,12 @@ chroot "$DIRECTORY" grub-mkconfig -o /mnt/boot/grub/grub.cfg
 chroot "$DIRECTORY" umount /mnt
 
 for dir in /dev /proc /sys; do
-	umount -R "${DIRECTORY}${dir}"
+	for attempt in {1..5}; do
+		umount -R "${DIRECTORY}${dir}" && break
+		[[ "$attempt" == 5 ]] && die "Too many failed attempts, aborting."
+		echo "Attempt $attempt failed, trying again after a small nap."
+		sleep 10
+	done
 done
 
 umount "$DIRECTORY/var/log"

--- a/live-build/misc/ansible-roles/appliance-build.dcenter/tasks/main.yml
+++ b/live-build/misc/ansible-roles/appliance-build.dcenter/tasks/main.yml
@@ -15,12 +15,21 @@
 #
 
 ---
+#
+# We are wrapping this in a retry block because the Gitlab server sometimes
+# hangs up unexpectedly. We haven't seen this with GitHub, so we should
+# probably remove the retry once we switch to GitHub.
+#
 - git:
     repo: 'https://gitlab.delphix.com/devops/dcenter-gate.git'
     version: master
     dest: /opt/dcenter/lib/dcenter-gate
     accept_hostkey: yes
     update: no
+  retries: 3
+  delay: 30
+  register: result
+  until: result is not failed
 
 - alternatives:
     name: java

--- a/live-build/misc/ansible-roles/appliance-build.dcenter/tasks/main.yml
+++ b/live-build/misc/ansible-roles/appliance-build.dcenter/tasks/main.yml
@@ -62,3 +62,17 @@
     - { regexp: '^RPCMOUNTDOPTS=', line: 'RPCMOUNTDOPTS="--num-threads=5 --manage-gids"' }
 
 - command: systemctl disable bind9.service isc-dhcp-server.service isc-dhcp-server6.service
+
+#
+# delphix-platform installs ntp in a disabled state by default.
+# We want to enable ntp to keep the time in sync on DCenter as clock skew
+# can cause operational problems.
+#
+# For example, we run awscli on DCenter hosts, and some preliminary searching
+# shows that aws s3 commands can return RequestTimeTooSkewed errors if there
+# is clock skew.
+#
+# We also have cleanup jobs that run on DCenter hosts that rely on filesystem
+# timestamps being accurate.
+#
+- command: systemctl enable ntp.service

--- a/live-build/misc/ansible-roles/appliance-build.masking-development/tasks/main.yml
+++ b/live-build/misc/ansible-roles/appliance-build.masking-development/tasks/main.yml
@@ -23,6 +23,11 @@
   retries: 3
   delay: 60
 
+#
+# We are wrapping this in a retry block because the Gitlab server sometimes
+# hangs up unexpectedly. We haven't seen this with GitHub, so we should
+# probably remove the retry once we switch to GitHub.
+#
 - git:
     repo: "{{ item.repo }}"
     dest:
@@ -34,6 +39,10 @@
     - { repo: 'https://gitlab.delphix.com/masking/dms-core-gate.git',
         version: master,
         dest: dms-core-gate }
+  retries: 3
+  delay: 30
+  register: result
+  until: result is not failed
 
 - file:
     path: "/export/home/delphix/{{ item }}"

--- a/live-build/misc/ansible-roles/appliance-build.qa-internal/tasks/main.yml
+++ b/live-build/misc/ansible-roles/appliance-build.qa-internal/tasks/main.yml
@@ -48,7 +48,6 @@
       - git
       - libcrypt-blowfish-dev
       - libcurl4-openssl-dev
-      - libnss3-dbg
       - libnss3-dev
       - libnss3-tools
       - libpam0g-dev

--- a/live-build/misc/ansible-roles/appliance-build.qa-internal/tasks/main.yml
+++ b/live-build/misc/ansible-roles/appliance-build.qa-internal/tasks/main.yml
@@ -52,7 +52,7 @@
       - libnss3-tools
       - libpam0g-dev
       - libssl-dev
-      - python-pip
+      - python3-pip
     state: present
   register: result
   until: result is not failed

--- a/live-build/misc/ansible-roles/appliance-build.unittest-internal/tasks/main.yml
+++ b/live-build/misc/ansible-roles/appliance-build.unittest-internal/tasks/main.yml
@@ -15,11 +15,6 @@
 #
 
 ---
-#
-# libxss1 and libgtk-3-0 are required dependencies for
-# chromium-browser. They are missing in the chromium-browser
-# package. Manually install them here.
-#
 - apt:
     name:
       - adoptopenjdk-java8-jdk
@@ -29,9 +24,56 @@
       - docker.io
       - git
       - python3-minimal
-      - chromium-browser
-      - libxss1
+    state: present
+
+#
+# The UI-precommit suite requires some chromium-browser dependendencies to be
+# installed. However on 20.04 chromium is provided by a snap, and the
+# "chromium-browser" package neither provides any dependencies nor the actual
+# chromium browser, but rather directs users to install the chromium snap.
+# While we could get chromium from a thrid party PPA, we do not actually need
+# chromium for UI-precommit to work, but only some of the libraries that
+# came as dependencies. As such we install here all the lib dependencies
+# that were brought in by the chromium-browser package on 18.04 as per:
+# https://packages.ubuntu.com/bionic/chromium-browser.
+#
+- apt:
+    name:
+      - libasound2
+      - libatk-bridge2.0-0
+      - libatk-bridge2.0-0
+      - libatspi2.0-0
+      - libc6
+      - libcairo2
+      - libcups2
+      - libdbus-1-3
+      - libdrm2
+      - libexpat1
+      - libgbm1
+      - libgcc1
+      - libgdk-pixbuf2.0-0
+      - libglib2.0-0
       - libgtk-3-0
+      - libnspr4
+      - libnss3
+      - libpango-1.0-0
+      - libpangocairo-1.0-0
+      - libwayland-client0
+      - libx11-6
+      - libx11-xcb1
+      - libxcb1
+      - libxcomposite1
+      - libxcursor1
+      - libxdamage1
+      - libxext6
+      - libxfixes3
+      - libxi6
+      - libxkbcommon0
+      - libxrandr2
+      - libxrender1
+      - libxshmfence1
+      - libxss1
+      - libxtst6
     state: present
 
 - user:

--- a/live-build/misc/ansible-roles/appliance-build.unittest-internal/tasks/main.yml
+++ b/live-build/misc/ansible-roles/appliance-build.unittest-internal/tasks/main.yml
@@ -28,7 +28,7 @@
       - build-essential
       - docker.io
       - git
-      - python-minimal
+      - python3-minimal
       - chromium-browser
       - libxss1
       - libgtk-3-0

--- a/live-build/misc/ansible-roles/appliance-build.virtualization-development/tasks/main.yml
+++ b/live-build/misc/ansible-roles/appliance-build.virtualization-development/tasks/main.yml
@@ -73,6 +73,11 @@
       [Service]
       Environment=DLPX_PG_DEBUG=true
 
+#
+# We are wrapping this in a retry block because the Gitlab server sometimes
+# hangs up unexpectedly. We haven't seen this with GitHub, so we should
+# probably remove the retry once we switch to GitHub.
+#
 - git:
     repo: "{{ item.repo }}"
     dest:
@@ -84,6 +89,10 @@
     - { repo: 'https://gitlab.delphix.com/app/dlpx-app-gate.git',
         version: master,
         dest: dlpx-app-gate }
+  retries: 3
+  delay: 30
+  register: result
+  until: result is not failed
 
 - file:
     path: "/export/home/delphix/{{ item }}"

--- a/live-build/misc/ansible-roles/appliance-build.zfsonlinux-development/tasks/main.yml
+++ b/live-build/misc/ansible-roles/appliance-build.zfsonlinux-development/tasks/main.yml
@@ -45,7 +45,7 @@
       - nfs-kernel-server
       - parted
       - pkg-config
-      - python-minimal
+      - python3-minimal
       - shellcheck
       - targetcli-fb
       - unzip

--- a/live-build/variants/internal-dcenter/package-lists/dcenter.list.chroot
+++ b/live-build/variants/internal-dcenter/package-lists/dcenter.list.chroot
@@ -39,3 +39,4 @@ python3-toml
 python3-venv
 targetcli-fb
 telnet
+unixodbc-dev

--- a/upgrade/upgrade-scripts/execute
+++ b/upgrade/upgrade-scripts/execute
@@ -175,59 +175,25 @@ DELPHIX_FLUENTD_IS_ENABLED=$(systemctl is-enabled delphix-fluentd.service)
 apt_get update || die "failed to update apt sources"
 
 #
-# First make sure delphix-platform-<platform> is installed. This package
-# is required by delphix-entire-<platform>, and would be installed even
-# if we just relied on the packages.list.gz file log below. However,
-# there are problems related to virtual packages that arise if we just
-# did that. In particular, the following could happen (using AWS as the
-# example for the platform on which the upgrade is being done):
+# Currently, we need to run the delphix-platform's "postinst" packaging hook
+# prior to the installation of the postgresql package. Further, right now,
+# the postgresql package is pulled in as a dependency of the
+# delphix-virtualization package. Thus, for the case of not-in-place upgrades,
+# we accomplish this goal (of installing the delphix-platform package prior
+# to the installation of the postgresql package) by first installing the
+# delphix-platform package here, and then installing all other packages later.
+# For the case of in-place upgrades, we can skip this step, as we assume the
+# postgresql package is already installed, and simply upgrade all packages
+# below.
 #
-#  - We install the package requirements for "delphix-entire-aws" using
-#    the packages.list.gz file.
+# Note that we have the same issue during appliance-build, and it is solved
+# by installing delphix-virtualization at a later stage of the build via
+# ansible hooks, when the delphix-platform package has already been installed.
 #
-#  - One of the packages in that list is the "delphix-virtualization"
-#    package, so it marks that package and its dependencies for
-#    installation. One of its dependencies is the virtual package
-#    "delphix-platform".
-#
-#  - Apt then sees that there are multiple concrete packages which
-#    provide the "delphix-platform" virtual package. It chooses one of
-#    these arbitrarily, say "delphix-platform-kvm".
-#
-#  - Apt marks all transitive dependencies of "delphix-platform-kvm" for
-#    installation, including, say, "linux-image-4.15.0-1028-kvm".
-#
-#  - After processing the dependencies of "delphix-virtualization", Apt
-#    continues to process the other dependencies of "delphix-entire-aws",
-#    including "delphix-platform-aws".
-#
-#  - Apt then sees that "delphix-platform-aws" conflicts with
-#    "delphix-platform-kvm", so it un-marks "delphix-platform-kvm" for
-#    installation, allowing "delphix-platform-aws" to satisfy the
-#    "delphix-virtualization" dependency on "delphix-platform". However,
-#    it does _not_ unmark all of the dependencies of
-#    "delphix-platform-kvm", so some unnecessary kvm-related packages
-#    end up being installed, such as "linux-image-4.15.0-1028-kvm"
-#
-# In short, we can end up with some unwanted packages installed because
-# Apt marked and then unmarked some package for installation while
-# trying to satisfy a dependency on a virtual package.
-#
-# To avoid this we install the delphix-platform-<platform> package that
-# we want before installing delphix-entire-<platform> and it's required
-# packages. If some delphix-platform package is already installed, that
-# dependency is already satisfied and Apt doesn't need to choose an
-# arbitrary one to satisfy the dependency.
-#
-# In general, we don't want upgrade to need know too much about the set
-# of packages to be installed. However, it seems reasonable to make an
-# exception for delphix-platform because delphix-platform is a
-# fundemental piece of the architecture of the appliance. Among other
-# things, it is the mechanism that we use to orchestrate the installation
-# all of the platform-dependant bits of the appliance.
-#
-apt_get install -y "delphix-platform-$platform" ||
-	die "failed to install delphix-platform"
+if ! dpkg-query -l "delphix-platform-$platform" &>/dev/null; then
+	apt_get install -y "delphix-platform-$platform" ||
+		die "failed to install delphix-platform"
+fi
 
 #
 # To enable the use of "autoremove" later in this script to remove all

--- a/upgrade/upgrade-scripts/upgrade-container
+++ b/upgrade/upgrade-scripts/upgrade-container
@@ -233,8 +233,34 @@ function create_upgrade_container() {
 		# communicate and later run commands in the container with
 		# "systemd-run".
 		#
-		debootstrap --no-check-gpg \
-			--components=delphix --include=systemd-container \
+		# On Ubuntu 20.04, in-order to satisfy some package
+		# dependencies, we must set the variant to "minbase" and list
+		# "ntp" in the include list before "systemd-container".
+		# Setting the variant to minbase removes systemd from the
+		# packages being installed by default. Systemd will still
+		# be installed, but in a later pass, as a dependency of
+		# systemd-container. The reason we need to go through those
+		# hoops is the following:
+		#  - systemd has a package dependency on a "time-daemon"
+		#    virtual package, which is provided by either "ntp" or
+		#    "systemd-timesyncd".
+		#  - If a time-deamon is not already installed when
+		#    installing systemd, then systemd will try to
+		#    install systemd-timesyncd.
+		#  - systemd-timesyncd is not available in our upgrade
+		#    images because we install ntp and ntp conflicts with
+		#    systemd-timesyncd.
+		#  - Setting variant as minbase and list ntp before
+		#    systemd-container in the include list allows debootstrap
+		#    to install ntp before systemd, thus satisfying the
+		#    package dependencies.
+		# Note that we do not run into those problems during live-build
+		# because debootstrap is already run with variant=minbase and
+		# systemd is not installed by debootstrap, but rather by
+		# delphix-platform which pulls both ntp and systemd.
+		#
+		debootstrap --no-check-gpg --variant=minbase \
+			--components=delphix --include=ntp,systemd-container \
 			bionic "$DIRECTORY" "file://$IMAGE_PATH" 1>&2 ||
 			die "failed to debootstrap upgrade filesystem"
 


### PR DESCRIPTION
This backports a bunch of commits from master to 6.0/stage.

## Testing
- ab-pre-push: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/6528/
- manually test that app-data testing on 6.0/stage still works with TOOL-12368