### PR TITLE
DLPX-78304 [Backport of DLPX-77901 to 6.0.12.0] Prevent services from being re-enabled on upgrade

### DIFF
--- a/live-build/misc/ansible-roles/appliance-build.virtualization-common/tasks/main.yml
+++ b/live-build/misc/ansible-roles/appliance-build.virtualization-common/tasks/main.yml
@@ -39,17 +39,82 @@
     state: link
 
 #
+# The section below deals with disabling and masking services that need to be
+# disabled on initial install. Some of those services will remain disabled
+# forever, while others could be enabled by the various applications running
+# on the Delphix Appliance.
+#
+# Our approach is to mask services that need to be disabled. Masking a service
+# instead of just disabling it has 2 advantages:
+#  1. A service that is just disabled will not be started automatically by
+#     systemd on boot, however it can be started by another service if it has
+#     a certain set of dependencies on it (such as "Requires", "PartOf"). A
+#     service that is masked cannot be started in any case (although a
+#     service that is already running and has just been masked will not be
+#     stopped automatically).
+#  2. A service that is disabled can get re-enabled by dpkg maintenance scripts
+#     when the package that provides that service is upgraded. A service that
+#     is masked will not be unmasked.
+#
+# While masking a service is sufficient, we also disable most of the services
+# that we mask. This is not strictly necessary, but is done to remain
+# consistent with how we did things in the past. Our current logic that deals
+# with re-enabling those services will both unmask and enable # them.
+#
+# We have divided the disabling and masking of the services in multiple
+# code blocks to group together services that are handled in the same way by
+# the appliance.
+#
+# Note that if you want to modify this list make sure to also update
+# the logic in fix_and_migrate_services() that is invoked during upgrade.
+# You may also want to look at the logic that handles enabling disabling
+# services in dlpx-app-gate.
+#
+
+#
+# The services in this section should always remain disabled & masked.
+#
+- name: Disable and mask services that should never run
+  shell: |
+    systemctl disable {{ item }}
+    systemctl mask {{ item }}
+  with_items:
+    - nginx.service
+    - postgresql.service
+    - systemd-timesyncd.service
+
+#
+# The services in this section should be disabled & masked initially, but
+# can be later dynamically enabled by the appliance.
+#
+- name: Disable and mask services that should not be running by default
+  shell: |
+    systemctl disable {{ item }}
+    systemctl mask {{ item }}
+  with_items:
+    - delphix-fluentd.service
+    - delphix-masking.service
+    - ntp.service
+    - snmpd.service
+
+#
 # Because we want an NFSv4-only configuration out of the box, we need to mask
 # NFSv3 services so that they don't get automatically started at boot via
 # dependencies. The virtualization software is responsible for unmasking and
 # starting these services if NFSv3 needed at runtime.
 #
-- name: Mask NFSv3 services
-  file:
-    src: "/dev/null"
-    dest: "/etc/systemd/system/{{ item }}"
-    state: link
+- name: Mask NFSv3 services that should not be started automatically
+  command: "systemctl mask {{ item }}"
   with_items:
-      - rpc-statd.service
-      - rpcbind.service
-      - rpcbind.socket
+    - rpcbind.service
+    - rpcbind.socket
+    - rpc-statd.service
+
+#
+# We disable docker. Instead of being started automatically by systemd, it
+# gets started via a dependency of delphix-virtualization.
+#
+- name: Disable docker
+  command: "systemctl disable {{ item }}"
+  with_items:
+    - docker.service

--- a/upgrade/upgrade-scripts/common.sh
+++ b/upgrade/upgrade-scripts/common.sh
@@ -362,3 +362,113 @@ function verify_upgrade_not_in_progress() {
 	. "$UPDATE_DIR/upgrade.properties" &>/dev/null
 	[[ -z "$UPGRADE_TYPE" ]] || die "upgrade currently in-progress"
 }
+
+function mask_service() {
+	local svc="$1"
+	local container="$2"
+
+	#
+	# Note that masking should succeed even if service doesn't exist
+	#
+	if [[ -n "$container" ]]; then
+		chroot "/var/lib/machines/$container" systemctl mask "$svc" ||
+			die "failed to mask '$svc' in container '$container'"
+	else
+		systemctl mask "$svc" || die "failed to mask '$svc'"
+	fi
+}
+
+function is_svc_masked_or_disabled() {
+	local svc="$1"
+
+	state=$(systemctl is-enabled "$svc")
+	if [[ "$state" == masked || "$state" == disabled ]]; then
+		return 0
+	fi
+
+	return 1
+}
+
+#
+# This function has 2 tasks:
+#  1. Fix/update the state of some services to be in line with what is expected
+#     in this version of the appliance.
+#  2. If we are doing a not-in-place upgrade, then migrate the state of the
+#     services into the upgrade container.
+#
+# It can be called from 2 different contexts:
+#  1. When creating upgrade container. In this case the container must be
+#     passed as first argument.
+#  2. When executing the in-place upgrade. In this case the function takes no
+#     arguments.
+#
+function fix_and_migrate_services() {
+	local container="$1"
+
+	#
+	# This function must be called from outside an upgrade container as it
+	# uses the state of the services on the running system as the source of
+	# truth. Since we want the logic in this script to apply both to an
+	# upgrade container and to the running system (in case of an in-place
+	# upgrade), we call it from two places: create_upgrade_container() and
+	# the execute script. The former will apply this logic on a container
+	# while the latter will apply this logic to the running system.
+	#
+	if systemd-detect-virt --container --quiet; then
+		echo "fix_and_migrate_services: should not run inside container"
+		return
+	fi
+
+	#
+	# In versions prior to 6.0.13.0, snmpd.service was always enabled.
+	# Disable (mask) it here if we detect that it should have been disabled.
+	#
+	if compare_versions "$(get_current_version)" lt "6.0.13.0"; then
+		if [[ "$(systemctl is-enabled snmpd)" == enabled ]] &&
+			! grep -q "Delphix" /etc/snmp/snmpd.conf; then
+			mask_service snmpd "$container"
+		fi
+	fi
+
+	#
+	# The services listed below are either permanently disabled or can be
+	# dynamically modified by the application(s) running on the appliance,
+	# so we need to ensure we migrate the state of these services when
+	# performing a not-in-place upgrade. Otherwise, we'd wind up with the
+	# default state of these services on initial install, which is to stay
+	# enabled and unmasked.
+	#
+	# If we are performing an in-place upgrade instead, then we want
+	# to make sure that the state of those services conforms to the new
+	# logic, which requires that the services are also masked when they
+	# are disabled.
+	#
+	# The reason we want to mask services instead of just disabling them
+	# is because when upgrading some of those packages, the services can
+	# be automatically enabled by postinst scripts; this is especially
+	# true for not-in-place upgrade, which creates a fresh debootstrap
+	# image on which the new packages are installed for the first time.
+	#
+	# Finally, some of the services that are masked may be both masked
+	# and disabled, while others would be only masked. This is okay
+	# given that masked services will not run whether they are enabled
+	# or disabled, and that the logic that unmasks them will also
+	# enable them.
+	#
+	while read -r svc; do
+		is_svc_masked_or_disabled "$svc" &&
+			mask_service "$svc" "$container"
+	done <<-EOF
+		delphix-fluentd.service
+		delphix-masking.service
+		nfs-mountd.service
+		nginx.service
+		ntp.service
+		postgresql.service
+		rpc-statd.service
+		rpcbind.service
+		rpcbind.socket
+		snmpd.service
+		systemd-timesyncd.service
+	EOF
+}

--- a/upgrade/upgrade-scripts/execute
+++ b/upgrade/upgrade-scripts/execute
@@ -124,6 +124,22 @@ EOF
 start_stdout_redirect_to_system_log
 start_stderr_redirect_to_system_log
 
+fix_and_migrate_services
+
+#
+# Due to DLPX-77949, docker needs to be masked for the duration
+# of the upgrade so that it does not get restarted automatically on
+# upgrade, which would also force a restart of the delphix-mgmt
+# service (since the latter has a dependency on docker.service), and
+# thus interrupt the upgrade.
+#
+# Once the upgrade is done we restart delphix.target, which will
+# attempt to restart both delphix-mgmt and docker, so docker
+# needs to be unmasked before that point. As such, docker is
+# unmasked at the end of this script.
+#
+systemctl mask docker.service
+
 #
 # Older versions (i.e. the 6.0.0.0 release) of the "nfs-kernel-server"
 # package had "etab" file delivered as part of the package. Thus, when
@@ -159,18 +175,6 @@ start_stderr_redirect_to_system_log
 #
 [[ -e /var/lib/dpkg/info/nfs-kernel-server.list ]] &&
 	sed -i '/\/var\/lib\/nfs\/etab/d' /var/lib/dpkg/info/nfs-kernel-server.list
-
-#
-# Older versions (i.e. the 6.0.0.0 release) of the virtualization
-# package would disable the "delphix-fluentd" service in that package's
-# "prerm" package hook. This meant that if the service was enabled prior
-# to the upgrade, it would be disabled after the upgrade. Since we can't
-# easily stop this behavior on systems already running 6.0.0.0, we have
-# to workaround this issue. Thus, before we upgrade the packages below,
-# we check to see if this service is currently enabled, and will
-# re-enable it after all packages have been upgraded.
-#
-DELPHIX_FLUENTD_IS_ENABLED=$(systemctl is-enabled delphix-fluentd.service)
 
 apt_get update || die "failed to update apt sources"
 
@@ -304,17 +308,6 @@ zcat "/usr/share/doc/delphix-entire-$platform/packages.list.gz" |
 apt_get autoremove --purge -y || die "autoremove after upgrade failed"
 
 #
-# As mentioned in a comment above, if the "delphix-fluentd" service is
-# enabled prior to upgrading all of the packages, we need to ensure it
-# remains enabled after upgrading all of the packages. Due to a bug in
-# 6.0.0.0 this might not be the case, so we explicitly enable it here.
-#
-if [[ "$DELPHIX_FLUENTD_IS_ENABLED" == "enabled" ]]; then
-	systemctl enable "delphix-fluentd.service" ||
-		die "failed to enable 'delphix-fluend.service'"
-fi
-
-#
 # Package configuration files are only automatically removed by the
 # package manager when the package that "owns" the file is "purged".
 # Thus, when upgrading a package to a new version that no longer
@@ -374,6 +367,12 @@ dpkg-query -Wf '${Conffiles}\n' | awk '$3 == "obsolete" {print $1}' |
 		apt_get install -y --reinstall "$package" ||
 			die "failed to reinstall package '$package'"
 	done || die "failed to remove obsolete package configuration files"
+
+#
+# Unmask docker, which was masked at the beginning of the upgrade due
+# to DLPX-77949.
+#
+systemctl unmask docker.service
 
 stop_stdout_redirect_to_system_log
 stop_stderr_redirect_to_system_log

--- a/upgrade/upgrade-scripts/upgrade-container
+++ b/upgrade/upgrade-scripts/upgrade-container
@@ -421,6 +421,8 @@ function create_upgrade_container() {
 	EOF
 		die "failed to create container service override file"
 
+	fix_and_migrate_services "$CONTAINER"
+
 	echo "$CONTAINER"
 }
 
@@ -639,33 +641,6 @@ function migrate_dir() {
 	fi
 }
 
-#
-# Preserve the persistent service state of the service named as an argument.
-#
-function migrate_svc() {
-	local svc="$1"
-	local state
-	state=$(systemctl is-enabled "$svc")
-
-	if [[ $state == "masked" ]]; then
-		chroot "/var/lib/machines/$CONTAINER" systemctl mask "$svc"
-	else
-		#
-		# The service may be masked by default, so always unmask before
-		# doing anything else. Otherwise, systemctl will ignore the new
-		# setting.
-		#
-		chroot "/var/lib/machines/$CONTAINER" systemctl unmask "$svc"
-		if systemctl is-enabled -q "$svc"; then
-			chroot "/var/lib/machines/$CONTAINER" systemctl \
-				enable "$svc"
-		else
-			chroot "/var/lib/machines/$CONTAINER" systemctl \
-				disable "$svc"
-		fi
-	fi
-}
-
 function migrate_configuration() {
 	#
 	# When performing a not-in-place upgrade, the root and delphix
@@ -676,26 +651,6 @@ function migrate_configuration() {
 	#
 	migrate_password_for_user delphix
 	migrate_password_for_user root
-
-	#
-	# The services listed here can be dynamically modified by the
-	# application(s) running on the appliance, so we need to ensure
-	# we migrate the state of these services when performing a
-	# not-in-place upgrade. Otherwise, we'd wind up with the default
-	# state of these services after the upgrade, which could be
-	# different than the current state of these services.
-	#
-	while read -r svc; do
-		migrate_svc "$svc"
-	done <<-EOF
-		delphix-fluentd.service
-		delphix-masking.service
-		nfs-mountd.service
-		ntp.service
-		rpc-statd.service
-		rpcbind.service
-		rpcbind.socket
-	EOF
 
 	#
 	# These files are generic OS files that are required for the


### PR DESCRIPTION
This backports #615

As for the original, it has dependencies on 2 other reviews:
dlpx-app-gate: http://reviews.delphix.com/r/75270/
delphix-platform: https://github.com/delphix/delphix-platform/pull/338

## Testing:
- ab-pre-push, including work from the other repos: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/6535/
- build internal-dcenter: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/6537/