### PR TITLE
DLPX-78464 Regression in appliance-build from DLPX-76293

### DIFF
--- a/live-build/config/hooks/configuration/81-upgrade-repository.binary
+++ b/live-build/config/hooks/configuration/81-upgrade-repository.binary
@@ -83,11 +83,16 @@ rename 's/\%3a/:/g' binary/packages/*.deb
 #
 # Copy over the generated hotfix metadata.
 #
+# Note: AWS_S3_HOTFIX_METADATA is the only variable that is allowed to
+# be unset in this logic, thus the temporary `set -u`.
+#
+set +u
 if [[ -z "$AWS_S3_HOTFIX_METADATA" ]]; then
 	touch hotfix_metadata
 else
 	aws s3 cp --only-show-errors "$AWS_S3_HOTFIX_METADATA" hotfix_metadata
 fi
+set -u
 
 if [[ ! -f "hotfix_metadata" ]]; then
 	echo "Could not generate hotfix_metadata file."


### PR DESCRIPTION
# Problem

Manually running the appliance-build steps mentioned in the README file of the repo fails with the following error:
```
./config/hooks/81-upgrade-repository.binary: line 86: AWS_S3_HOTFIX_METADATA: unbound variable
E: config/hooks/81-upgrade-repository.binary failed (exit non-zero). You should check for errors.
P: Begin unmounting filesystems...
P: Saving caches...
Reading package lists...
Building dependency tree...
Reading state information...
+ kill -9 104400
+ [[ ! -f binary/SHA256SUMS ]]
+ exit 1

> Task :live-build:buildInternalDevAws FAILED
```

The problem was introduced by :
```
commit e6c2dd1c29afae49778ab470fcb9bc62524842ac
Author: Matt Skinner <matt.skinner@delphix.com>
Date:   Mon Aug 9 12:13:58 2021 -0400

    DLPX-76293 Copy Hotfix Metadata Generation to appliance-build (#574)
```

# Testing

* Ran `sudo ./gradlew buildInternalDevAzure` manually without issues.
* http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/6624/