### PR TITLE
TOOL-12471 Remove Jenkins job references to devops-gate/master in appliance-build

### DIFF
--- a/scripts/aptly-repo-from-debs.sh
+++ b/scripts/aptly-repo-from-debs.sh
@@ -66,7 +66,7 @@ done
 #
 AWS_S3_URI_COMBINED_PACKAGES=$(resolve_s3_uri \
 	"$AWS_S3_URI_COMBINED_PACKAGES" \
-	"devops-gate/master/linux-pkg/${UPSTREAM_BRANCH}/combine-packages/post-push/latest")
+	"linux-pkg/${UPSTREAM_BRANCH}/combine-packages/post-push/latest")
 
 WORK_DIRECTORY=$(mktemp -d -p "$TOP/upgrade" tmp.pkgs.XXXXXXXXXX)
 

--- a/scripts/build-ancillary-repository.sh
+++ b/scripts/build-ancillary-repository.sh
@@ -98,7 +98,7 @@ echo "Running with UPSTREAM_BRANCH set to ${UPSTREAM_BRANCH}"
 
 AWS_S3_URI_COMBINED_PACKAGES=$(resolve_s3_uri \
 	"$AWS_S3_URI_COMBINED_PACKAGES" \
-	"devops-gate/master/linux-pkg/${UPSTREAM_BRANCH}/combine-packages/post-push/latest")
+	"linux-pkg/${UPSTREAM_BRANCH}/combine-packages/post-push/latest")
 
 mkdir -p "$TOP/build"
 WORK_DIRECTORY=$(mktemp -d -p "$TOP/build" tmp.pkgs.XXXXXXXXXX)


### PR DESCRIPTION
### Problem

As part of http://reviews.delphix.com/r/75405/ we are removing devops-gate/master from the job
hierarchy on Jenkins. Need to update all the references.

### Solution

Remove the references.

### Testing Done

Ran appliance-build-pre-push using my developer Jenkins controller
http://selfservice.jtor-docker.dcol2.delphix.com/job/appliance-build-orchestrator-pre-push/2/console

### Deployment Plan
This needs to be merged after the new Jenkins controllers have been deployed. Otherwise, jobs would fail to fetch the right artifacts on S3 since the JOB_NAME will differ.
