### PR TITLE
CP-6676 appliance-build changes to simplify the fluentd build

### DIFF
--- a/live-build/config/archives/delphix-secondary-mirror.list.in
+++ b/live-build/config/archives/delphix-secondary-mirror.list.in
@@ -14,6 +14,6 @@
 # limitations under the License.
 #
 
-deb @@URL@@ focal main multiverse universe
+deb @@URL@@ focal main multiverse universe contrib
 deb @@URL@@ focal-updates main multiverse universe
 deb @@URL@@ focal-pgdg main

--- a/live-build/misc/ansible-roles/appliance-build.virtualization-common/tasks/main.yml
+++ b/live-build/misc/ansible-roles/appliance-build.virtualization-common/tasks/main.yml
@@ -81,6 +81,7 @@
   with_items:
     - nginx.service
     - postgresql.service
+    - td-agent.service
 
 #
 # The services in this section should be disabled & masked initially, but


### PR DESCRIPTION
appliance-build needs to be updated to
1) pickup the standard ubuntu package from the contrib PPA in our linux-package-mirror
2) mask the td-agent service.

This is a companion of [app-gate](CP-6651) and [linux-pkg](CP-5327) changes. 

Testing:
[ab-pre-push](http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/6632/)  
