### PR TITLE
DLPX-78582 6.0/stage build needs python3.8 in order to release vSDK 4…

### DIFF
--- a/live-build/misc/ansible-roles/appliance-build.qa-internal/tasks/main.yml
+++ b/live-build/misc/ansible-roles/appliance-build.qa-internal/tasks/main.yml
@@ -40,6 +40,9 @@
 # can move the build dependencies from the list below back into the
 # "internal-dev" playbook.
 #
+- apt_repository:
+    repo: 'ppa:deadsnakes/ppa'
+
 - apt:
     name:
       - ant
@@ -53,6 +56,7 @@
       - libpam0g-dev
       - libssl-dev
       - python3-pip
+      - python3.8
     state: present
   register: result
   until: result is not failed


### PR DESCRIPTION
vSDK 4.0.0 relies on the existence of python3.8 during build time. To avoid breaking git-au, we also need it installed on the engine.