### PR TITLE
TOOL-12544 [Backport of TOOL-12471 to 6.0.6.2] Remove Jenkins job references to devops-gate/master in appliance-build

### DIFF
--- a/scripts/aptly-repo-from-debs.sh
+++ b/scripts/aptly-repo-from-debs.sh
@@ -66,7 +66,7 @@ done
 #
 AWS_S3_URI_COMBINED_PACKAGES=$(resolve_s3_uri \
 	"$AWS_S3_URI_COMBINED_PACKAGES" \
-	"devops-gate/master/linux-pkg/${UPSTREAM_BRANCH}/combine-packages/post-push/latest")
+	"linux-pkg/${UPSTREAM_BRANCH}/combine-packages/post-push/latest")
 
 WORK_DIRECTORY=$(mktemp -d -p "$TOP/upgrade" tmp.pkgs.XXXXXXXXXX)
 

--- a/scripts/build-ancillary-repository.sh
+++ b/scripts/build-ancillary-repository.sh
@@ -98,7 +98,7 @@ echo "Running with UPSTREAM_BRANCH set to ${UPSTREAM_BRANCH}"
 
 AWS_S3_URI_COMBINED_PACKAGES=$(resolve_s3_uri \
 	"$AWS_S3_URI_COMBINED_PACKAGES" \
-	"devops-gate/master/linux-pkg/${UPSTREAM_BRANCH}/combine-packages/post-push/latest")
+	"linux-pkg/${UPSTREAM_BRANCH}/combine-packages/post-push/latest")
 
 mkdir -p "$TOP/build"
 WORK_DIRECTORY=$(mktemp -d -p "$TOP/build" tmp.pkgs.XXXXXXXXXX)


### PR DESCRIPTION
Clean cherrypick of: https://www.github.com/delphix/appliance-build/pull/633