### PR TITLE
TOOL-12406 named.service may conflict with dcenter-dhcp.service on dcenter-internal variant

### DIFF
--- a/live-build/misc/ansible-roles/appliance-build.dcenter/tasks/main.yml
+++ b/live-build/misc/ansible-roles/appliance-build.dcenter/tasks/main.yml
@@ -70,7 +70,7 @@
     - { regexp: '^RPCNFSDCOUNT=', line: 'RPCNFSDCOUNT=64' }
     - { regexp: '^RPCMOUNTDOPTS=', line: 'RPCMOUNTDOPTS="--num-threads=5 --manage-gids"' }
 
-- command: systemctl disable bind9.service isc-dhcp-server.service isc-dhcp-server6.service
+- command: systemctl mask named.service isc-dhcp-server.service isc-dhcp-server6.service
 
 #
 # delphix-platform installs ntp in a disabled state by default.


### PR DESCRIPTION
ab-pre-push: http://selfservice.jenkins.delphix.com/job/appliance-build/job/master/job/pre-push/28/

I cloned a VM from the dcol1 group from this build to test that the correct set of services were masked.

```
root@seb-dcenter-test:~# systemctl status named.service
● named.service
     Loaded: masked (Reason: Unit named.service is masked.)
     Active: inactive (dead)
root@seb-dcenter-test:~# systemctl status isc-dhcp-server.service
● isc-dhcp-server.service
     Loaded: masked (Reason: Unit isc-dhcp-server.service is masked.)
     Active: inactive (dead)
root@seb-dcenter-test:~# systemctl status isc-dhcp-server6.service
● isc-dhcp-server6.service
     Loaded: masked (Reason: Unit isc-dhcp-server6.service is masked.)
     Active: inactive (dead)
```