### PR TITLE
DLPX-78736 Several test_api_and_cli_list_operation tests failed after…

### DIFF
--- a/upgrade/upgrade-scripts/common.sh
+++ b/upgrade/upgrade-scripts/common.sh
@@ -471,5 +471,6 @@ function fix_and_migrate_services() {
 		rpcbind.socket
 		snmpd.service
 		systemd-timesyncd.service
+		td-agent.service
 	EOF
 }


### PR DESCRIPTION
After upgrade the td-agent is not masked, but is running and keeping port 8888 tied up.  This is causing the failure.   It seems the td-agent is missing from a list of services that are masked after upgrade.

Testing:

ab-pre-push (pending) - http://selfservice.jenkins.delphix.com/job/appliance-build-orchestrator-pre-push/482/