### PR TITLE
CP-7160 [Backport of CP-6676 to 6.0.13.0] appliance-build changes to simplify the fluentd build

### DIFF
--- a/live-build/config/archives/delphix-secondary-mirror.list.in
+++ b/live-build/config/archives/delphix-secondary-mirror.list.in
@@ -14,6 +14,6 @@
 # limitations under the License.
 #
 
-deb @@URL@@ focal main multiverse universe
+deb @@URL@@ focal main multiverse universe contrib
 deb @@URL@@ focal-updates main multiverse universe
 deb @@URL@@ focal-pgdg main

--- a/live-build/misc/ansible-roles/appliance-build.virtualization-common/tasks/main.yml
+++ b/live-build/misc/ansible-roles/appliance-build.virtualization-common/tasks/main.yml
@@ -81,6 +81,7 @@
   with_items:
     - nginx.service
     - postgresql.service
+    - td-agent.service
 
 #
 # The services in this section should be disabled & masked initially, but


### PR DESCRIPTION
Clean cherry pick. 

Goes together with the app-gate change  http://reviews.delphix.com/r/77706/.