### PR TITLE
TOOL-12838 github Authentication failed

### DIFF
--- a/live-build/misc/ansible-roles/appliance-build.zfsonlinux-development/tasks/main.yml
+++ b/live-build/misc/ansible-roles/appliance-build.zfsonlinux-development/tasks/main.yml
@@ -66,6 +66,10 @@
     accept_hostkey: yes
     update: no
   when: lookup('env', 'GITHUB_TOKEN') != ''
+  retries: 3
+  delay: 30
+  register: result
+  until: result is not failed
 
 - file:
     path: "/export/home/delphix/zfs"


### PR DESCRIPTION
We use a retry loop when cloning all non-zfs repositories in appliance-build, so this change adds the retry loop for the zfs repository as well; hopefully this alleviates the flakiness with authentication to github, and at worst makes the zfs repository consistent with the other repositories (w.r.t. using a retry loop when cloning).