### PR TITLE
DLPX-79367 td-agent service is not masked after upgrade

### DIFF
--- a/upgrade/upgrade-scripts/common.sh
+++ b/upgrade/upgrade-scripts/common.sh
@@ -379,8 +379,13 @@ function mask_service() {
 	fi
 }
 
-function is_svc_masked_or_disabled() {
+function is_svc_new_or_masked_or_disabled() {
 	local svc="$1"
+
+	systemctl cat "$svc" &>/dev/null
+	if [ $? -eq 1 ]; then
+		return 0
+	fi
 
 	state=$(systemctl is-enabled "$svc")
 	if [[ "$state" == masked || "$state" == disabled ]]; then
@@ -457,7 +462,7 @@ function fix_and_migrate_services() {
 	# enable them.
 	#
 	while read -r svc; do
-		is_svc_masked_or_disabled "$svc" &&
+		is_svc_new_or_masked_or_disabled "$svc" &&
 			mask_service "$svc" "$container"
 	done <<-EOF
 		delphix-fluentd.service


### PR DESCRIPTION
This is the second attempt to fix this issue.  

The failed fix integrated for DLPX-78736 rightly saw that td-agent needed to be masked in the fix_and_migrate_services() function in the upgrade script appliance-build/upgrad/upgrad-scripts/comm.sh.  However; the logic in that script does not work for new services.  It only masks existing services that are in the masked or disabled state.  

I added a separate lists of services that should always be masked after upgrade.   

Upgrade tests: http://selfservice.jenkins.delphix.com/job/appliance-build-orchestrator-pre-push/614/
