### PR TITLE
DLPX-80114 Add list of installed linux packages for each platform variant during appliance build

### DIFF
--- a/live-build/build.gradle
+++ b/live-build/build.gradle
@@ -124,13 +124,16 @@ for (variant in allVariants) {
                 switch (runType) {
                     case upgradeArtifactsRunType:
                         outputs.file "${buildDir}/artifacts/${variant}-${platform}.debs.tar.gz"
+                        outputs.file "${buildDir}/artifacts/${variant}-${platform}.packages.list"
                         break
                     case vmArtifactsRunType:
                         outputs.file "${buildDir}/artifacts/${variant}-${platform}.${artifactTypes[platform]}"
+                        outputs.file "${buildDir}/artifacts/${variant}-${platform}.packages.list"
                         break
                     case allRunType:
                         outputs.file "${buildDir}/artifacts/${variant}-${platform}.debs.tar.gz"
                         outputs.file "${buildDir}/artifacts/${variant}-${platform}.${artifactTypes[platform]}"
+                        outputs.file "${buildDir}/artifacts/${variant}-${platform}.packages.list"
                         break
                 }
 

--- a/live-build/config/hooks/configuration/81-upgrade-repository.binary
+++ b/live-build/config/hooks/configuration/81-upgrade-repository.binary
@@ -109,6 +109,8 @@ cp config/hooks/template.ctl delphix-entire.ctl
 # shellcheck disable=SC2016
 chroot binary dpkg-query -Wf '${Package}=${Version}\n' | sort >packages.list
 
+cp packages.list "$ARTIFACT_NAME.packages.list"
+
 echo "$APPLIANCE_VARIANT" >variant
 
 test -n "$DELPHIX_APPLIANCE_VERSION"

--- a/scripts/run-live-build.sh
+++ b/scripts/run-live-build.sh
@@ -266,7 +266,7 @@ esac
 # user (e.g. other software); this is most useful when multiple variants
 # are built via a single call to "make" (e.g. using the "all" target).
 #
-for ext in debs.tar.gz $vm_artifact_ext; do
+for ext in debs.tar.gz $vm_artifact_ext packages.list; do
 	if [[ -f "$ARTIFACT_NAME.$ext" ]]; then
 		mv "$ARTIFACT_NAME.$ext" "$TOP/live-build/build/artifacts/"
 	fi


### PR DESCRIPTION
### Problem
Current BOM doesn't contain the linux packages that are installed part of the OS. Also, there is no easy way to check the version of these packages without looking at the delphix engine.

### Solution
While creating the delphix-entire package we aggregate the packages that need to be present for the install. We can sync this list to S3 and upload to download.delphix.com part of BOM. Other part of the review: http://reviews.delphix.com/r/79217/

### Testing
Check the above review.


