### PR TITLE
TOOL-13469 appliance-build changes to add telegraf support

### DIFF
--- a/live-build/config/archives/delphix-secondary-mirror.list.in
+++ b/live-build/config/archives/delphix-secondary-mirror.list.in
@@ -14,6 +14,6 @@
 # limitations under the License.
 #
 
-deb @@URL@@ focal main multiverse universe contrib
+deb @@URL@@ focal main multiverse universe contrib stable
 deb @@URL@@ focal-updates main multiverse universe
 deb @@URL@@ focal-pgdg main


### PR DESCRIPTION
This PR add the `stable` ppa so that we can add `telegraf` into the delphix image.