### PR TITLE
DLPX-80873 Upgrade verification gets stuck when upgrading from 6.0.13…

### DIFF
--- a/upgrade/upgrade-scripts/upgrade-container
+++ b/upgrade/upgrade-scripts/upgrade-container
@@ -831,12 +831,11 @@ function do_upgrade_container_not_in_place() {
 }
 
 function get_type() {
-	local root origin
+	local origin
 
-	root=$(zfs list -Hpo name /var/lib/machines/"${CONTAINER}")
-	[[ -n "${root}" ]] || die "Failed to obtain root filesystem for container '${CONTAINER}'"
-	origin=$(zfs get -Hpo value origin "${root}")
-	[[ -n "${origin}" ]] || die "Failed to origin of the root filesystem '${root}' for container '${CONTAINER}'"
+	origin=$(zfs get -Hpo value origin "rpool/ROOT/${CONTAINER}/root")
+	[[ -n "${origin}" ]] ||
+		die "failed to get origin for container '${CONTAINER}'"
 
 	case "${origin}" in
 	-)


### PR DESCRIPTION
….0 -> 6.0.13.1

George root-caused this to be a hang on an NFS mountpoint; "zfs list" being a victim of the hang. This change implements his workaround which he posted in the bug:

> One thing to note is that we can avoid the ZFS hang by not doing a list on the filesystem path but instead using the dataset name.