### PR TITLE
Add azure

### DIFF
--- a/live-build/misc/ansible-roles/appliance-build.minimal-common/tasks/main.yml
+++ b/live-build/misc/ansible-roles/appliance-build.minimal-common/tasks/main.yml
@@ -68,3 +68,8 @@
   delay: 30
   register: result
   until: result is succeeded
+
+- apt:
+    name:
+      - azure-cli
+    state: present


### PR DESCRIPTION
This PR adds the Azure CLI to our VMs. Thankfully, Ubuntu ships an azure-cli package that Azure doesn't list in their official installation instructions; this reduced the difficulty of adding the utilities to the image. They are added to the minimal common step unlike the awscli package because they are not needed for the bootstrap process, but we still want them on all systems.

http://selfservice.jenkins.delphix.com/job/appliance-build-orchestrator-pre-push/2004/console (upgrade failure appears to be an existing issue, I get it across a number of runs of different changes)