### PR TITLE
QA-35550 Add nmap to qa-internal appliance builds

### DIFF
--- a/live-build/misc/ansible-roles/appliance-build.qa-internal/tasks/main.yml
+++ b/live-build/misc/ansible-roles/appliance-build.qa-internal/tasks/main.yml
@@ -1,5 +1,5 @@
 #
-# Copyright 2018, 2021 Delphix
+# Copyright 2018, 2022 Delphix
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -23,6 +23,7 @@
       - nftables
       - snmptrapd
       - ufw
+      - nmap
     state: present
   register: result
   until: result is not failed


### PR DESCRIPTION
<!--
# Context:
A clear description of the high level effort that this pull request is
a part of. Anyone in the organization can see this change and may not
have the same context as you.
-->
# Problem:
iSCSI Initiator QA tests need `nmap`.
<!--
A clear description of the problem. The problem statement should be
written in terms of a specific symptom that affects users or the
business. The problem statement should not be written in terms of the
solution.
-->
# Solution:
Add `nmap` to the list of packages in the qa-internal Ansible rules.
<!--
A clear description of the high-level solution you have chosen. If
there were other possible solutions that you considered and rejected,
please mention those as well. Please do not describe implementation
details when writing about the solution, those should go into the
implementation section.
-->
# Testing
```
$ git ab-pre-push
Your build is at: http://selfservice.jenkins.delphix.com/job/appliance-build-orchestrator-pre-push/2113/
```
Build passed with 100% success.

Then, I did a quick manual inspection of my built appliance:
```
$ which nmap
/usr/bin/nmap

$ dpkg-query --search /usr/bin/nmap
nmap: /usr/bin/nmap

$ dpkg-query --status nmap
Package: nmap
Status: install ok installed
...
```
Changes look good.
<!--
Describe explicitly how this change was tested. Were we able to
recreate the issue? Were we able to write a test case that failed
before that passes now?
-->
<!--
# Implementation:
The implementation details of the solution.
-->
<!--
# Notes To Reviewers:
Any extra information a reviewer may need to know before reviewing
your change. For example here you might want to describe which files
should be looked at first or which files are auto-generated.
-->
<!--
# Deployment Plan:
Some changes get more complicated and may need changes in multiple
repositories or may require infrastructure changes. Describe how these
changes will be smoothly deployed.
-->
<!--
# Future work:
A description of what follow up work is explicitly not being done in
this change.
-->
<!--
# Bonus:
A description of extra problems you've solved in this change. Did you
reformat an unrelated docstring? Point it out here
-->
