### PR TITLE
CP-8404 disable default telegraf service

### DIFF
--- a/live-build/misc/ansible-roles/appliance-build.virtualization-common/tasks/main.yml
+++ b/live-build/misc/ansible-roles/appliance-build.virtualization-common/tasks/main.yml
@@ -82,6 +82,7 @@
     - nginx.service
     - postgresql.service
     - td-agent.service
+    - telegraf.service
 
 #
 # The services in this section should be disabled & masked initially, but


### PR DESCRIPTION
As part of the integration of telegraf metrics into our product, we want to disable the default systemd service that is enabled by default.