### PR TITLE
GHM-743 transition more platform repository to pre-gitflow branching model

### DIFF
--- a/live-build/misc/ansible-roles/appliance-build.dcenter/tasks/main.yml
+++ b/live-build/misc/ansible-roles/appliance-build.dcenter/tasks/main.yml
@@ -70,7 +70,7 @@
     - { regexp: '^RPCNFSDCOUNT=', line: 'RPCNFSDCOUNT=64' }
     - { regexp: '^RPCMOUNTDOPTS=', line: 'RPCMOUNTDOPTS="--num-threads=5 --manage-gids"' }
 
-- command: systemctl disable bind9.service isc-dhcp-server.service isc-dhcp-server6.service
+- command: systemctl mask named.service isc-dhcp-server.service isc-dhcp-server6.service
 
 #
 # delphix-platform installs ntp in a disabled state by default.


### PR DESCRIPTION
This is a `git merge` of `master` into `6.0/stage`; this is in preparation for development to be done directly on `6.0/stage` instead of `master`.

Here's the only difference that exists between `6.0/stage` and `master` after this change:
```
± git diff HEAD..origin/master
diff --git a/branch.config b/branch.config
index 9e572e6..cedb298 100644
--- a/branch.config
+++ b/branch.config
@@ -10,4 +10,4 @@
 # UPSTREAM_BRANCH parameter should be updated by the release lead on branching
 #
 
-UPSTREAM_BRANCH="6.0/stage"
+UPSTREAM_BRANCH="master"

```

Additionally, here are the git conflicts that arose during the merge, and how they were addressed:
```
± git show
commit f7ab804d752e05d5ef157ada08a0ca318c1a1583 (HEAD -> 6.0/stage, ps/6.0/stage)
Author: Prakash Surya <prakash.surya@delphix.com>
Date:   Tue Jul 19 09:56:52 2022 -0700

    fixup: fix git conflicts

diff --git a/branch.config b/branch.config
index 0825011..9e572e6 100644
--- a/branch.config
+++ b/branch.config
@@ -1,4 +1,3 @@
-<<<<<<< HEAD
 #
 # Copyright (c) 2019 by Delphix. All rights reserved.
 #
@@ -12,19 +11,3 @@
 #
 
 UPSTREAM_BRANCH="6.0/stage"
-||||||| 13a71be
-=======
-#
-# Copyright (c) 2019 by Delphix. All rights reserved.
-#
-
-#
-# The "BRANCH" parameter tracks the upstream branch of appliance-build. It is
-# used to determine which branch of the linux package mirror will be used for
-# the build if UPSTREAM_PRODUCT_BRANCH is not set. UPSTREAM_PRODUCT_BRANCH is
-# set when appliance build is built by the appliance-build Jenkins job. The
-# UPSTREAM_BRANCH parameter should be updated by the release lead on branching
-#
-
-UPSTREAM_BRANCH="master"
->>>>>>> origin/master
diff --git a/live-build/misc/ansible-roles/appliance-build.dcenter/tasks/main.yml b/live-build/misc/ansible-roles/appliance-build.dcenter/tasks/main.yml
index 1d6ffe6..edf426a 100644
--- a/live-build/misc/ansible-roles/appliance-build.dcenter/tasks/main.yml
+++ b/live-build/misc/ansible-roles/appliance-build.dcenter/tasks/main.yml
@@ -63,20 +63,6 @@
 # we use on the delphix engine.
 #
 - lineinfile:
-<<<<<<< HEAD
-    path: /etc/default/nfs-kernel-server
-    regexp: "{{ item.regexp }}"
-    line: "{{ item.line }}"
-  with_items:
-    - { regexp: '^RPCNFSDCOUNT=', line: 'RPCNFSDCOUNT=64' }
-    - { regexp: '^RPCMOUNTDOPTS=', line: 'RPCMOUNTDOPTS="--num-threads=5 --manage-gids"' }
-
-- command: systemctl disable bind9.service isc-dhcp-server.service isc-dhcp-server6.service
-||||||| 13a71be
-    path: /etc/cloud/cloud.cfg
-    regexp: '^preserve_hostname: false'
-    line: 'preserve_hostname: true'
-=======
     path: /etc/default/nfs-kernel-server
     regexp: "{{ item.regexp }}"
     line: "{{ item.line }}"
@@ -85,7 +71,6 @@
     - { regexp: '^RPCMOUNTDOPTS=', line: 'RPCMOUNTDOPTS="--num-threads=5 --manage-gids"' }
 
 - command: systemctl mask named.service isc-dhcp-server.service isc-dhcp-server6.service
->>>>>>> origin/master
 
 #
 # delphix-platform installs ntp in a disabled state by default.
```