### PR TITLE
TOOL-15951 hotfixes without changes fail to build sparse hotfix image

### DIFF
--- a/scripts/aptly-repo-from-image-diff.sh
+++ b/scripts/aptly-repo-from-image-diff.sh
@@ -131,7 +131,7 @@ aptly repo search image-b |
 	xargs aptly repo remove upgrade-repository ||
 	die "failed to remove packages from repository: 'upgrade-repository'"
 
-aptly publish repo -skip-contents -skip-signing upgrade-repository ||
+aptly publish repo -skip-contents -skip-signing -architectures=amd64 upgrade-repository ||
 	die "failed to publish repository: 'upgrade-repository'"
 
 [[ -d ~/.aptly/public ]] || die "failed to generate aptly repository"


### PR DESCRIPTION
This is needed to fix the errors seen when building HF-1197. This has been verified when building HF-1197.

The issue is, when building the sparse image, if the hotfix doesn't contain any changes w.r.t. the release it's building on, the sparse hotfix APT repository will not have any packages in it.. thus, when we attempt to publish that repository, the publish will fail since Aptly will not be able to determine the architecture for the repository.. i.e. since the repository doesn't have any packages, it can't determine the architecture from the packages contained in the repository, resulting in the failure.

The fix it to be explicit, and specify "amd64", which is the only architecture we currently support.

See also: http://reviews.delphix.com/r/85033/