### PR TITLE
SCAL-738 Setup creation fails trying to install filebeat agent on dlpx-qa images as gnupg installation fails

### DIFF
--- a/live-build/misc/ansible-roles/appliance-build.qa-internal/tasks/main.yml
+++ b/live-build/misc/ansible-roles/appliance-build.qa-internal/tasks/main.yml
@@ -24,6 +24,7 @@
       - snmptrapd
       - ufw
       - nmap
+      - gnupg
     state: present
   register: result
   until: result is not failed


### PR DESCRIPTION
### Problem
Scale setup creation fails trying to install the `filebeat` agent with the below error as it tries to install the `gnupg` package first as its dependency (the installation of `filebeat` agent needs to add GPG keys which is done by `sudo apt-key add` command which in turn requires `gnupg` package installation).
```
11:51:08  Package gnupg is not available, but is referred to by another package.
11:51:08  This may mean that the package is missing, has been obsoleted, or
11:51:08  is only available from another source
11:51:08  
11:51:08  E: Package 'gnupg' has no installation candidate
```
### Solution
Adding `gnupg` as QA image requirements as filebeat agent is extensively used in the Scalability testing for automated monitoring of the engine's logs.
### Testing Done
Able to add GPG keys after manually installing the `gnupg` package on a QA image `dlpx-qa-6.0/stage`.
```
delphix@dlpx60qastage-srusia:/etc/apt/sources.list.d$ wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | sudo apt-key add -
OK
```