### PR TITLE
DLPX-83408 Post-upgrade cleanup fails with internal error due to already deleted dataset

### DIFF
--- a/upgrade/upgrade-scripts/common.sh
+++ b/upgrade/upgrade-scripts/common.sh
@@ -169,7 +169,13 @@ function get_dataset_rollback_snapshot_name() {
 }
 
 function get_snapshot_clones() {
-	zfs get clones -Hpo value "$1"
+	local CLONES
+
+	CLONES="$(zfs get clones -Hpo value "$1")"
+
+	if [[ "$CLONES" != "-" ]]; then
+		echo "$CLONES"
+	fi
 }
 
 function get_version_property() {

--- a/upgrade/upgrade-scripts/rootfs-container
+++ b/upgrade/upgrade-scripts/rootfs-container
@@ -23,8 +23,10 @@ function delete() {
 	zfs list "rpool/ROOT/$CONTAINER/root" &>/dev/null ||
 		die "rootfs container '$CONTAINER' does not exist"
 
+	MOUNTPOINT=$(zfs get mountpoint -Hpo value "rpool/ROOT/$CONTAINER/root")
 	MOUNTED=$(zfs get mounted -Hpo value "rpool/ROOT/$CONTAINER/root")
-	[[ "$MOUNTED" == "no" ]] ||
+
+	[[ "$MOUNTPOINT" == "/" ]] && [[ "$MOUNTED" == "yes" ]] &&
 		die "cannot delete mounted rootfs container: '$CONTAINER'"
 
 	local snapname


### PR DESCRIPTION
If a snapshot does not have any clones, `zfs get clones` will return `-`.. rather than return this to the caller, we want to return an empty list.

We've had this happen on a customer system, resulting in a failed post-upgrade cleanup job; e.g.
```
Oct 12 11:09:14 localhost upgrade-scripts:rootfs-container[1794622]: //var/dlpx-update/6.0.16.0/common.sh:get_snapshot_clones:172 zfs get clones -Hpo value rpool/ROOT/delphix.kToQFki/root@execute-upgrade.YYUo6NC
Oct 12 11:09:14 localhost upgrade-scripts:rootfs-container[1794622]: /var/dlpx-update/6.0.16.0/rootfs-container:delete:45 for clone in $(get_snapshot_clones "$snap")
Oct 12 11:09:14 localhost upgrade-scripts:rootfs-container[1794622]: /var/dlpx-update/6.0.16.0/rootfs-container:delete:46 zfs promote -
Oct 12 11:09:14 localhost upgrade-scripts:rootfs-container[1794622]: /var/dlpx-update/6.0.16.0/rootfs-container:delete:47 die ''\''zfs promote -'\'' failed'
```

Here we can see we called `get_snapshot_clones`, and then subsequently called `zfs promote -`.. the issue being, `get_snapshot_clones` returned `-`, rather than an empty list.. here's a snippet of how the return value is used:
```
 45                 for clone in $(get_snapshot_clones "$snap"); do                 
 46                         zfs promote "$clone" ||                                 
 47                                 die "'zfs promote $clone' failed"               
 48                                                                                 
 49                         snapname="$(echo "$snap" | cut -d @ -f 2-)"             
 50                         clonesnaps+=("$clone@$snapname")                        
 51                 done   
 ```
 
 This change modifies the `get_snaphost_clones` function, such that it won't emit anything to stdout when no clones are found, such that this loop will not call `zfs promote` in that case.