### PR TITLE
TOOL-16451 Add new "buildserver" variant

### DIFF
--- a/live-build/misc/ansible-roles/appliance-build.buildserver-internal/tasks/main.yml
+++ b/live-build/misc/ansible-roles/appliance-build.buildserver-internal/tasks/main.yml
@@ -1,0 +1,24 @@
+#
+# Copyright 2022 Delphix
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+---
+- apt:
+    name:
+      - adoptopenjdk-java8-jdk
+      - curl
+      - git
+      - gnupg
+    state: present

--- a/live-build/variants/internal-buildserver/ansible/playbook.yml
+++ b/live-build/variants/internal-buildserver/ansible/playbook.yml
@@ -1,0 +1,26 @@
+#
+# Copyright 2022 Delphix
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+---
+- hosts: all
+  gather_facts: no
+  vars:
+    ansible_python_interpreter: /usr/bin/python3
+  roles:
+    - appliance-build.minimal-common
+    - appliance-build.minimal-internal
+    - appliance-build.minimal-development
+    - appliance-build.buildserver-internal

--- a/live-build/variants/internal-buildserver/ansible/roles
+++ b/live-build/variants/internal-buildserver/ansible/roles
@@ -1,0 +1,1 @@
+../../../misc/ansible-roles


### PR DESCRIPTION
This change adds a new "buildserver" variant, where the intention is to use this variant for building our software (packages, appliance, etc), rather than our current buildserver image which is based on Ubuntu.