### PR TITLE
TOOL-16510 Add more rpool space for buildserver variant

### DIFF
--- a/live-build/config/hooks/vm-artifacts/90-raw-disk-image.binary
+++ b/live-build/config/hooks/vm-artifacts/90-raw-disk-image.binary
@@ -60,14 +60,21 @@ retry() {
 # We want to use different sized rpool depending on if we're building a
 # disk image meant for internal use, or external (i.e. customer) use.
 #
-# The only exception to this is our "dcenter" variant. While that
-# variant is only used internally, we use it in a way that more
-# resembles our external variants, so we want the rpool size for
-# the dcenter images to match our external images.
+# One exception to this is our "dcenter" variant. While that variant is
+# only used internally, we use it in a way that more resembles our
+# external variants, so we want the rpool size for the dcenter images to
+# match our external images.
+#
+# Another exception is our "buildserver" variant. We use those images to
+# generate our appliance images, and upgrade images, which consume a lot
+# of space during the build process; thus, we need a larger rpool.
 #
 case "$APPLIANCE_VARIANT" in
 external-* | internal-dcenter)
 	RAW_DISK_SIZE_GB=127
+	;;
+internal-buildserver)
+	RAW_DISK_SIZE_GB=256
 	;;
 internal-*)
 	RAW_DISK_SIZE_GB=70


### PR DESCRIPTION
Our current Ubuntu buildservers have 256G of root disk space, so I'm changing the delphix buildserver to match. Otherwise, we hit ENOSPC issues when running appliance-build, (I think) due to the size of the VM and upgrade artifacts.