### PR TITLE
DLPX-68852 systemd-run hung after running "execute" script during upgrade

### DIFF
--- a/upgrade/upgrade-scripts/upgrade-container
+++ b/upgrade/upgrade-scripts/upgrade-container
@@ -593,7 +593,10 @@ function run() {
 	# the upgrade. Thus, to try and avoid the failure to begin with,
 	# we restart this service, which serves to run "daemon-reexec".
 	#
-	systemctl restart systemd-reexec.service
+	# This will fail on versions of Delphix that don't yet have
+	# this service, so we hide any failure to account for that.
+	#
+	systemctl restart systemd-reexec.service 2>/dev/null
 
 	systemd-run \
 		--machine="$CONTAINER" \


### PR DESCRIPTION
This has no impact to the product, just silences some lines emitted to stderr when upgrading from a version that does not have the systemd-reexec service.