### PR TITLE
Add delphix-go to appliance-build

### DIFF
--- a/live-build/misc/ansible-roles/appliance-build.zfsonlinux-development/tasks/main.yml
+++ b/live-build/misc/ansible-roles/appliance-build.zfsonlinux-development/tasks/main.yml
@@ -25,6 +25,7 @@
       - build-essential
       - cppcheck
       - curl
+      - delphix-go
       - delphix-rust
       - dwarves
       - emacs-nox


### PR DESCRIPTION
This change includes the new delphix-go package into the list of packages required for zfs development so that the go compiler will be installed on dev VMs. It was tested in conjunction with corresponding changes to [linux-pkg](https://github.com/delphix/linux-pkg/pull/287) and [devops-gate](https://github.com/delphix/devops-gate/pull/1124). ab-pre-push was run [here](http://selfservice.pd-jenkins.dcol2.delphix.com/job/appliance-build-orchestrator-pre-push/23/console) and the resulting VM had the GO sdk installed correctly and could be used for zfs builds.