### PR TITLE
DLPX-85893 run upgrade "execute" script from separate service

### DIFF
--- a/upgrade/upgrade-scripts/execute
+++ b/upgrade/upgrade-scripts/execute
@@ -28,6 +28,37 @@ function usage() {
 	exit 2
 }
 
+function post_alert() {
+	local jmxtool="/opt/delphix/server/bin/jmxtool"
+
+	#
+	# Alerts are a virtualization service concept. Thus, if we're
+	# running on a variant that doesn't have the virtualization
+	# package installed, skip the alert.
+	#
+	[[ ! -x "$jmxtool" ]] && return
+
+	#
+	# Skip the alert when running in an upgrade container, as the
+	# alert is only meant to notify the user about the host.
+	#
+	systemd-detect-virt -qc && return
+
+	#
+	# The alert isn't critical, so if it fails to post, that's
+	# acceptiable. Further, it's possible to execute this script
+	# without the virtualization service running. As a result, we
+	# use "-w" and don't worry if it returns an error code.
+	#
+	if [[ "$1" == "reboot" ]]; then
+		$jmxtool -w boot upgrade server &>/dev/null
+	elif [[ "$1" == "restart" ]]; then
+		$jmxtool -w boot upgrade management &>/dev/null
+	else
+		die "invalid alert specified: '$1'"
+	fi
+}
+
 function generate_interface_to_mac_address_map() {
 	INTERFACE_TO_MACADRESS_MAP_FILE_PATH="/etc/interface_to_macaddress_map.out"
 
@@ -563,8 +594,10 @@ if [[ -f "$UPDATE_DIR/upgrade.properties" ]]; then
 fi
 
 if [[ -n "$opt_f" ]] || [[ "$UPGRADE_TYPE" == "FULL" ]]; then
+	post_alert "reboot"
 	exec systemctl reboot || die "failed to reboot"
 else
+	post_alert "restart"
 	exec systemctl restart delphix.target ||
 		die "failed to restart delphix.target"
 fi

--- a/upgrade/upgrade-scripts/execute
+++ b/upgrade/upgrade-scripts/execute
@@ -24,7 +24,7 @@ set -o pipefail
 
 function usage() {
 	echo "$(basename "$0"): $*" >&2
-	echo "Usage: $(basename "$0") -p <platform>"
+	echo "Usage: $(basename "$0") [-f] [-p <platform>]"
 	exit 2
 }
 
@@ -47,17 +47,40 @@ function generate_interface_to_mac_address_map() {
 		die "Failed to generate map from interface names to mac addresses"
 }
 
-while getopts ':rlBfsp:' c; do
+#
+# Specifies the platform to upgrade to; by default choose the same
+# platform the script is running on.
+#
+# For not-in-place upgrades, we cannot use the get-appliance-platform
+# script to determine the platform, hence why this option exists.
+#
+# This option should not be used to change platforms via an upgrade.
+#
+opt_p=""
+
+#
+# Perform a "full" upgrade, which does a system reboot. By default, we
+# perform a "deferred" upgrade, which resetarts services, but does not
+# reboot the system.
+#
+opt_f=""
+
+while getopts ':fp:' c; do
 	case $c in
-	r | l | B | f | s) ;; # LX-72: For now, silently ignore these.
-	p)
-		platform=$OPTARG
-		;;
+	f) eval "opt_$c=true" ;;
+	p) eval "opt_$c='$OPTARG'" ;;
 	*) usage "illegal options -- $OPTARG" ;;
 	esac
 done
+shift $((OPTIND - 1))
 
-[[ -z "$platform" ]] && usage "platform must be specified"
+[[ $# -ne 0 ]] && usage "too many arguments specified"
+[[ "$EUID" -ne 0 ]] && die "must be run as root"
+
+if [[ -z "$opt_p" ]]; then
+	opt_p="$(get-appliance-platform)" ||
+		usage "platform must be specified"
+fi
 
 #
 # When upgrading the packages on with this script, we want to ensure
@@ -205,8 +228,8 @@ apt_get update || die "failed to update apt sources"
 # by installing delphix-virtualization at a later stage of the build via
 # ansible hooks, when the delphix-platform package has already been installed.
 #
-if ! dpkg-query -l "delphix-platform-$platform" &>/dev/null; then
-	apt_get install -y "delphix-platform-$platform" ||
+if ! dpkg-query -l "delphix-platform-$opt_p" &>/dev/null; then
+	apt_get install -y "delphix-platform-$opt_p" ||
 		die "failed to install delphix-platform"
 fi
 
@@ -270,7 +293,7 @@ dpkg-query -Wf '${Package}\n' | xargs apt-mark auto ||
 # shellcheck disable=SC2153
 apt_get install \
 	-y --allow-downgrades --reinstall \
-	"delphix-entire-$platform=$VERSION" ||
+	"delphix-entire-$opt_p=$VERSION" ||
 	die "upgrade failed; from '$CURRENT_VERSION' to '$VERSION'"
 
 #
@@ -282,17 +305,17 @@ apt_get install \
 # particularly in the case of "--reinstall", which replaces the current
 # package with a new package of the same version (i.e. for hotfixes).
 #
-apt-mark manual "delphix-entire-$platform" ||
+apt-mark manual "delphix-entire-$opt_p" ||
 	die "failed to mark 'delphix-entire' package as 'manual' installed"
 
-[[ -f "/usr/share/doc/delphix-entire-$platform/packages.list.gz" ]] ||
+[[ -f "/usr/share/doc/delphix-entire-$opt_p/packages.list.gz" ]] ||
 	die "delphix-entire's packages.list.gz file is missing"
 
-zcat "/usr/share/doc/delphix-entire-$platform/packages.list.gz" |
+zcat "/usr/share/doc/delphix-entire-$opt_p/packages.list.gz" |
 	xargs_apt_get install -y --allow-downgrades ||
 	die "failed to install packages listed in packages.list.gz file"
 
-zcat "/usr/share/doc/delphix-entire-$platform/packages.list.gz" |
+zcat "/usr/share/doc/delphix-entire-$opt_p/packages.list.gz" |
 	cut -d= -f1 | xargs apt-mark manual ||
 	die "failed to mark as manual packages listed in packages.list.gz file"
 
@@ -394,7 +417,7 @@ stop_stderr_redirect_to_system_log
 # we verify the package is installed and its version is correct; this
 # is simply to help us be confident that upgrade behaves as we expect.
 #
-zcat "/usr/share/doc/delphix-entire-$platform/packages.list.gz" | sed 's/=/ /' |
+zcat "/usr/share/doc/delphix-entire-$opt_p/packages.list.gz" | sed 's/=/ /' |
 	while read -r name version; do
 		installed=$(dpkg-query -Wf '${Version}' "$name")
 		compare_versions "$installed" "=" "$version" ||
@@ -497,9 +520,37 @@ fi
 # The container does not have visibility into the complete network namespace of the
 # engine. Hence we need to create the map outside the container to ensure the presense
 # of all the interfaces in the map
-if ! systemd-detect-virt --container --quiet && [[ $(get-appliance-platform) == "aws" ]]; then
+if ! systemd-detect-virt -qc && [[ "$opt_p" == "aws" ]]; then
 	generate_interface_to_mac_address_map
 fi
+
+#
+# We use a seperate ZFS dataset for GRUB, and this dataset is generally
+# not mounted when we update pacakges on the system.  Thus, when a new
+# kernel package is installed, via the call to "execute" above, the GRUB
+# configuration will not be modified to use that new kernel.
+#
+# In order for the system to use the new kernel after a reboot, we must
+# regenerate the GRUB configuration after the new kernel has been
+# installed. The "rootfs-container set-bootfs" command will do just
+# that; it knows how to mount our GRUB specific dataset, and how
+# properly update the GRUB configuration.
+#
+# Note, we only want to update GRUB when running outside of an upgrade
+# container; since executing an upgrade within an upgrade container
+# should not affect the host system.
+#
+if ! systemd-detect-virt -qc; then
+	ROOTFS_CONTAINER="$(get_mounted_rootfs_container_name)"
+	[[ -n "$ROOTFS_CONTAINER" ]] ||
+		die "unable to determine currently mounted rootfs container"
+
+	"$IMAGE_PATH/rootfs-container" set-bootfs "$ROOTFS_CONTAINER" ||
+		die "failed to set-bootfs '$ROOTFS_CONTAINER'"
+fi
+
+systemctl reload delphix-platform.service ||
+	die "failed to reload delphix-platform.service"
 
 #
 # Before we exit, we want to ensure all of the changes made to the root
@@ -507,4 +558,16 @@ fi
 #
 zpool sync rpool || die "'zpool sync rpool' failed"
 
-exit 0
+if [[ -f "$UPDATE_DIR/upgrade.properties" ]]; then
+	source_upgrade_properties
+fi
+
+if [[ -n "$opt_f" ]] || [[ "$UPGRADE_TYPE" == "FULL" ]]; then
+	exec systemctl reboot || die "failed to reboot"
+else
+	exec systemctl restart delphix.target ||
+		die "failed to restart delphix.target"
+fi
+
+# We shouldn't reach this statement; error if we do.
+exit 1

--- a/upgrade/upgrade-scripts/upgrade
+++ b/upgrade/upgrade-scripts/upgrade
@@ -128,14 +128,26 @@ function upgrade_in_place() {
 	#
 	[[ "$DLPX_UPGRADE_DRY_RUN" == "true" ]] && return
 
+	CURRENT_VERSION=$(get_current_version) || die "failed to get version"
+
+	source_version_information
+
 	set_upgrade_property "UPGRADE_TYPE" "$UPGRADE_TYPE" ||
 		die "failed to set upgrade property 'UPGRADE_TYPE' to '$UPGRADE_TYPE'"
+
+	set_upgrade_property "UPGRADE_VERSION" "$VERSION" ||
+		die "failed to set upgrade property 'UPGRADE_VERSION' to '$VERSION'"
+
+	if [[ -n "$HOTFIX" ]]; then
+		set_upgrade_property "UPGRADE_HOTFIX" "$HOTFIX" ||
+			die "failed to set upgrade property 'UPGRADE_HOTFIX' to '$HOTFIX'"
+	fi
 
 	set_upgrade_property "UPGRADE_BASE_CONTAINER" \
 		"$(get_mounted_rootfs_container_name)" ||
 		die "failed to set upgrade property 'UPGRADE_BASE_CONTAINER'"
 
-	set_upgrade_property "UPGRADE_BASE_VERSION" "$(get_current_version)" ||
+	set_upgrade_property "UPGRADE_BASE_VERSION" "$CURRENT_VERSION" ||
 		die "failed to set upgrade property 'UPGRADE_BASE_VERSION'"
 
 	#
@@ -147,41 +159,45 @@ function upgrade_in_place() {
 	cleanup_in_place_upgrade
 	trap - EXIT
 
-	ROOTFS_CONTAINER="$(get_mounted_rootfs_container_name)"
-	[[ -n "$ROOTFS_CONTAINER" ]] ||
-		die "unable to determine currently mounted rootfs container"
-
-	[[ -f "/var/lib/delphix-appliance/platform" ]] ||
-		die "could not determine platform; file does not exist"
-
-	"$IMAGE_PATH/execute" \
-		-p "$(cat /var/lib/delphix-appliance/platform)" ||
-		die "'$IMAGE_PATH/execute' failed in running appliance."
-
-	#
-	# We use a seperate ZFS dataset for GRUB, and this dataset is
-	# generally not mounted when we update pacakges on the system.
-	# Thus, when a new kernel package is installed, via the call to
-	# "execute" above, the GRUB configuration will not be modified
-	# to use that new kernel.
-	#
-	# In order for the system to use the new kernel after a reboot,
-	# we must regenerate the GRUB configuration after the new kernel
-	# has been installed. The "rootfs-container set-bootfs" command
-	# will do just that; it knows how to mount our GRUB specific
-	# dataset, and how properly update the GRUB configuration.
-	#
-	"$IMAGE_PATH/rootfs-container" set-bootfs "$ROOTFS_CONTAINER" ||
-		die "failed to set-bootfs '$ROOTFS_CONTAINER'"
-
-	if [[ "$UPGRADE_TYPE" == "FULL" ]]; then
-		systemctl reboot || die "'systemctl reboot' failed"
+	if compare_versions "$CURRENT_VERSION" "ge" "12.0.0.0-0"; then
+		execute-in-place-upgrade -p
 	else
-		systemctl reload delphix-platform ||
-			die "'systemctl reload delphix-platform' failed"
+		ROOTFS_CONTAINER="$(get_mounted_rootfs_container_name)"
+		[[ -n "$ROOTFS_CONTAINER" ]] ||
+			die "unable to determine mounted rootfs container"
 
-		systemctl restart delphix-platform ||
-			die "'systemctl restart delphix-platform' failed"
+		[[ -f "/var/lib/delphix-appliance/platform" ]] ||
+			die "could not determine platform; file does not exist"
+
+		"$IMAGE_PATH/execute" \
+			-p "$(cat /var/lib/delphix-appliance/platform)" ||
+			die "'$IMAGE_PATH/execute' failed in running appliance."
+
+		#
+		# We use a seperate ZFS dataset for GRUB, and this dataset is
+		# generally not mounted when we update pacakges on the system.
+		# Thus, when a new kernel package is installed, via the call to
+		# "execute" above, the GRUB configuration will not be modified
+		# to use that new kernel.
+		#
+		# In order for the system to use the new kernel after a reboot,
+		# we must regenerate the GRUB configuration after the new kernel
+		# has been installed. The "rootfs-container set-bootfs" command
+		# will do just that; it knows how to mount our GRUB specific
+		# dataset, and how properly update the GRUB configuration.
+		#
+		"$IMAGE_PATH/rootfs-container" set-bootfs "$ROOTFS_CONTAINER" ||
+			die "failed to set-bootfs '$ROOTFS_CONTAINER'"
+
+		if [[ "$UPGRADE_TYPE" == "FULL" ]]; then
+			systemctl reboot || die "'systemctl reboot' failed"
+		else
+			systemctl reload delphix-platform ||
+				die "reload of delphix-platform failed"
+
+			systemctl restart delphix-platform ||
+				die "restart of delphix-platform failed"
+		fi
 	fi
 }
 
@@ -269,8 +285,18 @@ function upgrade_not_in_place() {
 	#
 	trap - EXIT
 
-	set_upgrade_property "UPGRADE_TYPE" "FULL" ||
-		die "failed to set upgrade property 'UPGRADE_TYPE'"
+	source_version_information
+
+	set_upgrade_property "UPGRADE_TYPE" "$UPGRADE_TYPE" ||
+		die "failed to set upgrade property 'UPGRADE_TYPE' to '$UPGRADE_TYPE'"
+
+	set_upgrade_property "UPGRADE_VERSION" "$VERSION" ||
+		die "failed to set upgrade property 'UPGRADE_VERSION' to '$VERSION'"
+
+	if [[ -n "$HOTFIX" ]]; then
+		set_upgrade_property "UPGRADE_HOTFIX" "$HOTFIX" ||
+			die "failed to set upgrade property 'UPGRADE_HOTFIX' to '$HOTFIX'"
+	fi
 
 	set_upgrade_property "UPGRADE_BASE_CONTAINER" \
 		"$(get_mounted_rootfs_container_name)" ||

--- a/upgrade/upgrade-scripts/upgrade
+++ b/upgrade/upgrade-scripts/upgrade
@@ -159,46 +159,13 @@ function upgrade_in_place() {
 	cleanup_in_place_upgrade
 	trap - EXIT
 
-	if compare_versions "$CURRENT_VERSION" "ge" "12.0.0.0-0"; then
-		execute-in-place-upgrade -p
-	else
-		ROOTFS_CONTAINER="$(get_mounted_rootfs_container_name)"
-		[[ -n "$ROOTFS_CONTAINER" ]] ||
-			die "unable to determine mounted rootfs container"
-
-		[[ -f "/var/lib/delphix-appliance/platform" ]] ||
-			die "could not determine platform; file does not exist"
-
-		"$IMAGE_PATH/execute" \
-			-p "$(cat /var/lib/delphix-appliance/platform)" ||
-			die "'$IMAGE_PATH/execute' failed in running appliance."
-
-		#
-		# We use a seperate ZFS dataset for GRUB, and this dataset is
-		# generally not mounted when we update pacakges on the system.
-		# Thus, when a new kernel package is installed, via the call to
-		# "execute" above, the GRUB configuration will not be modified
-		# to use that new kernel.
-		#
-		# In order for the system to use the new kernel after a reboot,
-		# we must regenerate the GRUB configuration after the new kernel
-		# has been installed. The "rootfs-container set-bootfs" command
-		# will do just that; it knows how to mount our GRUB specific
-		# dataset, and how properly update the GRUB configuration.
-		#
-		"$IMAGE_PATH/rootfs-container" set-bootfs "$ROOTFS_CONTAINER" ||
-			die "failed to set-bootfs '$ROOTFS_CONTAINER'"
-
-		if [[ "$UPGRADE_TYPE" == "FULL" ]]; then
-			systemctl reboot || die "'systemctl reboot' failed"
-		else
-			systemctl reload delphix-platform ||
-				die "reload of delphix-platform failed"
-
-			systemctl restart delphix-platform ||
-				die "restart of delphix-platform failed"
-		fi
+	local opt_f=""
+	if [[ "$UPGRADE_TYPE" == "FULL" ]]; then
+		opt_f="-f"
 	fi
+
+	"$IMAGE_PATH/execute" "$opt_f" ||
+		die "'$IMAGE_PATH/execute' failed in running appliance."
 }
 
 function cleanup_not_in_place_upgrade() {

--- a/upgrade/upgrade-scripts/upgrade-container
+++ b/upgrade/upgrade-scripts/upgrade-container
@@ -813,23 +813,8 @@ function migrate_configuration() {
 }
 
 function do_upgrade_container_in_place() {
-	CONTAINER_VERSION="$(run /usr/bin/get-appliance-version)"
-	if compare_versions "$CONTAINER_VERSION" "ge" "12.0.0.0-0"; then
-		run /usr/bin/execute-in-place-upgrade -i "$IMAGE_PATH"
-	else
-		[[ -f "/var/lib/delphix-appliance/platform" ]] ||
-			die "could not determine platform; file does not exist"
-
-		run "$IMAGE_PATH/execute" \
-			-p "$(cat /var/lib/delphix-appliance/platform)" ||
-			die "'$IMAGE_PATH/execute' failed in '$CONTAINER'"
-
-		run /bin/systemctl reload delphix-platform ||
-			die "reload of delphix-platform failed in '$CONTAINER'"
-
-		run /bin/systemctl restart delphix-platform ||
-			die "restart of delphix-platform failed in '$CONTAINER'"
-	fi
+	run "$IMAGE_PATH/execute" ||
+		die "'$IMAGE_PATH/execute' failed in '$CONTAINER'"
 }
 
 function do_upgrade_container_not_in_place() {
@@ -839,9 +824,6 @@ function do_upgrade_container_not_in_place() {
 	run "$IMAGE_PATH/execute" \
 		-p "$(cat /var/lib/delphix-appliance/platform)" ||
 		die "'$IMAGE_PATH/execute' failed in '$CONTAINER'"
-
-	run /bin/systemctl start delphix-platform ||
-		die "'systemctl start delphix-platform' failed in '$CONTAINER'"
 
 	migrate_configuration ||
 		die "failed to migrate configuration for '$CONTAINER'"

--- a/upgrade/upgrade-scripts/upgrade-container
+++ b/upgrade/upgrade-scripts/upgrade-container
@@ -813,18 +813,23 @@ function migrate_configuration() {
 }
 
 function do_upgrade_container_in_place() {
-	[[ -f "/var/lib/delphix-appliance/platform" ]] ||
-		die "could not determine platform; file does not exist"
+	CONTAINER_VERSION="$(run /usr/bin/get-appliance-version)"
+	if compare_versions "$CONTAINER_VERSION" "ge" "12.0.0.0-0"; then
+		run /usr/bin/execute-in-place-upgrade -i "$IMAGE_PATH"
+	else
+		[[ -f "/var/lib/delphix-appliance/platform" ]] ||
+			die "could not determine platform; file does not exist"
 
-	run "$IMAGE_PATH/execute" \
-		-p "$(cat /var/lib/delphix-appliance/platform)" ||
-		die "'$IMAGE_PATH/execute' failed in '$CONTAINER'"
+		run "$IMAGE_PATH/execute" \
+			-p "$(cat /var/lib/delphix-appliance/platform)" ||
+			die "'$IMAGE_PATH/execute' failed in '$CONTAINER'"
 
-	run /bin/systemctl reload delphix-platform ||
-		die "'systemctl reload delphix-platform' failed in '$CONTAINER'"
+		run /bin/systemctl reload delphix-platform ||
+			die "reload of delphix-platform failed in '$CONTAINER'"
 
-	run /bin/systemctl restart delphix-platform ||
-		die "'systemctl restart delphix-platform' failed in '$CONTAINER'"
+		run /bin/systemctl restart delphix-platform ||
+			die "restart of delphix-platform failed in '$CONTAINER'"
+	fi
 }
 
 function do_upgrade_container_not_in_place() {


### PR DESCRIPTION
### Problem

When an upgrade fails while running the `execute` script, we don't have
a mechanism for the product to automatically recover.

For example, we've had cases where the OOM killer will kick in, killing
the virtualization service while it's running the `execute` script,
causing the entire upgrade to fail and requiring support intervention on
the system to recover.

### Solution

The solution we've discussed is to run the `execute` portion of the
upgrade in a standalone service, such that it wouldn't be killed when
the OOM killer targets the virtualization service, and such that it
could be automatically restarted in the event that it dies for some
other reason (e.g. a kernel panic).

While this change doesn't provide the full solution, it's a step in that
direction. This change extends the `execute` script such that it performs
the additional steps that the `upgrade` script and/or the virtualization
service currently perform, after they run `execute`. This way, users
of this script now can run `execute` asynchronously, and be assured
everything needed to complete the upgrade will be performed.

The intention is for `execute` to be used by the virtualization service
as it is today, but eventually be called by a yet-to-be-created upgrade
service. Until the upgrade service is created, `execute` can be run via
`systemd-run`, such that it can be started by the virtualization service,
but decoupled from the virtualization service's cgroup limits (which will
help prevent OOMs).

### Why?

The `execute` script needed to be modified for a couple of reasons:

1. The current `execute` script doesn't handle things like updating the
   GRUB bootloader, nor does it handle restarting services. So, if we
   wanted to have a new service to "execute" the upgrade, the service
   would need to handle these additional steps. IMO, it makes sense to
   encapsulate all of these steps in `execute` like I've done here, so that
  when the new service is created, it can simply call this script.

2. Likewise, the virtualization service currently calls the `execute`
   script and needs to wait for it to complete, such that it can perform
   these additional tasks mentioned in the point above. By moving these
   additional tasks into this script, the virtualization service can now run
   the script asynchronously via `systemd-run` (since it no longer needs
   to wait for the script to complete); which allows us to solve the
   problem incrementally.

### Related Work

- https://github.com/delphix/dlpx-app-gate/pull/773

### Testing

- `ab-pre-push` is [here](http://selfservice.jenkins.delphix.com/job/github/job/delphix/job/appliance-build/job/appliance-build-orchestrator/job/pre-push/211/)
- upgrade v12 to v12 via `FULL` is [here](http://selfservice.jenkins.delphix.com/job/blackbox-chained/4905/)
- upgrade v11 to v12 via `FULL` is [here](http://selfservice.jenkins.delphix.com/job/blackbox-chained/4906/)
- upgrade v12 to v12 via `DEFERRED` is [here](http://selfservice.jenkins.delphix.com/job/blackbox-chained/4907/)
- upgrade v11 to v12 via `DEFERRED` is [here](http://selfservice.jenkins.delphix.com/job/blackbox-chained/4908/)