### PR TITLE
DLPX-86405 deferred upgrade via scripts fails

### DIFF
--- a/upgrade/upgrade-scripts/upgrade
+++ b/upgrade/upgrade-scripts/upgrade
@@ -164,7 +164,7 @@ function upgrade_in_place() {
 		opt_f="-f"
 	fi
 
-	"$IMAGE_PATH/execute" "$opt_f" ||
+	"$IMAGE_PATH/execute" $opt_f ||
 		die "'$IMAGE_PATH/execute' failed in running appliance."
 }
 


### PR DESCRIPTION
### Problem

When we run a deferred upgrade via the scripts, we're currently running `execute` with incorrect parameters.

### Solution

Fix the parameters passed in to `execute`.

### Related Work

This regression was introduced by:
- https://github.com/delphix/appliance-build/pull/725

### Testing

- Before:
```
$ sudo /var/dlpx-update/latest/upgrade deferred
execute: too many arguments specified
Usage: execute [-f] [-p <platform>]
upgrade: '/var/dlpx-update/12.0.0.0-snapshot.20230606130957767+jenkins-ops-appliance-build-develop-post-push-323/execute' failed in running appliance.
```

- After
```
$ sudo /var/dlpx-update/latest/upgrade deferred
Installing for i386-pc platform.
Installation finished. No error reported.
Sourcing file `/etc/default/grub'
Sourcing file `/etc/default/grub.d/init-select.cfg'
Sourcing file `/etc/default/grub.d/kdump-tools.cfg'
Sourcing file `/etc/default/grub.d/override.cfg'
Generating grub configuration file ...
Found linux image: /boot/vmlinuz-5.4.0-1103-dx2023060600-6dbd3ba07-aws
Found initrd image: /boot/initrd.img-5.4.0-1103-dx2023060600-6dbd3ba07-aws
done
```