### PR TITLE
DLPX-86854 Post-upgrade cleanup task fails with internal error, due to attempting to delete dataset which has already been deleted

### DIFF
--- a/upgrade/upgrade-scripts/rootfs-cleanup
+++ b/upgrade/upgrade-scripts/rootfs-cleanup
@@ -26,6 +26,10 @@ def version(rootfs: str) -> str:
         ]).decode("UTF-8").strip())
 
 
+def exists(rootfs: str) -> bool:
+    return not bool(subprocess.run(["zfs", "list", rootfs]).returncode)
+
+
 #
 # Helper class used when sorting rootfs filesystems and snapshots. This allows
 # us to use the "sorted" builtin, to build a list of all rootfs filesystems and
@@ -111,6 +115,13 @@ def main() -> None:
     # after an upgrade (i.e. we never upgrade to a lower version).
     #
     for rootfs in sorted(filesystems + snapshots, key=rootfscmp)[:-2]:
+        #
+        # Skip if the snapshot or filesystem was destroyed by a previous
+        # iteration.
+        #
+        if not exists(rootfs):
+            continue
+
         #
         # In the event of a rollback, we want to be careful to not
         # delete the currently running version, as well as any versions


### PR DESCRIPTION
<!--
<details open>
<summary><h2> Background </h2></summary>

Provide a clear description of the high-level effort with which this
pull request is associated. Recall that while anyone in the organization
can see this pull request, not everyone necessarily has the same context
as you. If applicable, link to design documents or high-level tracking
epics here.
</details>
-->

<details open>
<summary><h2> Problem </h2></summary>

See this Jira comment for RCA: https://delphix.atlassian.net/browse/DLPX-86854?focusedCommentId=702681.
Essentially, this code lists all snapshots and filesystems of the rpool/ROOT and then attempts to destroy them if they are from at least 2 versions before the current one. This code also iterates over these filesystems and snapshots in this order: 
```
    for rootfs in sorted(filesystems + snapshots, key=rootfscmp)[:-2]:
```
So the filesystem (along with all snapshots because of the use of the -r option) was destroyed before the snapshot causing this error.
</details>

<!--
<details>
<summary><h2> Evaluation </h2></summary>

If the cause of the problem is not obvious, provide a root-cause
analysis (RCA), ideally using the Five Whys iterative interrogative
technique or some other form of analytical reasoning.
</details>
-->

<details open>
<summary><h2> Solution </h2></summary>

Add a condition to check if a FS or snapshot exists before attempting to destroy.
</details>


<details open>
<summary><h2> Testing Done </h2></summary>

I tested this by manually running the script on an engine. To test this, I created a couple of filesystems and snapshots.
```
delphix@pg-DLPX-86854:~$ sudo zfs get -Hpo value com.delphix:current-version rpool/ROOT/delphix.x8ZpkSW
14.0.0.0-snapshot.20230716095228662+jenkins-ops-appliance-build-develop-post-push-501

// Clone a root FS container and it's root FS.
$ sudo zfs snapshot rpool/ROOT/delphix.x8ZpkSW@init-container-snap
$ sudo zfs snapshot rpool/ROOT/delphix.x8ZpkSW/root@init-root-fs-snap

// 13.0 FS and snapshot
$ sudo zfs clone rpool/ROOT/delphix.x8ZpkSW@init-container-snap rpool/ROOT/delphix.pgandhi
$ sudo zfs clone rpool/ROOT/delphix.x8ZpkSW/root@init-root-fs-snap rpool/ROOT/delphix.pgandhi/root
$ sudo zfs set com.delphix:current-version=13.0.0.0 rpool/ROOT/delphix.pgandhi
$ sudo zfs snapshot rpool/ROOT/delphix.pgandhi@execute-upgrade.pg130sn

// 12.0 FS and snapshot
$ sudo zfs clone rpool/ROOT/delphix.x8ZpkSW@init-container-snap rpool/ROOT/delphix.pgasd12
$ sudo zfs clone rpool/ROOT/delphix.x8ZpkSW/root@init-root-fs-snap rpool/ROOT/delphix.pgasd12/root
$ sudo zfs set com.delphix:current-version=12.0.0.0 rpool/ROOT/delphix.pgasd12
$ sudo zfs snapshot rpool/ROOT/delphix.pgasd12@execute-upgrade.pg120sn

// 11.0 FS and snapshot
$ sudo zfs clone rpool/ROOT/delphix.x8ZpkSW@init-container-snap rpool/ROOT/delphix.pgasd11
$ sudo zfs clone rpool/ROOT/delphix.x8ZpkSW/root@init-root-fs-snap rpool/ROOT/delphix.pgasd11/root
$ sudo zfs set com.delphix:current-version=11.0.0.0 rpool/ROOT/delphix.pgasd11
$ sudo zfs snapshot rpool/ROOT/delphix.pgasd11@execute-upgrade.pg110sn

$ zfs list
NAME                              USED  AVAIL  REFER  MOUNTPOINT
rpool                            10.7G  56.7G    64K  none
rpool/ROOT                       10.7G  56.7G    64K  none
rpool/ROOT/delphix.pgandhi          1K  56.7G    64K  none
rpool/ROOT/delphix.pgandhi/root     1K  56.7G  8.45G  none
rpool/ROOT/delphix.pgasd11          1K  56.7G    64K  none
rpool/ROOT/delphix.pgasd11/root     1K  56.7G  8.45G  none
rpool/ROOT/delphix.pgasd12          1K  56.7G    64K  none
rpool/ROOT/delphix.pgasd12/root     1K  56.7G  8.45G  none
rpool/ROOT/delphix.x8ZpkSW       10.7G  56.7G    64K  none
rpool/ROOT/delphix.x8ZpkSW/data   521M  56.7G   521M  legacy
rpool/ROOT/delphix.x8ZpkSW/home  1.69G  56.7G  1.69G  legacy
rpool/ROOT/delphix.x8ZpkSW/log   10.4M  56.7G  10.4M  legacy
rpool/ROOT/delphix.x8ZpkSW/root  8.45G  56.7G  8.45G  /

$ zfs list -t snapshot
NAME                                                 USED  AVAIL  REFER  MOUNTPOINT
rpool/ROOT/delphix.pgandhi@execute-upgrade.pg130sn     0B      -    64K  -
rpool/ROOT/delphix.pgasd11@execute-upgrade.pg110sn     0B      -    64K  -
rpool/ROOT/delphix.pgasd12@execute-upgrade.pg120sn     0B      -    64K  -
rpool/ROOT/delphix.x8ZpkSW@init-container-snap         0B      -    64K  -
rpool/ROOT/delphix.x8ZpkSW/root@init-root-fs-snap    210K      -  8.45G  -
```

(correction) - I tried running the script and realized that the script will fail because I have a snapshot not conforming with the script so I had to rename `init-container-snap`:
```
$ sudo zfs rename rpool/ROOT/delphix.x8ZpkSW@init-container-snap rpool/ROOT/delphix.x8ZpkSW@execute-upgrade.pg140sn
```

Next, I ran the `rootfs-cleanup`:
```
delphix@pg-DLPX-86854:~$ sudo ./rootfs-cleanup
NAME                         USED  AVAIL  REFER  MOUNTPOINT
rpool/ROOT/delphix.pgasd11     1K  56.7G    64K  none
cannot open 'rpool/ROOT/delphix.pgasd11/data': dataset does not exist
cannot open 'rpool/ROOT/delphix.pgasd11/home': dataset does not exist
cannot open 'rpool/ROOT/delphix.pgasd11/log': dataset does not exist
cannot open 'rpool/ROOT/delphix.pgasd11@execute-upgrade.pg110sn': dataset does not exist
NAME                         USED  AVAIL  REFER  MOUNTPOINT
rpool/ROOT/delphix.pgasd12     1K  56.7G    64K  none
cannot open 'rpool/ROOT/delphix.pgasd12/data': dataset does not exist
cannot open 'rpool/ROOT/delphix.pgasd12/home': dataset does not exist
cannot open 'rpool/ROOT/delphix.pgasd12/log': dataset does not exist
cannot open 'rpool/ROOT/delphix.pgasd12@execute-upgrade.pg120sn': dataset does not exist
NAME                         USED  AVAIL  REFER  MOUNTPOINT
rpool/ROOT/delphix.pgandhi     1K  56.7G    64K  none
cannot open 'rpool/ROOT/delphix.pgandhi/data': dataset does not exist
cannot open 'rpool/ROOT/delphix.pgandhi/home': dataset does not exist
cannot open 'rpool/ROOT/delphix.pgandhi/log': dataset does not exist
cannot open 'rpool/ROOT/delphix.pgandhi@execute-upgrade.pg130sn': dataset does not exist
delphix@pg-DLPX-86854:~$ echo $?
0
```

Result:
```
$ zfs list
NAME                              USED  AVAIL  REFER  MOUNTPOINT
rpool                            10.7G  56.7G    64K  none
rpool/ROOT                       10.7G  56.7G    64K  none
rpool/ROOT/delphix.x8ZpkSW       10.7G  56.7G    64K  none
rpool/ROOT/delphix.x8ZpkSW/data   521M  56.7G   521M  legacy
rpool/ROOT/delphix.x8ZpkSW/home  1.69G  56.7G  1.69G  legacy
rpool/ROOT/delphix.x8ZpkSW/log   11.2M  56.7G  11.2M  legacy
rpool/ROOT/delphix.x8ZpkSW/root  8.45G  56.7G  8.45G  /
rpool/crashdump                    29K  34.7G    29K  legacy
rpool/docker                      320K  56.7G   320K  -
rpool/grub                       3.08M  56.7G  3.08M  legacy
rpool/public                       29K  56.7G    29K  /public
rpool/update                       31K  30.0G    31K  /var/dlpx-update
rpool/upgrade-logs                 29K  56.7G    29K  /var/tmp/delphix-upgrade

$ zfs list -t snapshot
NAME                                                 USED  AVAIL  REFER  MOUNTPOINT
rpool/ROOT/delphix.x8ZpkSW@execute-upgrade.pg140sn     0B      -    64K  -
rpool/ROOT/delphix.x8ZpkSW/root@init-root-fs-snap    210K      -  8.45G  -
```

The 13.0 snapshot `execute-upgrade.pg130sn` was correctly destroyed because I had an extra snapshot of the current root container:
```
-> for rootfs in sorted(filesystems + snapshots, key=rootfscmp)[:-2]:
(Pdb) sorted(filesystems + snapshots, key=rootfscmp)
['rpool/ROOT/delphix.pgasd11', 'rpool/ROOT/delphix.pgasd11@execute-upgrade.pg110sn', 'rpool/ROOT/delphix.pgasd12', 'rpool/ROOT/delphix.pgasd12@execute-upgrade.pg120sn', 'rpool/ROOT/delphix.pgandhi', 'rpool/ROOT/delphix.pgandhi@execute-upgrade.pg130sn', 'rpool/ROOT/delphix.x8ZpkSW', 'rpool/ROOT/delphix.x8ZpkSW@execute-upgrade.pg140sn']
```

Without this fix:
```
delphix@pg-DLPX-86854:~$ sudo ./rootfs-cleanup
cannot open 'rpool/ROOT/delphix.pgasd11/data': dataset does not exist
cannot open 'rpool/ROOT/delphix.pgasd11/home': dataset does not exist
cannot open 'rpool/ROOT/delphix.pgasd11/log': dataset does not exist
cannot open 'rpool/ROOT/delphix.pgasd11@execute-upgrade.pg110sn': dataset does not exist
Traceback (most recent call last):
  File "./rootfs-cleanup", line 174, in <module>
    main()
  File "./rootfs-cleanup", line 134, in main
    if dpkgcmp(version(rootfs), "ge", current):
  File "./rootfs-cleanup", line 24, in version
    subprocess.check_output([
  File "/usr/lib/python3.8/subprocess.py", line 415, in check_output
    return run(*popenargs, stdout=PIPE, timeout=timeout, check=True,
  File "/usr/lib/python3.8/subprocess.py", line 516, in run
    raise CalledProcessError(retcode, process.args,
subprocess.CalledProcessError: Command '['zfs', 'get', '-Hpo', 'value', 'com.delphix:current-version', 'rpool/ROOT/delphix.pgasd11@execute-upgrade.pg110sn']' returned non-zero exit status 1.
```
(note that that line numbers in the stacktrace are a bit different from the stacktrace of the original bug because I simply removed the `if not exists(rootfs)` conditional block and let the function `exists()` remain in the script.
</details>

<!--
<details>
<summary><h2> Implementation </h2></summary>

Describe the implementation details of the solution. Generally the
reasoning behind any non-obvious code should be recorded in code
comments. However, code comments should always describe the current
state of the code; in contrast, this section may be useful to describe
the relationship between the original code and the code being proposed
in this pull request.
</details>
-->

<!--
<details>
<summary><h2> Notes to Reviewers </h2></summary>

Provide any extra information a reviewer may need to know before
evaluating your pull request. For example, you may wish to describe
which files should be reviewed first or which files are auto-generated.
If the review tool cannot detect a file move, you may wish to link to a
patch comparing the old file and the new file.
</details>
-->

<!--
<details>
<summary><h2> Deployment Plan </h2></summary>

Describe how the code in this pull request will be deployed. Some
deployments are complicated and may require flag days between multiple
repositories or the provisioning of new infrastructure. Describing your
deployment plan allows reviewers to ensure that your work will not cause
any unnecessary interruption to end users.
</details>
-->

<!--
<details>
<summary><h2> Future Work </h2></summary>

Provide a description of any possible follow-up work that is explicitly
not being done in this pull request.
</details>
-->

<!--
<details>
<summary><h2> Bonus </h2></summary>

Provide a description of any extra problems you have solved in this pull
request.
</details>
-->