### PR TITLE
DLPX-87038 VMDK file size differs from the size in the OVF file

### DIFF
--- a/live-build/config/hooks/vm-artifacts/92-ova-machine-image.binary
+++ b/live-build/config/hooks/vm-artifacts/92-ova-machine-image.binary
@@ -47,8 +47,7 @@ esac
 
 DATE=$(date --utc --iso-8601=seconds)
 
-VMDK_FILESIZE=$(qemu-img info --output=json "$ARTIFACT_NAME.vmdk" |
-	jq '.["actual-size"]')
+VMDK_FILESIZE=$(stat -c %s "$ARTIFACT_NAME.vmdk")
 VMDK_CAPACITY=$(qemu-img info --output=json "$ARTIFACT_NAME.vmdk" |
 	jq '.["virtual-size"]')
 


### PR DESCRIPTION
<!--
<details open>
<summary><h2> Background </h2></summary>

Provide a clear description of the high-level effort with which this
pull request is associated. Recall that while anyone in the organization
can see this pull request, not everyone necessarily has the same context
as you. If applicable, link to design documents or high-level tracking
epics here.
</details>
-->

<details open>
<summary><h2> Problem </h2></summary>

`qemu-img` seems to be returning a different size for a VMDK.
```
delphix@pg-release:~$ aws s3 cp s3://snapshot-de-images/builds/jenkins-ops/appliance-build/release/post-push/48/external-standard-esx/external-standard-esx.ova .
download: s3://snapshot-de-images/builds/jenkins-ops/appliance-build/release/post-push/48/external-standard-esx/external-standard-esx.ova to ./external-standard-esx.ova

delphix@pg-release:~$ tar -xvf external-standard-esx.ova
external-standard-esx.ovf
external-standard-esx.mf
external-standard-esx.vmdk

delphix@pg-release:~$ stat -c %s external-standard-esx.vmdk
7058465280

delphix@pg-release:~$ grep ovf:size external-standard-esx.ovf
    <File ovf:href="external-standard-esx.vmdk" ovf:id="file1" ovf:size="7058241024"/>

delphix@pg-release:~$ qemu-img info --output=json external-standard-esx.vmdk | grep actual-size
    "actual-size": 7062785536,
```
This caused [ESCL-4527](https://delphix.atlassian.net/browse/ESCL-4527)
</details>

<!--
<details>
<summary><h2> Evaluation </h2></summary>

If the cause of the problem is not obvious, provide a root-cause
analysis (RCA), ideally using the Five Whys iterative interrogative
technique or some other form of analytical reasoning.
</details>
-->

<details open>
<summary><h2> Solution </h2></summary>

Use `stat` instead to ensure sizes match.
</details>


<details open>
<summary><h2> Testing Done </h2></summary>

Run `ab-pre-push`, download resulting OVAs and verify that sizes match
```
delphix@pg-release:~$ aws s3 cp s3://dev-de-images/builds/jenkins-selfservice/appliance-build/develop/pre-push/880/external-standard-esx/external-standard-esx.ova .
download: s3://dev-de-images/builds/jenkins-selfservice/appliance-build/develop/pre-push/880/external-standard-esx/external-standard-esx.ova to ./external-standard-esx.ova

delphix@pg-release:~$ tar -xvf external-standard-esx.ova
external-standard-esx.ovf
external-standard-esx.mf
external-standard-esx.vmdk

delphix@pg-release:~$ grep ovf:size external-standard-esx.ovf
    <File ovf:href="external-standard-esx.vmdk" ovf:id="file1" ovf:size="7096252928"/>

delphix@pg-release:~$ stat -c %s external-standard-esx.vmdk
7096252928
```

Uploaded the OVA to vcenter and deployed an engine from it: https://qa-esxi01.delphix.com/ui/#/host/vms/1429
</details>

<!--
<details>
<summary><h2> Implementation </h2></summary>

Describe the implementation details of the solution. Generally the
reasoning behind any non-obvious code should be recorded in code
comments. However, code comments should always describe the current
state of the code; in contrast, this section may be useful to describe
the relationship between the original code and the code being proposed
in this pull request.
</details>
-->

<!--
<details>
<summary><h2> Notes to Reviewers </h2></summary>

Provide any extra information a reviewer may need to know before
evaluating your pull request. For example, you may wish to describe
which files should be reviewed first or which files are auto-generated.
If the review tool cannot detect a file move, you may wish to link to a
patch comparing the old file and the new file.
</details>
-->

<!--
<details>
<summary><h2> Deployment Plan </h2></summary>

Describe how the code in this pull request will be deployed. Some
deployments are complicated and may require flag days between multiple
repositories or the provisioning of new infrastructure. Describing your
deployment plan allows reviewers to ensure that your work will not cause
any unnecessary interruption to end users.
</details>
-->

<!--
<details>
<summary><h2> Future Work </h2></summary>

Provide a description of any possible follow-up work that is explicitly
not being done in this pull request.
</details>
-->

<!--
<details>
<summary><h2> Bonus </h2></summary>

Provide a description of any extra problems you have solved in this pull
request.
</details>
-->
