### PR TITLE
DLPX-87656 Update sshd_config to allow sftp call on internal-qa instance

### DIFF
--- a/live-build/misc/ansible-roles/appliance-build.qa-internal/tasks/main.yml
+++ b/live-build/misc/ansible-roles/appliance-build.qa-internal/tasks/main.yml
@@ -68,3 +68,9 @@
       #!/usr/sbin/nft -f
       flush ruleset
   notify: nftables
+
+- lineinfile:
+    path: /etc/ssh/sshd_config
+    regexp: '^#?\s*(Subsystem\s+sftp.*$)'
+    line: '\1'
+    backrefs: yes


### PR DESCRIPTION
# Problem
- As part of [PR1190](https://github.com/delphix/dlpx-app-gate/pull/1190) of dlpx-app-gate, the file transfer protocol of sshj changed from SCP to SFTP but sftp is disabled on DE so to test SFTP working on DE as part of dxoTest uncomment below line from sshd_config:
`Subsystem       sftp    /usr/lib/openssh/sftp-server`

# Solution
- Uncommented the above line for the internal-qa instances.

# Testing
- http://selfservice.jenkins.delphix.com/job/appliance-build-orchestrator-pre-push/6851/
- Tried below local ansible code to test regex and that is working:
```
- name: Test of lineinfile
  hosts: localhost

  tasks:
    - name: "Test: Validate if a String or line is present in the file"
      become: yes
      become_user: root
      tags: test
      lineinfile:
        path: /etc/ssh/sshd_config
        regexp: '^#?\s*(Subsystem\s+sftp.*$)'
        line: '\1'
        backrefs: yes
```