### PR TITLE
DLPX-87792 Fix timeout when starting an upgrade container

### DIFF
--- a/upgrade/upgrade-scripts/upgrade-container
+++ b/upgrade/upgrade-scripts/upgrade-container
@@ -462,6 +462,7 @@ function start() {
 		die "container '$CONTAINER' non-existent or mis-configured"
 	fi
 
+	systemctl restart systemd-reexec.service 2>/dev/null
 	machinectl start "$CONTAINER" ||
 		die "failed to start container '$CONTAINER'"
 
@@ -486,6 +487,7 @@ function start() {
 }
 
 function stop() {
+	systemctl restart systemd-reexec.service 2>/dev/null
 	machinectl terminate "$CONTAINER" ||
 		die "failed to termiante container: '$CONTAINER'"
 


### PR DESCRIPTION
### Problem

Sometimes systemd goes out to lunch, and needs to be restarted. We attempted to fix this previously in #713 but seem to have missed a couple spots.. e.g. if systemd is unresponsive when we go to start a container, that start request may get dropped on the floor.

### Solution

This PR address the issue by restarting systemd just prior to starting the container. Also, this also fixes the issue when we terminate the container, too.