### PR TITLE
TOOL-22969 Add mold to development engines

### DIFF
--- a/live-build/misc/ansible-roles/appliance-build.zfsonlinux-development/tasks/main.yml
+++ b/live-build/misc/ansible-roles/appliance-build.zfsonlinux-development/tasks/main.yml
@@ -45,6 +45,7 @@
       - llvm-12
       - lsscsi
       - mandoc
+      - mold
       - nfs-kernel-server
       - parted
       - pkg-config
@@ -76,3 +77,14 @@
     group: staff
     state: directory
     recurse: yes
+
+- file:
+    path: "/export/home/delphix/.cargo/"
+    state: directory
+    owner: delphix
+    group: staff
+- copy:
+    dest: "/export/home/delphix/.cargo/config.toml"
+    content: |
+        [target.x86_64-unknown-linux-gnu]
+        rustflags = ["-C", "link-arg=-B/usr/libexec/mold"]


### PR DESCRIPTION
This PR adds the mold linker to our internal development environments, and configures it for use with our development builds. mold is significantly faster than the default GNU linker, which will improve build times significantly. This change has been tested in conjuction with linux-pkg changes, which can be found [here](https://github.com/delphix/linux-pkg/pull/301).

http://selfservice.jenkins.delphix.com/job/appliance-build-orchestrator-pre-push/7029/console