### PR TITLE
DLPX-84565 telegraf.service restarts after upgrade when it should be masked

### DIFF
--- a/upgrade/upgrade-scripts/execute
+++ b/upgrade/upgrade-scripts/execute
@@ -435,6 +435,17 @@ dpkg-query -Wf '${Conffiles}\n' | awk '$3 == "obsolete" {print $1}' |
 	done || die "failed to remove obsolete package configuration files"
 
 #
+# Due to https://github.com/influxdata/telegraf/issues/14052, telegraf must be masked after
+# packages are upgraded. The telegraf package removes /etc/systemd/system/telegraf.service thus
+# reversing the `systemctl mask` operation performed before the packages are upgraded.
+# Once this issue is fixed and a version with the fix makes it into the product, this can be
+# removed.
+#
+if [[ "$(systemctl is-enabled telegraf)" == enabled ]]; then
+	systemctl mask --now telegraf.service
+fi
+
+#
 # Unmask docker, which was masked at the beginning of the upgrade due
 # to DLPX-77949.
 #


### PR DESCRIPTION
<!--
<details open>
<summary><h2> Background </h2></summary>

Provide a clear description of the high-level effort with which this
pull request is associated. Recall that while anyone in the organization
can see this pull request, not everyone necessarily has the same context
as you. If applicable, link to design documents or high-level tracking
epics here.
</details>
-->

<details open>
<summary><h2> Problem </h2></summary>

The telegraf package enables `telegraf.service`. The service ends up in a restart loop as noted in the Jira.
While the service is masked and disabled on a fresh install, there is nothing in the upgrade logic to mask this service.
</details>

<!--
<details>
<summary><h2> Evaluation </h2></summary>

If the cause of the problem is not obvious, provide a root-cause
analysis (RCA), ideally using the Five Whys iterative interrogative
technique or some other form of analytical reasoning.
</details>
-->

<details open>
<summary><h2> Solution </h2></summary>

Mask it like other services.
</details>


<details open>
<summary><h2> Testing Done </h2></summary>

ab-pre-push: http://selfservice.jenkins.delphix.com/job/appliance-build-orchestrator-pre-push/7191/console

Manual test: Upgrade from 6.0.13.0 to 7.0 to 16.0 and verify telegraf.service is not running
http://selfservice.jenkins.delphix.com/job/blackbox-chained/5396/console

From the syslog:
During verify:
```
Oct  5 08:11:05 ip-10-110-240-233 upgrade-scripts:upgrade-container[11483]: //var/dlpx-update/16.0.0.0-snapshot.20231004163329604+jenkins-selfservice-appliance-
build-develop-pre-push-1584/common.sh:fix_and_migrate_services:448 systemctl is-enabled telegraf
Oct  5 08:11:05 ip-10-110-240-233 upgrade-scripts:upgrade-container[11483]: /var/dlpx-update/16.0.0.0-snapshot.20231004163329604+jenkins-selfservice-appliance-b
uild-develop-pre-push-1584/common.sh:fix_and_migrate_services:448 [[ enabled == enabled ]]
Oct  5 08:11:05 ip-10-110-240-233 upgrade-scripts:upgrade-container[11483]: /var/dlpx-update/16.0.0.0-snapshot.20231004163329604+jenkins-selfservice-appliance-build-develop-pre-push-1584/common.sh:fix_and_migrate_services:449 mask_service telegraf delphix.iyDDbhM
Oct  5 08:11:05 ip-10-110-240-233 upgrade-scripts:upgrade-container[11483]: /var/dlpx-update/16.0.0.0-snapshot.20231004163329604+jenkins-selfservice-appliance-build-develop-pre-push-1584/common.sh:mask_service:374 local svc=telegraf
Oct  5 08:11:05 ip-10-110-240-233 upgrade-scripts:upgrade-container[11483]: /var/dlpx-update/16.0.0.0-snapshot.20231004163329604+jenkins-selfservice-appliance-build-develop-pre-push-1584/common.sh:mask_service:375 local container=delphix.iyDDbhM
Oct  5 08:11:05 ip-10-110-240-233 upgrade-scripts:upgrade-container[11483]: /var/dlpx-update/16.0.0.0-snapshot.20231004163329604+jenkins-selfservice-appliance-build-develop-pre-push-1584/common.sh:mask_service:380 [[ -n delphix.iyDDbhM ]]
Oct  5 08:11:05 ip-10-110-240-233 upgrade-scripts:upgrade-container[11483]: /var/dlpx-update/16.0.0.0-snapshot.20231004163329604+jenkins-selfservice-appliance-build-develop-pre-push-1584/common.sh:mask_service:381 chroot /var/lib/machines/delphix.iyDDbhM systemctl mask telegraf
...
...
Oct  5 08:11:05 ip-10-110-240-233 upgrade-scripts:upgrade-container[11483]: /var/dlpx-update/16.0.0.0-snapshot.20231004163329604+jenkins-selfservice-appliance-b
uild-develop-pre-push-1584/common.sh:fix_and_migrate_services:478 is_svc_new_or_masked_or_disabled telegraf.service
Oct  5 08:11:05 ip-10-110-240-233 upgrade-scripts:upgrade-container[11483]: /var/dlpx-update/16.0.0.0-snapshot.20231004163329604+jenkins-selfservice-appliance-b
uild-develop-pre-push-1584/common.sh:is_svc_new_or_masked_or_disabled:389 local svc=telegraf.service
Oct  5 08:11:05 ip-10-110-240-233 upgrade-scripts:upgrade-container[11483]: /var/dlpx-update/16.0.0.0-snapshot.20231004163329604+jenkins-selfservice-appliance-build-develop-pre-push-1584/common.sh:is_svc_new_or_masked_or_disabled:391 systemctl cat telegraf.service
Oct  5 08:11:05 ip-10-110-240-233 upgrade-scripts:upgrade-container[11483]: /var/dlpx-update/16.0.0.0-snapshot.20231004163329604+jenkins-selfservice-appliance-build-develop-pre-push-1584/common.sh:is_svc_new_or_masked_or_disabled:392 '[' 0 -eq 1 ']'
Oct  5 08:11:05 ip-10-110-240-233 upgrade-scripts:upgrade-container[11483]: //var/dlpx-update/16.0.0.0-snapshot.20231004163329604+jenkins-selfservice-appliance-build-develop-pre-push-1584/common.sh:is_svc_new_or_masked_or_disabled:396 systemctl is-enabled telegraf.service
Oct  5 08:11:05 ip-10-110-240-233 upgrade-scripts:upgrade-container[11483]: /var/dlpx-update/16.0.0.0-snapshot.20231004163329604+jenkins-selfservice-appliance-build-develop-pre-push-1584/common.sh:is_svc_new_or_masked_or_disabled:396 state=enabled
Oct  5 08:11:05 ip-10-110-240-233 upgrade-scripts:upgrade-container[11483]: /var/dlpx-update/16.0.0.0-snapshot.20231004163329604+jenkins-selfservice-appliance-build-develop-pre-push-1584/common.sh:is_svc_new_or_masked_or_disabled:397 [[ enabled == masked ]]
Oct  5 08:11:05 ip-10-110-240-233 upgrade-scripts:upgrade-container[11483]: /var/dlpx-update/16.0.0.0-snapshot.20231004163329604+jenkins-selfservice-appliance-build-develop-pre-push-1584/common.sh:is_svc_new_or_masked_or_disabled:397 [[ enabled == disabled ]]
Oct  5 08:11:05 ip-10-110-240-233 upgrade-scripts:upgrade-container[11483]: /var/dlpx-update/16.0.0.0-snapshot.20231004163329604+jenkins-selfservice-appliance-build-develop-pre-push-1584/common.sh:is_svc_new_or_masked_or_disabled:401 return 1
```


During apply:
```
Oct  5 08:39:50 ip-10-110-240-233 upgrade-scripts:execute[83847]: //var/dlpx-update/16.0.0.0-snapshot.20231004163329604+jenkins-selfservice-appliance-build-develop-pre-push-1584/common.sh:fix_and_migrate_services:448 systemctl is-enabled telegraf
Oct  5 08:39:50 ip-10-110-240-233 upgrade-scripts:execute[83847]: telegraf.service is not a native service, redirecting to systemd-sysv-install.
Oct  5 08:39:50 ip-10-110-240-233 upgrade-scripts:execute[83847]: Executing: /lib/systemd/systemd-sysv-install is-enabled telegraf
Oct  5 08:39:50 ip-10-110-240-233 upgrade-scripts:execute[83847]: /var/dlpx-update/16.0.0.0-snapshot.20231004163329604+jenkins-selfservice-appliance-build-devel
op-pre-push-1584/common.sh:fix_and_migrate_services:448 [[ enabled == enabled ]]
Oct  5 08:39:50 ip-10-110-240-233 upgrade-scripts:execute[83847]: /var/dlpx-update/16.0.0.0-snapshot.20231004163329604+jenkins-selfservice-appliance-build-devel
op-pre-push-1584/common.sh:fix_and_migrate_services:449 mask_service telegraf ''
Oct  5 08:39:50 ip-10-110-240-233 upgrade-scripts:execute[83847]: /var/dlpx-update/16.0.0.0-snapshot.20231004163329604+jenkins-selfservice-appliance-build-devel
op-pre-push-1584/common.sh:mask_service:374 local svc=telegraf
Oct  5 08:39:50 ip-10-110-240-233 upgrade-scripts:execute[83847]: /var/dlpx-update/16.0.0.0-snapshot.20231004163329604+jenkins-selfservice-appliance-build-devel
op-pre-push-1584/common.sh:mask_service:375 local container=
Oct  5 08:39:50 ip-10-110-240-233 upgrade-scripts:execute[83847]: /var/dlpx-update/16.0.0.0-snapshot.20231004163329604+jenkins-selfservice-appliance-build-devel
op-pre-push-1584/common.sh:mask_service:380 [[ -n '' ]]
Oct  5 08:39:50 ip-10-110-240-233 upgrade-scripts:execute[83847]: /var/dlpx-update/16.0.0.0-snapshot.20231004163329604+jenkins-selfservice-appliance-build-devel
op-pre-push-1584/common.sh:mask_service:384 systemctl mask --now telegraf
Oct  5 08:39:50 ip-10-110-240-233 upgrade-scripts:execute[83847]: Created symlink /etc/systemd/system/telegraf.service → /dev/null.
Oct  5 08:39:50 ip-10-110-240-233 systemd[1]: Reloading.
Oct  5 08:39:51 ip-10-110-240-233 systemd[1]: Stopping telegraf.service...
Oct  5 08:39:51 ip-10-110-240-233 systemd[1]: telegraf.service: Succeeded.
Oct  5 08:39:51 ip-10-110-240-233 systemd[1]: Stopped telegraf.service.
...
...
Oct  5 08:39:54 ip-10-110-240-233 upgrade-scripts:execute[83847]: /var/dlpx-update/16.0.0.0-snapshot.20231004163329604+jenkins-selfservice-appliance-build-devel
op-pre-push-1584/common.sh:fix_and_migrate_services:478 is_svc_new_or_masked_or_disabled telegraf.service
Oct  5 08:39:54 ip-10-110-240-233 upgrade-scripts:execute[83847]: /var/dlpx-update/16.0.0.0-snapshot.20231004163329604+jenkins-selfservice-appliance-build-devel
op-pre-push-1584/common.sh:is_svc_new_or_masked_or_disabled:389 local svc=telegraf.service
Oct  5 08:39:54 ip-10-110-240-233 upgrade-scripts:execute[83847]: /var/dlpx-update/16.0.0.0-snapshot.20231004163329604+jenkins-selfservice-appliance-build-devel
op-pre-push-1584/common.sh:is_svc_new_or_masked_or_disabled:391 systemctl cat telegraf.service
Oct  5 08:39:54 ip-10-110-240-233 upgrade-scripts:execute[83847]: /var/dlpx-update/16.0.0.0-snapshot.20231004163329604+jenkins-selfservice-appliance-build-devel
op-pre-push-1584/common.sh:is_svc_new_or_masked_or_disabled:392 '[' 0 -eq 1 ']'
Oct  5 08:39:54 ip-10-110-240-233 upgrade-scripts:execute[83847]: //var/dlpx-update/16.0.0.0-snapshot.20231004163329604+jenkins-selfservice-appliance-build-deve
lop-pre-push-1584/common.sh:is_svc_new_or_masked_or_disabled:396 systemctl is-enabled telegraf.service
Oct  5 08:39:54 ip-10-110-240-233 upgrade-scripts:execute[83847]: /var/dlpx-update/16.0.0.0-snapshot.20231004163329604+jenkins-selfservice-appliance-build-devel
op-pre-push-1584/common.sh:is_svc_new_or_masked_or_disabled:396 state=masked
Oct  5 08:39:54 ip-10-110-240-233 upgrade-scripts:execute[83847]: /var/dlpx-update/16.0.0.0-snapshot.20231004163329604+jenkins-selfservice-appliance-build-devel
op-pre-push-1584/common.sh:is_svc_new_or_masked_or_disabled:397 [[ masked == masked ]]
Oct  5 08:39:54 ip-10-110-240-233 upgrade-scripts:execute[83847]: /var/dlpx-update/16.0.0.0-snapshot.20231004163329604+jenkins-selfservice-appliance-build-devel
op-pre-push-1584/common.sh:is_svc_new_or_masked_or_disabled:398 return 0
Oct  5 08:39:54 ip-10-110-240-233 upgrade-scripts:execute[83847]: /var/dlpx-update/16.0.0.0-snapshot.20231004163329604+jenkins-selfservice-appliance-build-devel
op-pre-push-1584/common.sh:fix_and_migrate_services:479 mask_service telegraf.service ''
Oct  5 08:39:54 ip-10-110-240-233 upgrade-scripts:execute[83847]: /var/dlpx-update/16.0.0.0-snapshot.20231004163329604+jenkins-selfservice-appliance-build-devel
op-pre-push-1584/common.sh:mask_service:374 local svc=telegraf.service
Oct  5 08:39:54 ip-10-110-240-233 upgrade-scripts:execute[83847]: /var/dlpx-update/16.0.0.0-snapshot.20231004163329604+jenkins-selfservice-appliance-build-devel
op-pre-push-1584/common.sh:mask_service:375 local container=
Oct  5 08:39:54 ip-10-110-240-233 upgrade-scripts:execute[83847]: /var/dlpx-update/16.0.0.0-snapshot.20231004163329604+jenkins-selfservice-appliance-build-devel
op-pre-push-1584/common.sh:mask_service:380 [[ -n '' ]]
Oct  5 08:39:54 ip-10-110-240-233 upgrade-scripts:execute[83847]: /var/dlpx-update/16.0.0.0-snapshot.20231004163329604+jenkins-selfservice-appliance-build-devel
op-pre-push-1584/common.sh:mask_service:384 systemctl mask --now telegraf.service
```
</details>

<!--
<details>
<summary><h2> Implementation </h2></summary>

Describe the implementation details of the solution. Generally the
reasoning behind any non-obvious code should be recorded in code
comments. However, code comments should always describe the current
state of the code; in contrast, this section may be useful to describe
the relationship between the original code and the code being proposed
in this pull request.
</details>
-->

<!--
<details>
<summary><h2> Notes to Reviewers </h2></summary>

Provide any extra information a reviewer may need to know before
evaluating your pull request. For example, you may wish to describe
which files should be reviewed first or which files are auto-generated.
If the review tool cannot detect a file move, you may wish to link to a
patch comparing the old file and the new file.
</details>
-->

<!--
<details>
<summary><h2> Deployment Plan </h2></summary>

Describe how the code in this pull request will be deployed. Some
deployments are complicated and may require flag days between multiple
repositories or the provisioning of new infrastructure. Describing your
deployment plan allows reviewers to ensure that your work will not cause
any unnecessary interruption to end users.
</details>
-->

<!--
<details>
<summary><h2> Future Work </h2></summary>

Provide a description of any possible follow-up work that is explicitly
not being done in this pull request.
</details>
-->

<!--
<details>
<summary><h2> Bonus </h2></summary>

Provide a description of any extra problems you have solved in this pull
request.
</details>
-->
