### PR TITLE
DLPX-85893 run upgrade "execute" script from separate service

### DIFF
--- a/upgrade/upgrade-scripts/upgrade
+++ b/upgrade/upgrade-scripts/upgrade
@@ -164,7 +164,7 @@ function upgrade_in_place() {
 		opt_f="-f"
 	fi
 
-	"$IMAGE_PATH/execute" "$opt_f" ||
+	"$IMAGE_PATH/execute" $opt_f ||
 		die "'$IMAGE_PATH/execute' failed in running appliance."
 }
 


### PR DESCRIPTION
Fix a bug introduced in #725, the `execute` script now only accepts optional parameters, so we need to be careful not to pass in the empty string (`""`) from `upgrade` when performing a deferred upgrade.