### PR TITLE
DLPX-88573 Perform deferred upgrade prior to VDB downtime for FULL upgrade

### DIFF
--- a/upgrade/upgrade-scripts/execute
+++ b/upgrade/upgrade-scripts/execute
@@ -604,7 +604,13 @@ if [[ -f "$UPDATE_DIR/upgrade.properties" ]]; then
 	source_upgrade_properties
 fi
 
-if [[ -n "$opt_f" ]] || [[ "$UPGRADE_TYPE" == "FULL" ]]; then
+#
+# On versions 18.0 and greater, we don't issue the reboot. Rather,
+# we restart the delphix services, and the reboot will be issued by
+# the virtualization service as it starts up.
+#
+if { [[ -n "$opt_f" ]] || [[ "$UPGRADE_TYPE" == "FULL" ]]; } &&
+	compare_versions "$CURRENT_VERSION" lt "18.0.0.0-0"; then
 	post_alert "reboot"
 	exec systemctl reboot || die "failed to reboot"
 else


### PR DESCRIPTION
### Context

We intend to modify the upgrade logic, such that we don't perform a reboot
when doing FULL upgrades until after a stack restart, such that we can wait
to quiesce VDBs until we're running the stack on the new version. For more
context w.r.t. the motivation for doing this, see CP-10570.

### Problem

Currently, when the "execute" is run, it'll automatically reboot the system
after packages are upgraded, when a FULL upgrade is requested. This conflicts
with the goals of CP-10570, as "execute" is run from the "old version", rather
than the "new version".

### Solution

The changes being made in this PR, is to modify execute to only restart delphix
services, regardless if a FULL or DEFERRED upgrade is requested. This means, via
the scripts, there is no longer any difference between a FULL or DEFERRED upgrade.
But, with the accompanying virtualization changes, the required reboot for a FULL
upgrade will now be performed by the virtualization product's upgrade logic instead.

The intention is for the virtualization product's upgrade logic to run the "execute"
script to perform the package upgrades as necessary, and restart the application.
Then, when the application starts back up on the new version, it'll detect a FULL
upgrade was being performed at stack startup time, and automatically initiate the
necessary logic to quiesce VDBs and perform the reboot.

One caveat to the approach taken in this PR, is any consumers that happened to be
using the upgrade scripts to perform a FULL upgrade, will now need to manually
reboot the system themselves. Argueably this fixes a bug, since previously a
FULL upgrade via the scripts would not quiesce VDBs, and thus could result in
problems for VDBs due to the reboot; i.e. it's now up to the user to quiesce
VDBs after the upgrade, and perform the reboot.

### Related Work

 - https://github.com/delphix/dlpx-app-gate/pull/1389
 
 ### Testing
 
 - `git-ab-pre-push` is [here](http://selfservice.jenkins.delphix.com/job/appliance-build-orchestrator-pre-push/7343/)
