### PR TITLE
DLPX-88546 upgrade verification failed to generate faults

### DIFF
--- a/upgrade/upgrade-scripts/upgrade-container
+++ b/upgrade/upgrade-scripts/upgrade-container
@@ -423,6 +423,21 @@ function create_upgrade_container() {
 	fi
 
 	#
+	# Lastly, we create the log directory and bind mount this into
+	# the container. This is meant as a way for software running in
+	# the container, to share files with software running on the
+	# host; e.g. during upgrade verify, this directory can be used
+	# to store logs, such that they persist after the container is
+	# destroyed.
+	#
+	mkdir -p "$LOG_DIRECTORY" ||
+		die "failed to create directory: '$LOG_DIRECTORY'"
+	cat >>"/etc/systemd/nspawn/$CONTAINER.nspawn" <<-EOF ||
+		Bind=$LOG_DIRECTORY
+	EOF
+		die "failed to add '$LOG_DIRECTORY' to container config file"
+
+	#
 	# We want to enable all available capabilities to the container
 	# that we will use to run the ugprade verification. Ideally, we
 	# would accomplish this by using "CAPABILITY=all" in the


### PR DESCRIPTION
### Problem

See JIRA for details; to summarize, DLPX-65276 moved us over to relying on the `zfs-mount` service to mount `/var/tmp/delphix-upgrade` in the container, then DLPX-81199 removed the `zfs-mount` service from running in the container, inadvertently causing this issue.

### Solution

The solution is to move back to relying on a `Bind=` directive for the container's configuration, to bind mount the directory from the host into the container.

### Testing

- `git-ab-pre-push` is [here](http://selfservice.jenkins.delphix.com/job/appliance-build-orchestrator-pre-push/7420/)
- Ran upgrade verify on a 16.0 to 17.0 upgrade, with this change, and verified faults were generated.