### PR TITLE
Add tab completion, path modifications

### DIFF
--- a/live-build/misc/ansible-roles/appliance-build.virtualization-common/tasks/main.yml
+++ b/live-build/misc/ansible-roles/appliance-build.virtualization-common/tasks/main.yml
@@ -119,3 +119,19 @@
   command: "systemctl disable {{ item }}"
   with_items:
     - docker.service
+
+- name: Add systemctl bash completion
+  copy:
+    dest: "/etc/bash_completion.d/systemctl"
+    content: |
+      if [[ -r /usr/share/bash-completion/completions/systemctl ]]; then
+        . /usr/share/bash-completion/completions/systemctl && complete -F _systemctl systemctl
+      fi
+
+- name: Source bash completion
+  blockinfile:
+    dest: "/export/home/delphix/.bashrc"
+    block: |
+      . /etc/bash_completion.d/systemctl
+      . /etc/bash_completion.d/zfs
+      PATH=$PATH:/opt/delphix/server/bin


### PR DESCRIPTION
<details open>
<summary><h2> Problem </h2></summary>

Interacting with the systemctl command line tools can be cumbersome. Finding what services exist
and are active can require grepping the output of commands that are not intended for machine parsing.
Remembering and entering the full names of commands is potentially cumbersome if you don't use them
regularly. There are tab completion scripts that intend to solve these problems.

We also have similar problems with the zfs command line tools and the /opt/delphix/server/bin path.
These things add small friction to countless processes that can be easily reduced.
</details>

<details open>
<summary><h2> Solution </h2></summary>

We add tab completion scripts to the standard location for them on ubuntu systems, and then
source those scripts to get their functionality. We also add the /opt/delphix path to the
delphix user's PATH variable.
</details>

<details>
<summary><h2> Testing Done </h2></summary>

Spun up a development VM with these changes and verified that they all performed as expected.
</details>