### PR TITLE
DLPX-90090 Update Ansible config to override DLPX_DEBUG to true for delphix-osadmin service in development engines

### DIFF
--- a/live-build/misc/ansible-roles/appliance-build.virtualization-development/tasks/main.yml
+++ b/live-build/misc/ansible-roles/appliance-build.virtualization-development/tasks/main.yml
@@ -44,6 +44,21 @@
       Environment=DLPX_DEBUG=true
 
 - file:
+    path: "/etc/systemd/system/delphix-osadmin.service.d"
+    owner: root
+    group: root
+    state: directory
+    recurse: yes
+
+- copy:
+    dest: "/etc/systemd/system/delphix-osadmin.service.d/override.conf"
+    owner: root
+    group: root
+    content: |
+      [Service]
+      Environment=DLPX_DEBUG=true
+
+- file:
     path: "/etc/systemd/system/delphix-sso-app.service.d"
     owner: root
     group: root

--- a/live-build/misc/ansible-roles/appliance-build.virtualization-development/tasks/main.yml
+++ b/live-build/misc/ansible-roles/appliance-build.virtualization-development/tasks/main.yml
@@ -28,50 +28,33 @@
   retries: 3
   delay: 60
 
-- file:
-    path: "/etc/systemd/system/delphix-mgmt.service.d"
-    owner: root
-    group: root
-    state: directory
-    recurse: yes
+- name: Ensure systemd service directories and override configurations are set
+  block:
+    - name: Ensure systemd service directory exists
+      file:
+        path: "{{ item.directory }}"
+        owner: root
+        group: root
+        state: directory
+        recurse: yes
+      with_items:
+        - { directory: "/etc/systemd/system/delphix-mgmt.service.d" }
+        - { directory: "/etc/systemd/system/delphix-osadmin.service.d" }
+        - { directory: "/etc/systemd/system/delphix-sso-app.service.d" }
 
-- copy:
-    dest: "/etc/systemd/system/delphix-mgmt.service.d/override.conf"
-    owner: root
-    group: root
-    content: |
-      [Service]
-      Environment=DLPX_DEBUG=true
-
-- file:
-    path: "/etc/systemd/system/delphix-osadmin.service.d"
-    owner: root
-    group: root
-    state: directory
-    recurse: yes
-
-- copy:
-    dest: "/etc/systemd/system/delphix-osadmin.service.d/override.conf"
-    owner: root
-    group: root
-    content: |
-      [Service]
-      Environment=DLPX_DEBUG=true
-
-- file:
-    path: "/etc/systemd/system/delphix-sso-app.service.d"
-    owner: root
-    group: root
-    state: directory
-    recurse: yes
-
-- copy:
-    dest: "/etc/systemd/system/delphix-sso-app.service.d/override.conf"
-    owner: root
-    group: root
-    content: |
-      [Service]
-      Environment=DLPX_DEBUG=true
+    - name: Set override configuration for systemd services
+      copy:
+        dest: "{{ item.directory }}/override.conf"
+        owner: root
+        group: root
+        content: |
+          [Service]
+          Environment=DLPX_DEBUG=true
+      with_items:
+        - { directory: "/etc/systemd/system/delphix-mgmt.service.d" }
+        - { directory: "/etc/systemd/system/delphix-osadmin.service.d" }
+        - { directory: "/etc/systemd/system/delphix-sso-app.service.d" }
+  become: true
 
 - file:
     path: "/etc/systemd/system/delphix-postgres@.service.d"


### PR DESCRIPTION
<details open>
<summary><h2> Problem </h2></summary>

To enable remote-debug in delphix-osadmin, we will introduce an environment DLPX_DEBUG in https://delphix.atlassian.net/browse/DLPX-90086  but the default value is false. We want to set it to true for development engines, just like what we have done for delphix-mgmt service.
</details>


<details open>
<summary><h2> Solution </h2></summary>

- Update Ansible config to override DLPX_DEBUG to true for delphix-osadmin service in development engines

</details>


<details open>
<summary><h2> Testing Done </h2></summary>

I manually verified this worked.
```
delphix@ip-10-110-225-246:/etc/systemd/system/delphix-osadmin.service.d$ sudo vim override.conf
delphix@ip-10-110-225-246:/etc/systemd/system/delphix-osadmin.service.d$ cat override.conf
[Service]
Environment=DLPX_DEBUG=true
$ sudo systemctl daemon-reload
$ sudo systemctl restart delphix-osadmin
$ systemctl show delphix-osadmin --property=Environment
Environment=DLPX_DEBUG=true
```
Further testing can be found under PR https://github.com/delphix/dlpx-app-gate/pull/1899

git ab-pre-push: http://selfservice.jenkins.delphix.com/job/appliance-build-orchestrator-pre-push/8023/

</details>
