### PR TITLE
DLPX-86523 CIS: /home filesystem and mount options

### DIFF
--- a/bootstrap/roles/appliance-build.bootstrap/tasks/main.yml
+++ b/bootstrap/roles/appliance-build.bootstrap/tasks/main.yml
@@ -87,6 +87,9 @@
   ansible.builtin.pip:
     name: awscli
     break_system_packages: true
+    extra_args: "--no-cache-dir"
+  environment:
+    PIP_NO_CACHE_DIR: "yes"
   become: true
 
 - name: Load ZFS kernel module.

--- a/bootstrap/roles/appliance-build.bootstrap/tasks/main.yml
+++ b/bootstrap/roles/appliance-build.bootstrap/tasks/main.yml
@@ -92,7 +92,7 @@
     PIP_NO_CACHE_DIR: "yes"
   become: true
 
-- name: Remove pip cache directory
+- name: Clean up pip cache directory
   ansible.builtin.file:
     path: "/export/home/delphix/.cache"
     state: absent

--- a/bootstrap/roles/appliance-build.bootstrap/tasks/main.yml
+++ b/bootstrap/roles/appliance-build.bootstrap/tasks/main.yml
@@ -92,12 +92,6 @@
     PIP_NO_CACHE_DIR: "yes"
   become: true
 
-- name: Clean up pip cache directory
-  ansible.builtin.file:
-    path: "/export/home/delphix/.cache"
-    state: absent
-  become: true
-
 - name: Load ZFS kernel module.
   community.general.modprobe:
     name: zfs

--- a/bootstrap/roles/appliance-build.bootstrap/tasks/main.yml
+++ b/bootstrap/roles/appliance-build.bootstrap/tasks/main.yml
@@ -87,6 +87,7 @@
   ansible.builtin.pip:
     name: awscli
     break_system_packages: true
+    extra_args: "--no-cache-dir"
   become: true
 
 - name: Load ZFS kernel module.

--- a/bootstrap/roles/appliance-build.bootstrap/tasks/main.yml
+++ b/bootstrap/roles/appliance-build.bootstrap/tasks/main.yml
@@ -87,9 +87,6 @@
   ansible.builtin.pip:
     name: awscli
     break_system_packages: true
-    extra_args: "--no-cache-dir"
-  environment:
-    PIP_NO_CACHE_DIR: "yes"
   become: true
 
 - name: Load ZFS kernel module.

--- a/bootstrap/roles/appliance-build.bootstrap/tasks/main.yml
+++ b/bootstrap/roles/appliance-build.bootstrap/tasks/main.yml
@@ -88,6 +88,14 @@
     name: awscli
     break_system_packages: true
     extra_args: "--no-cache-dir"
+  environment:
+    PIP_NO_CACHE_DIR: "yes"
+  become: true
+
+- name: Remove pip cache directory
+  ansible.builtin.file:
+    path: "/export/home/delphix/.cache"
+    state: absent
   become: true
 
 - name: Load ZFS kernel module.

--- a/live-build/config/hooks/vm-artifacts/90-raw-disk-image.binary
+++ b/live-build/config/hooks/vm-artifacts/90-raw-disk-image.binary
@@ -1,6 +1,6 @@
 #!/bin/bash -ex
 #
-# Copyright 2018 Delphix
+# Copyright 2018, 2025 Delphix
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -274,8 +274,8 @@ zfs create \
 # contents. During normal boot up, we'll rely on "/etc/fstab" to handle
 # these mounts.
 #
-mkdir -p "$DIRECTORY/export/home"
-mount -t zfs "$FSNAME/ROOT/$FSNAME/home" "$DIRECTORY/export/home"
+mkdir -p "$DIRECTORY/home"
+mount -t zfs "$FSNAME/ROOT/$FSNAME/home" "$DIRECTORY/home"
 
 mkdir -p "$DIRECTORY/var/delphix"
 mount -t zfs "$FSNAME/ROOT/$FSNAME/data" "$DIRECTORY/var/delphix"
@@ -314,7 +314,7 @@ rsync --info=stats3 -WaAX binary/* "$DIRECTORY/"
 # automatically whenever we boot into the crash kernel.
 #
 cat <<-EOF >"$DIRECTORY/etc/fstab"
-	rpool/ROOT/$FSNAME/home /export/home zfs defaults,x-systemd.before=zfs-import-cache.service 0 0
+	rpool/ROOT/$FSNAME/home /home zfs defaults,nodev,x-systemd.before=zfs-import-cache.service 0 0
 	rpool/ROOT/$FSNAME/data /var/delphix zfs defaults,x-systemd.before=zfs-import-cache.service 0 0
 	rpool/ROOT/$FSNAME/log  /var/log     zfs defaults,x-systemd.before=zfs-import-cache.service 0 0
 	rpool/ROOT/$FSNAME/tmp  /tmp     zfs defaults,nosuid,nodev,exec,x-systemd.before=zfs-import-cache.service 0 0
@@ -440,7 +440,7 @@ done
 
 umount "$DIRECTORY/var/log"
 umount "$DIRECTORY/var/delphix"
-umount "$DIRECTORY/export/home"
+umount "$DIRECTORY/home"
 umount "$DIRECTORY/tmp"
 umount "$DIRECTORY/var/tmp"
 umount "/var/crash"

--- a/live-build/config/hooks/vm-artifacts/90-raw-disk-image.binary
+++ b/live-build/config/hooks/vm-artifacts/90-raw-disk-image.binary
@@ -314,7 +314,7 @@ rsync --info=stats3 -WaAX binary/* "$DIRECTORY/"
 # automatically whenever we boot into the crash kernel.
 #
 cat <<-EOF >"$DIRECTORY/etc/fstab"
-	rpool/ROOT/$FSNAME/home /home zfs defaults,nodev,x-systemd.before=zfs-import-cache.service 0 0
+	rpool/ROOT/$FSNAME/home /home zfs defaults,nodev,nosuid,x-systemd.before=zfs-import-cache.service 0 0
 	rpool/ROOT/$FSNAME/data /var/delphix zfs defaults,x-systemd.before=zfs-import-cache.service 0 0
 	rpool/ROOT/$FSNAME/log  /var/log     zfs defaults,x-systemd.before=zfs-import-cache.service 0 0
 	rpool/ROOT/$FSNAME/tmp  /tmp     zfs defaults,nosuid,nodev,exec,x-systemd.before=zfs-import-cache.service 0 0

--- a/live-build/config/hooks/vm-artifacts/90-raw-disk-image.binary
+++ b/live-build/config/hooks/vm-artifacts/90-raw-disk-image.binary
@@ -1,6 +1,6 @@
 #!/bin/bash -ex
 #
-# Copyright 2018, 2025 Delphix
+# Copyright 2018, 2026 Delphix
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/live-build/misc/ansible-roles/appliance-build.masking-development/tasks/main.yml
+++ b/live-build/misc/ansible-roles/appliance-build.masking-development/tasks/main.yml
@@ -1,5 +1,5 @@
 #
-# Copyright 2018, 2025 Delphix
+# Copyright 2018, 2026 Delphix
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/live-build/misc/ansible-roles/appliance-build.masking-development/tasks/main.yml
+++ b/live-build/misc/ansible-roles/appliance-build.masking-development/tasks/main.yml
@@ -1,5 +1,5 @@
 #
-# Copyright 2018 Delphix
+# Copyright 2018, 2025 Delphix
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -26,14 +26,14 @@
 - git:
     repo: "https://{{ lookup('env', 'GITHUB_TOKEN') }}@github.com/delphix/dms-core-gate.git"
     dest:
-      "/export/home/delphix/dms-core-gate"
+      "/home/delphix/dms-core-gate"
     version: "develop"
     accept_hostkey: yes
     update: no
   when: lookup('env', 'GITHUB_TOKEN') != ''
 
 - file:
-    path: "/export/home/delphix/{{ item }}"
+    path: "/home/delphix/{{ item }}"
     owner: delphix
     group: staff
     mode: "g+w"

--- a/live-build/misc/ansible-roles/appliance-build.minimal-common/tasks/main.yml
+++ b/live-build/misc/ansible-roles/appliance-build.minimal-common/tasks/main.yml
@@ -1,5 +1,5 @@
 #
-# Copyright 2018 Delphix
+# Copyright 2018, 2025 Delphix
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -26,7 +26,7 @@
   no_log: true
 
 - file:
-    path: /export/home
+    path: /home
     state: directory
     mode: 0755
 
@@ -39,7 +39,7 @@
     shell: /bin/bash
     create_home: yes
     comment: Delphix User
-    home: /export/home/delphix
+    home: /home/delphix
     password:
       "{{ lookup('env', 'APPLIANCE_PASSWORD') | password_hash('sha512') }}"
 

--- a/live-build/misc/ansible-roles/appliance-build.minimal-common/tasks/main.yml
+++ b/live-build/misc/ansible-roles/appliance-build.minimal-common/tasks/main.yml
@@ -1,5 +1,5 @@
 #
-# Copyright 2018, 2025 Delphix
+# Copyright 2018, 2026 Delphix
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/live-build/misc/ansible-roles/appliance-build.minimal-internal/tasks/main.yml
+++ b/live-build/misc/ansible-roles/appliance-build.minimal-internal/tasks/main.yml
@@ -34,17 +34,8 @@
   ansible.builtin.pip:
     name: awscli
     break_system_packages: true
-  environment:
-    PIP_NO_CACHE_DIR: "off"
+    extra_args: --no-cache-dir
   become: true
-#- name: Install awscli python package
-#  ansible.builtin.pip:
-#    name: awscli
-#    break_system_packages: true
-#    extra_args: "--no-cache-dir"
-#  environment:
-#    PIP_NO_CACHE_DIR: "yes"
-#  become: true
 
 # Add /usr/local/bin to the PATH (awscli needs it)
 - name: Create s3-bin-path.sh under profile.d

--- a/live-build/misc/ansible-roles/appliance-build.minimal-internal/tasks/main.yml
+++ b/live-build/misc/ansible-roles/appliance-build.minimal-internal/tasks/main.yml
@@ -39,12 +39,6 @@
     PIP_NO_CACHE_DIR: "yes"
   become: true
 
-- name: Clean up pip cache directory
-  ansible.builtin.file:
-    path: "/export/home/delphix/.cache"
-    state: absent
-  become: true
-
 # Add /usr/local/bin to the PATH (awscli needs it)
 - name: Create s3-bin-path.sh under profile.d
   ansible.builtin.copy:

--- a/live-build/misc/ansible-roles/appliance-build.minimal-internal/tasks/main.yml
+++ b/live-build/misc/ansible-roles/appliance-build.minimal-internal/tasks/main.yml
@@ -34,9 +34,6 @@
   ansible.builtin.pip:
     name: awscli
     break_system_packages: true
-    extra_args: "--no-cache-dir"
-  environment:
-    PIP_NO_CACHE_DIR: "yes"
   become: true
 
 # Add /usr/local/bin to the PATH (awscli needs it)

--- a/live-build/misc/ansible-roles/appliance-build.minimal-internal/tasks/main.yml
+++ b/live-build/misc/ansible-roles/appliance-build.minimal-internal/tasks/main.yml
@@ -34,6 +34,15 @@
   ansible.builtin.pip:
     name: awscli
     break_system_packages: true
+    extra_args: "--no-cache-dir"
+  environment:
+    PIP_NO_CACHE_DIR: "yes"
+  become: true
+
+- name: Clean up pip cache directory
+  ansible.builtin.file:
+    path: "/export/home/delphix/.cache"
+    state: absent
   become: true
 
 # Add /usr/local/bin to the PATH (awscli needs it)

--- a/live-build/misc/ansible-roles/appliance-build.minimal-internal/tasks/main.yml
+++ b/live-build/misc/ansible-roles/appliance-build.minimal-internal/tasks/main.yml
@@ -34,10 +34,17 @@
   ansible.builtin.pip:
     name: awscli
     break_system_packages: true
-    extra_args: "--no-cache-dir"
   environment:
-    PIP_NO_CACHE_DIR: "yes"
+    PIP_NO_CACHE_DIR: "off"
   become: true
+#- name: Install awscli python package
+#  ansible.builtin.pip:
+#    name: awscli
+#    break_system_packages: true
+#    extra_args: "--no-cache-dir"
+#  environment:
+#    PIP_NO_CACHE_DIR: "yes"
+#  become: true
 
 # Add /usr/local/bin to the PATH (awscli needs it)
 - name: Create s3-bin-path.sh under profile.d

--- a/live-build/misc/ansible-roles/appliance-build.minimal-internal/tasks/main.yml
+++ b/live-build/misc/ansible-roles/appliance-build.minimal-internal/tasks/main.yml
@@ -34,6 +34,9 @@
   ansible.builtin.pip:
     name: awscli
     break_system_packages: true
+    extra_args: "--no-cache-dir"
+  environment:
+    PIP_NO_CACHE_DIR: "yes"
   become: true
 
 # Add /usr/local/bin to the PATH (awscli needs it)

--- a/live-build/misc/ansible-roles/appliance-build.unittest-internal/tasks/main.yml
+++ b/live-build/misc/ansible-roles/appliance-build.unittest-internal/tasks/main.yml
@@ -94,7 +94,7 @@
 - user:
     name: testrunner
     comment: "Delphix"
-    home: /export/home/testrunner
+    home: /home/testrunner
     groups: docker
     password:
       "$6$pWQE0MPZWgue7fNC$8RvR0u04Mt67792b.x4ao0G2Z/H/hrYPWezOqCkz59MIA\

--- a/live-build/misc/ansible-roles/appliance-build.virtualization-development/tasks/main.yml
+++ b/live-build/misc/ansible-roles/appliance-build.virtualization-development/tasks/main.yml
@@ -1,5 +1,5 @@
 #
-# Copyright 2018, 2025 Delphix
+# Copyright 2018, 2026 Delphix
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/live-build/misc/ansible-roles/appliance-build.virtualization-development/tasks/main.yml
+++ b/live-build/misc/ansible-roles/appliance-build.virtualization-development/tasks/main.yml
@@ -1,5 +1,5 @@
 #
-# Copyright 2018 Delphix
+# Copyright 2018, 2025 Delphix
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -73,14 +73,14 @@
 
 - git:
     repo: "https://{{ lookup('env', 'GITHUB_TOKEN') }}@github.com/delphix/dlpx-app-gate.git"
-    dest: "/export/home/delphix/dlpx-app-gate"
+    dest: "/home/delphix/dlpx-app-gate"
     version: "develop"
     accept_hostkey: yes
     update: no
   when: lookup('env', 'GITHUB_TOKEN') != ''
 
 - file:
-    path: "/export/home/delphix/{{ item }}"
+    path: "/home/delphix/{{ item }}"
     owner: delphix
     group: staff
     mode: "g+w"

--- a/live-build/misc/ansible-roles/appliance-build.zfsonlinux-development/tasks/main.yml
+++ b/live-build/misc/ansible-roles/appliance-build.zfsonlinux-development/tasks/main.yml
@@ -1,5 +1,5 @@
 #
-# Copyright 2018 Delphix
+# Copyright 2018, 2025 Delphix
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -67,26 +67,26 @@
 - git:
     repo: "https://{{ lookup('env', 'GITHUB_TOKEN') }}@github.com/delphix/zfs.git"
     dest:
-      "/export/home/delphix/zfs"
+      "/home/delphix/zfs"
     version: develop
     accept_hostkey: yes
     update: no
   when: lookup('env', 'GITHUB_TOKEN') != ''
 
 - file:
-    path: "/export/home/delphix/zfs"
+    path: "/home/delphix/zfs"
     owner: delphix
     group: staff
     state: directory
     recurse: yes
 
 - file:
-    path: "/export/home/delphix/.cargo/"
+    path: "/home/delphix/.cargo/"
     state: directory
     owner: delphix
     group: staff
 - copy:
-    dest: "/export/home/delphix/.cargo/config.toml"
+    dest: "/home/delphix/.cargo/config.toml"
     content: |
         [target.x86_64-unknown-linux-gnu]
         rustflags = ["-C", "link-arg=-B/usr/libexec/mold"]

--- a/live-build/misc/ansible-roles/appliance-build.zfsonlinux-development/tasks/main.yml
+++ b/live-build/misc/ansible-roles/appliance-build.zfsonlinux-development/tasks/main.yml
@@ -1,5 +1,5 @@
 #
-# Copyright 2018, 2025 Delphix
+# Copyright 2018, 2026 Delphix
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/upgrade/FAQ.md
+++ b/upgrade/FAQ.md
@@ -89,7 +89,7 @@ resemble the following:
 
 A "rootfs container" is a collection of ZFS datasets that can be used as
 the "root filesytsem" of the appliance. This includes a dataset for "/"
-of the appliance, but also seperate datasets for "/export/home" and
+of the appliance, but also seperate datasets for "/home" and
 "/var/delphix".
 
 Here's an example of the datasets for a rootfs container:

--- a/upgrade/upgrade-scripts/common.sh
+++ b/upgrade/upgrade-scripts/common.sh
@@ -530,3 +530,40 @@ function fix_and_migrate_services() {
 		telegraf.service
 	EOF
 }
+
+
+function update_fstab_for_upgrade() {
+  # shellcheck disable=SC2155
+  fstab_backup="/etc/fstab.bak.$(date +%s)"
+
+  # Backup current fstab
+  cp /etc/fstab "$fstab_backup" || die "failed to backup /etc/fstab to $fstab_backup"
+
+  # Update legacy /export/home paths to /home
+  sed -i 's|/export/home|/home|g' /etc/fstab /etc/passwd || warn "failed to update legacy /export/home paths"
+
+  # Add nodev,nosuid only if not already present
+  if grep -qE '^[^#].*\s/home\s' /etc/fstab; then
+    if ! grep -qE '^[^#].*\s/home\s.*nodev' /etc/fstab || \
+      ! grep -qE '^[^#].*\s/home\s.*nosuid' /etc/fstab; then
+        sed -i '/^[^#].*\s\/home\s/ s/defaults/defaults,nodev,nosuid/' /etc/fstab
+    fi
+  fi
+
+  # Ensure /home directory exists
+  mkdir -p /home || die "failed to create /home directory"
+
+  # Attempt to mount /home with new flags
+  if ! mount /home 2>/dev/null; then
+    warn "failed to mount /home with new fstab configuration"
+  fi
+
+  # Validate the entire fstab by attempting to mount all entries
+  if ! mount -a 2>/dev/null; then
+    warn "fstab validation failed, restoring backup"
+    cp "$fstab_backup" /etc/fstab || die "failed to restore fstab backup from $fstab_backup"
+    die "fstab modification failed validation; backup restored"
+  fi
+
+  echo "Successfully updated /etc/fstab with security compliance flags (nodev,nosuid)"
+}

--- a/upgrade/upgrade-scripts/common.sh
+++ b/upgrade/upgrade-scripts/common.sh
@@ -542,14 +542,6 @@ function update_fstab_for_upgrade() {
   # Update legacy /export/home paths to /home
   sed -i 's|/export/home|/home|g' /etc/fstab /etc/passwd || warn "failed to update legacy /export/home paths"
 
-  # Add nodev,nosuid only if not already present
-  if grep -qE '^[^#].*\s/home\s' /etc/fstab; then
-    if ! grep -qE '^[^#].*\s/home\s.*nodev' /etc/fstab || \
-      ! grep -qE '^[^#].*\s/home\s.*nosuid' /etc/fstab; then
-        sed -i '/^[^#].*\s\/home\s/ s/defaults/defaults,nodev,nosuid/' /etc/fstab
-    fi
-  fi
-
   # Ensure /home directory exists
   mkdir -p /home || die "failed to create /home directory"
 

--- a/upgrade/upgrade-scripts/common.sh
+++ b/upgrade/upgrade-scripts/common.sh
@@ -530,32 +530,3 @@ function fix_and_migrate_services() {
 		telegraf.service
 	EOF
 }
-
-
-function update_fstab_for_upgrade() {
-  # shellcheck disable=SC2155
-  fstab_backup="/etc/fstab.bak.$(date +%s)"
-
-  # Backup current fstab
-  cp /etc/fstab "$fstab_backup" || die "failed to backup /etc/fstab to $fstab_backup"
-
-  # Update legacy /export/home paths to /home
-  sed -i 's|/export/home|/home|g' /etc/fstab /etc/passwd || warn "failed to update legacy /export/home paths"
-
-  # Ensure /home directory exists
-  mkdir -p /home || die "failed to create /home directory"
-
-  # Attempt to mount /home with new flags
-  if ! mount /home 2>/dev/null; then
-    warn "failed to mount /home with new fstab configuration"
-  fi
-
-  # Validate the entire fstab by attempting to mount all entries
-  if ! mount -a 2>/dev/null; then
-    warn "fstab validation failed, restoring backup"
-    cp "$fstab_backup" /etc/fstab || die "failed to restore fstab backup from $fstab_backup"
-    die "fstab modification failed validation; backup restored"
-  fi
-
-  echo "Successfully updated /etc/fstab with security compliance flags (nodev,nosuid)"
-}

--- a/upgrade/upgrade-scripts/execute
+++ b/upgrade/upgrade-scripts/execute
@@ -183,13 +183,6 @@ if [[ -n "$CURRENT_VERSION" ]]; then
 	[[ -n "$ROOTFS_CONTAINER" ]] ||
 		die "unable to determine currently mounted rootfs container"
 
-  #
-  # Update fstab for security compliance before performing any upgrade
-  # operations. This ensures the system is properly configured before
-  # package installation and snapshot creation.
-  #
-  update_fstab_for_upgrade
-
 	#
 	# It's possible for this script to be run multiple times,
 	# and each time this script is run, we want to keep a
@@ -226,6 +219,32 @@ if [[ -n "$CURRENT_VERSION" ]]; then
 		"$ROOTFS_CONTAINER" "$ROOTFS_CONTAINER@execute-upgrade.$UNIQUE"
 	copy_optional_dataset_property "$PROP_PACKAGED_APP_VERSION" \
 		"$ROOTFS_CONTAINER" "$ROOTFS_CONTAINER@execute-upgrade.$UNIQUE"
+fi
+
+#
+# Home directories were previously mounted under /export/home, and this was
+# changed to /home. This upgrade logic updates the /etc/fstab and /etc/passwd
+# files to reflect that change.
+#
+# Home directories will be mounted in both /export/home and /home until the
+# system is rebooted to ensure that running processes referencing the old
+# /export/home paths continue to function while also enabling new logins
+# under /home to work.
+#
+# This check only runs outside a container and during upgrades, consistent
+# with the pattern used for the GRUB and nodev/nosuid updates.
+#
+if [[ -n "$CURRENT_VERSION" ]] && ! systemd-detect-virt -qc; then
+	if grep -q "/export/home" /etc/fstab; then
+		sed -i 's|/export/home|/home|g' /etc/fstab ||
+			die "failed to update /export/home to /home in /etc/fstab"
+		mount /home || die "failed to mount /home"
+	fi
+
+	if grep -q "/export/home" /etc/passwd; then
+		sed -i 's|/export/home|/home|g' /etc/passwd ||
+			die "failed to update /export/home to /home in /etc/passwd"
+	fi
 fi
 
 #
@@ -759,6 +778,25 @@ if ! systemd-detect-virt -qc; then
 
 	"$IMAGE_PATH/rootfs-container" set-bootfs "$ROOTFS_CONTAINER" ||
 		die "failed to set-bootfs '$ROOTFS_CONTAINER'"
+fi
+
+#
+# Ensure nodev and nosuid mount options are present for the /home entry
+# in /etc/fstab on the running host system. This is required for CIS
+# compliance on systems being upgraded that predate this hardening.
+# New upgrade containers already have these options set by upgrade-container.
+# This check is idempotent and only runs outside a container, consistent
+# with the pattern used for the GRUB update above.
+#
+if ! systemd-detect-virt -qc; then
+	if grep -qE '^[^#].*[[:space:]]/home[[:space:]]' /etc/fstab; then
+		if ! grep -qE '^[^#].*[[:space:]]/home[[:space:]].*nodev' /etc/fstab ||
+			! grep -qE '^[^#].*[[:space:]]/home[[:space:]].*nosuid' /etc/fstab; then
+			sed -i '/^[^#].*[[:space:]]\/home[[:space:]]/ s/defaults/defaults,nodev,nosuid/' \
+				/etc/fstab ||
+				die "failed to add nodev,nosuid to /home entry in /etc/fstab"
+		fi
+	fi
 fi
 
 systemctl reload delphix-platform.service ||

--- a/upgrade/upgrade-scripts/execute
+++ b/upgrade/upgrade-scripts/execute
@@ -183,6 +183,13 @@ if [[ -n "$CURRENT_VERSION" ]]; then
 	[[ -n "$ROOTFS_CONTAINER" ]] ||
 		die "unable to determine currently mounted rootfs container"
 
+  #
+  # Update fstab for security compliance before performing any upgrade
+  # operations. This ensures the system is properly configured before
+  # package installation and snapshot creation.
+  #
+  update_fstab_for_upgrade
+
 	#
 	# It's possible for this script to be run multiple times,
 	# and each time this script is run, we want to keep a

--- a/upgrade/upgrade-scripts/upgrade-container
+++ b/upgrade/upgrade-scripts/upgrade-container
@@ -212,19 +212,19 @@ function create_upgrade_container() {
 	# associated with that rootfs dataset. The mounts need to happen
 	# before the zfs-import service is run.
 	#
-	cat <<-EOF >"$DIRECTORY/etc/fstab"
-		rpool/ROOT/$CONTAINER/home /home zfs defaults,nodev,nosuid,x-systemd.before=zfs-import-cache.service 0 0
-		rpool/ROOT/$CONTAINER/data /var/delphix zfs defaults,x-systemd.before=zfs-import-cache.service 0 0
-		rpool/ROOT/$CONTAINER/log  /var/log     zfs defaults,x-systemd.before=zfs-import-cache.service 0 0
-		rpool/crashdump            /var/crash   zfs defaults,x-systemd.before=zfs-import-cache.service,x-systemd.before=kdump-tools.service 0 0
-	EOF
+    cat <<-EOF >"$DIRECTORY/etc/fstab"
+      rpool/ROOT/$CONTAINER/home /home zfs defaults,nodev,nosuid,x-systemd.before=zfs-import-cache.service 0 0
+      rpool/ROOT/$CONTAINER/data /var/delphix zfs defaults,x-systemd.before=zfs-import-cache.service 0 0
+      rpool/ROOT/$CONTAINER/log  /var/log     zfs defaults,x-systemd.before=zfs-import-cache.service 0 0
+      rpool/crashdump            /var/crash   zfs defaults,x-systemd.before=zfs-import-cache.service,x-systemd.before=kdump-tools.service 0 0
+    EOF
 
-	if $TMP_DATASETS_EXIST; then
-		cat <<-EOF >>"$DIRECTORY/etc/fstab"
-			         rpool/ROOT/$CONTAINER/tmp  /tmp         zfs defaults,nosuid,nodev,exec,x-systemd.before=zfs-import-cache.service 0 0
-			         rpool/ROOT/$CONTAINER/vartmp  /var/tmp  zfs defaults,nosuid,nodev,exec,x-systemd.before=zfs-import-cache.service 0 0
-		EOF
-	fi
+    if $TMP_DATASETS_EXIST; then
+      cat <<-EOF >>"$DIRECTORY/etc/fstab"
+                 rpool/ROOT/$CONTAINER/tmp  /tmp         zfs defaults,nosuid,nodev,exec,x-systemd.before=zfs-import-cache.service 0 0
+                 rpool/ROOT/$CONTAINER/vartmp  /var/tmp  zfs defaults,nosuid,nodev,exec,x-systemd.before=zfs-import-cache.service 0 0
+      EOF
+    fi
 
 	#
 	# DLPX-75089 - Since older versions of Delphix did not properly

--- a/upgrade/upgrade-scripts/upgrade-container
+++ b/upgrade/upgrade-scripts/upgrade-container
@@ -213,7 +213,7 @@ function create_upgrade_container() {
 	# before the zfs-import service is run.
 	#
 	cat <<-EOF >"$DIRECTORY/etc/fstab"
-		rpool/ROOT/$CONTAINER/home /home zfs defaults,nodev,x-systemd.before=zfs-import-cache.service 0 0
+		rpool/ROOT/$CONTAINER/home /home zfs defaults,nodev,nosuid,x-systemd.before=zfs-import-cache.service 0 0
 		rpool/ROOT/$CONTAINER/data /var/delphix zfs defaults,x-systemd.before=zfs-import-cache.service 0 0
 		rpool/ROOT/$CONTAINER/log  /var/log     zfs defaults,x-systemd.before=zfs-import-cache.service 0 0
 		rpool/crashdump            /var/crash   zfs defaults,x-systemd.before=zfs-import-cache.service,x-systemd.before=kdump-tools.service 0 0

--- a/upgrade/upgrade-scripts/upgrade-container
+++ b/upgrade/upgrade-scripts/upgrade-container
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright 2018, 2025 Delphix
+# Copyright 2018, 2026 Delphix
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/upgrade/upgrade-scripts/upgrade-container
+++ b/upgrade/upgrade-scripts/upgrade-container
@@ -177,7 +177,7 @@ function create_upgrade_container() {
 		-o mountpoint=legacy \
 		"$ROOTFS_DATASET/home@$SNAPSHOT_NAME" \
 		"rpool/ROOT/$CONTAINER/home" ||
-		die "failed to create upgrade /export/home clone"
+		die "failed to create upgrade /home clone"
 
 	zfs clone \
 		-o mountpoint=legacy \
@@ -213,7 +213,7 @@ function create_upgrade_container() {
 	# before the zfs-import service is run.
 	#
 	cat <<-EOF >"$DIRECTORY/etc/fstab"
-		rpool/ROOT/$CONTAINER/home /export/home zfs defaults,x-systemd.before=zfs-import-cache.service 0 0
+		rpool/ROOT/$CONTAINER/home /home zfs defaults,nodev,x-systemd.before=zfs-import-cache.service 0 0
 		rpool/ROOT/$CONTAINER/data /var/delphix zfs defaults,x-systemd.before=zfs-import-cache.service 0 0
 		rpool/ROOT/$CONTAINER/log  /var/log     zfs defaults,x-systemd.before=zfs-import-cache.service 0 0
 		rpool/crashdump            /var/crash   zfs defaults,x-systemd.before=zfs-import-cache.service,x-systemd.before=kdump-tools.service 0 0

--- a/upgrade/upgrade-scripts/upgrade-container
+++ b/upgrade/upgrade-scripts/upgrade-container
@@ -212,19 +212,19 @@ function create_upgrade_container() {
 	# associated with that rootfs dataset. The mounts need to happen
 	# before the zfs-import service is run.
 	#
-    cat <<-EOF >"$DIRECTORY/etc/fstab"
-      rpool/ROOT/$CONTAINER/home /home zfs defaults,nodev,nosuid,x-systemd.before=zfs-import-cache.service 0 0
-      rpool/ROOT/$CONTAINER/data /var/delphix zfs defaults,x-systemd.before=zfs-import-cache.service 0 0
-      rpool/ROOT/$CONTAINER/log  /var/log     zfs defaults,x-systemd.before=zfs-import-cache.service 0 0
-      rpool/crashdump            /var/crash   zfs defaults,x-systemd.before=zfs-import-cache.service,x-systemd.before=kdump-tools.service 0 0
-    EOF
+	cat <<-EOF >"$DIRECTORY/etc/fstab"
+		rpool/ROOT/$CONTAINER/home /home zfs defaults,nodev,nosuid,x-systemd.before=zfs-import-cache.service 0 0
+		rpool/ROOT/$CONTAINER/data /var/delphix zfs defaults,x-systemd.before=zfs-import-cache.service 0 0
+		rpool/ROOT/$CONTAINER/log  /var/log     zfs defaults,x-systemd.before=zfs-import-cache.service 0 0
+		rpool/crashdump            /var/crash   zfs defaults,x-systemd.before=zfs-import-cache.service,x-systemd.before=kdump-tools.service 0 0
+	EOF
 
-    if $TMP_DATASETS_EXIST; then
-      cat <<-EOF >>"$DIRECTORY/etc/fstab"
-                 rpool/ROOT/$CONTAINER/tmp  /tmp         zfs defaults,nosuid,nodev,exec,x-systemd.before=zfs-import-cache.service 0 0
-                 rpool/ROOT/$CONTAINER/vartmp  /var/tmp  zfs defaults,nosuid,nodev,exec,x-systemd.before=zfs-import-cache.service 0 0
-      EOF
-    fi
+	if $TMP_DATASETS_EXIST; then
+		cat <<-EOF >>"$DIRECTORY/etc/fstab"
+			         rpool/ROOT/$CONTAINER/tmp  /tmp         zfs defaults,nosuid,nodev,exec,x-systemd.before=zfs-import-cache.service 0 0
+			         rpool/ROOT/$CONTAINER/vartmp  /var/tmp  zfs defaults,nosuid,nodev,exec,x-systemd.before=zfs-import-cache.service 0 0
+		EOF
+	fi
 
 	#
 	# DLPX-75089 - Since older versions of Delphix did not properly


### PR DESCRIPTION
<!--
<details open>
<summary><h2> Background </h2></summary>

Provide a clear description of the high-level effort with which this
pull request is associated. Recall that while anyone in the organization
can see this pull request, not everyone necessarily has the same context
as you. If applicable, link to design documents or high-level tracking
epics here.
</details>
-->

<details open>
<summary><h2> Problem </h2></summary>

CIS is looking or a single home directory filesystem mounted at the `/home` location, currently we have the home dataset is mounted on `/export/home`

Due to that we see the below issues in the CIS Report

- (1.45) 7402 Status of the '/home' partition in the '/etc/fstab' file
- (1.46) 13248 Status of Mount Partition '/home' using mount command
- (1.47) 7403 Status of the 'nodev' mount option setting for the '/home partition' defined in the '/etc/ fstab' file
- (1.48) 14601 Status of the 'nodev' option for '/home' partition using 'mount' command

</details>

<!--
<details>
<summary><h2> Evaluation </h2></summary>

If the cause of the problem is not obvious, provide a root-cause
analysis (RCA), ideally using the Five Whys iterative interrogative
technique or some other form of analytical reasoning.
</details>
-->

<details open>
<summary><h2> Solution </h2></summary>
Mounting the home dataset to `/home`.

- Upgrade scripts are modified to mount the data set to a new mount path.
- Ansible scripts modified for new home mount path.

</details>


<details>
<summary><h2> Testing Done </h2></summary>

I have worked on suggestions on PR(s) and posted new changes -

- [delphix-platform/pull/477](https://github.com/delphix/delphix-platform/pull/477)
- [appliance-build/pull/756](https://github.com/delphix/appliance-build/pull/756)

**The major changes  are** 
- delphix-platform - movement of the logic inside the  debian/preinst  to appliance-build 
- A major concern on executing rmdir /export/home and if that fails taking  a backup of /export/home  - A separate upgrade path is chosen to test this where created a directory with a file /data/data.txt inside the /export/home/delphix and upgraded. 
- Handling of adding the nosuid,nodev  changes for  in  delphix-platform https://github.com/delphix/delphix-platform/blob/4e091fb64368ccd84cd16e179887dfb4ccf2cb11/files/common/var/lib/delphix-platform/ansible/10-delphix-platform/roles/delphix-platform/tasks/main.yml


**Build**: https://selfservice-jenkins.eng-tools-prd.aws.delphixcloud.com/job/appliance-build-orchestrator-pre-push/14047/console 🟢 

- **Manual Upgrade with a unstructured source mounted and a vdb created.** Upgrades are tested from 2026.3.0.0 to develop[s3://dev-de-images/builds/jenkins-selfservice/appliance-build/develop/pre-push/6578/upgrade-artifacts/internal-qa.upgrade.tar]
  - [dlpx-qa-2026300-qar-215365-766f97e2.dlpxdc.co](http://dlpx-qa-2026300-qar-217654-766f97e2.dlpxdc.co) 🟢 


- **fstab for upgraded engines, has nosuid and nodev** ✅ 
````
delphix@ip-10-110-197-250:~$ cat /etc/fstab
rpool/ROOT/delphix.qCL48gW/home /home zfs defaults,nodev,nosuid,x-systemd.before=zfs-import-cache.service 0 0
rpool/ROOT/delphix.qCL48gW/data /var/delphix zfs defaults,x-systemd.before=zfs-import-cache.service 0 0
rpool/ROOT/delphix.qCL48gW/log  /var/log     zfs defaults,x-systemd.before=zfs-import-cache.service 0 0
rpool/ROOT/delphix.qCL48gW/tmp  /tmp     zfs defaults,nosuid,nodev,exec,x-systemd.before=zfs-import-cache.service 0 0
rpool/ROOT/delphix.qCL48gW/vartmp  /var/tmp     zfs defaults,nosuid,nodev,exec,x-systemd.before=zfs-import-cache.service 0 0
rpool/crashdump  /var/crash     zfs defaults,x-systemd.before=zfs-import-cache.service,x-systemd.before=kdump-tools.service 0 0
tmpfs /dev/shm tmpfs defaults,noexec,nosuid,nodev 0 0
delphix@ip-10-110-197-250:~$ 
````
- **Symlink Check** ✅ 
````
delphix@ip-10-110-197-250:~$ ls -ltr /export/
total 1
lrwxrwxrwx 1 root root 5 May 27 17:41 home -> /home
delphix@ip-10-110-197-250:~$ 
````



**New Engine**: sr-dev01.dlpxdc.co
- **fstab for new engine, has nosuid and nodev** ✅ 
````
delphix@ip-10-110-223-101:~$ cat /etc/fstab
rpool/ROOT/delphix.pYi7i0b/home /home zfs defaults,nodev,nosuid,x-systemd.before=zfs-import-cache.service 0 0
rpool/ROOT/delphix.pYi7i0b/data /var/delphix zfs defaults,x-systemd.before=zfs-import-cache.service 0 0
rpool/ROOT/delphix.pYi7i0b/log  /var/log     zfs defaults,x-systemd.before=zfs-import-cache.service 0 0
rpool/ROOT/delphix.pYi7i0b/tmp  /tmp     zfs defaults,nosuid,nodev,exec,x-systemd.before=zfs-import-cache.service 0 0
rpool/ROOT/delphix.pYi7i0b/vartmp  /var/tmp     zfs defaults,nosuid,nodev,exec,x-systemd.before=zfs-import-cache.service 0 0
rpool/crashdump  /var/crash     zfs defaults,x-systemd.before=zfs-import-cache.service,x-systemd.before=kdump-tools.service 0 0
tmpfs /dev/shm tmpfs defaults,noexec,nosuid,nodev 0 0
delphix@ip-10-110-223-101:~$ 
````
- **Symlink Check** ✅ 
````
delphix@ip-10-110-223-101:~$ ls -ltr /export/
total 1
lrwxrwxrwx 1 root root 5 May 27 15:42 home -> /home
delphix@ip-10-110-223-101:~$ 
````


-----------------
✳️ ✳️ ✳️ ✳️ ✳️ New SCA scan updates [Please note that with Ubuntu 24.04 , there are changes in the CIS test, we have Ran the CIS Scans now with a new policy. The controls **7402** , **7403**, **14601** and **13248** are not present in the new policy instead we have 3 new controls.]

- 29044 - 🟢 
- 29045 - 🟢 
- 29046 - 🟢 

[Compliance_Report_cisScanReport01_perfr3sr2_20260116.pdf](https://github.com/user-attachments/files/24664096/Compliance_Report_cisScanReport01_perfr3sr2_20260116.pdf)

------------


**Build**: `git ab-pre-push` : [appliance-build-orchestrator-pre-push/12953/](https://selfservice-jenkins.eng-tools-prd.aws.delphixcloud.com/job/appliance-build-orchestrator-pre-push/12953/console) - ✅ 


**New Engine**
- dlpxdevsr001.dlpxdc.co - 🟢 

Here, In a new engine we have successfully overcome the issue of backup dir creation problem observed with the last build.
````
 % ssh delphix@dlpxdevsr001.dlpxdc.co
Warning: Permanently added 'dlpxdevsr001.dlpxdc.co' (ED25519) to the list of known hosts.
(delphix@dlpxdevsr001.dlpxdc.co) Password: 
delphix@ip-10-110-227-161:~$ 
delphix@ip-10-110-227-161:~$ ls -ltr /export/
total 1
lrwxrwxrwx 1 root root 5 Jan 13 06:00 home -> /home
delphix@ip-10-110-227-161:~$ 

````



**Manual Upgrades** 
- http://dlpx2026100cis5762.dlpxdc.co/login/index.html - 🟢  
- http://dlpx2026100cis5762-0.dlpxdc.co/login/index.html - 🟢  [Before upgrade a unstructured datasource was created and a VDB was also created, After upgrade the dsource/VDB were online and mounted.]



**`sudo lsof +f -- /export/home`** results below shows that all active file handles are actually pointing to: `/home/delphix`. This means:
- The Delphix services are not using /export/home directly
- They are operating on /home/delphix

````
delphix@ip-10-110-239-15:~$  sudo lsof +f -- /export/home
COMMAND      PID    USER   FD   TYPE DEVICE SIZE/OFF NODE NAME
delphix-s   2133    root  cwd    DIR   0,40        8    3 /home/delphix
delphix-s   2138    root  cwd    DIR   0,40        8    3 /home/delphix
delphix-s   2139    root  cwd    DIR   0,40        8    3 /home/delphix
delphix-s   2141    root  cwd    DIR   0,40        8    3 /home/delphix
delphix-s   2150    root  cwd    DIR   0,40        8    3 /home/delphix
delphix-s   2157    root  cwd    DIR   0,40        8    3 /home/delphix
delphix-s   2164    root  cwd    DIR   0,40        8    3 /home/delphix
delphix-s   2207    root  cwd    DIR   0,40        8    3 /home/delphix
delphix-s   2208    root  cwd    DIR   0,40        8    3 /home/delphix
delphix-s   2209    root  cwd    DIR   0,40        8    3 /home/delphix
delphix-s   2244    root  cwd    DIR   0,40        8    3 /home/delphix
delphix-s   2250    root  cwd    DIR   0,40        8    3 /home/delphix
delphix-s   2253    root  cwd    DIR   0,40        8    3 /home/delphix
delphix-s   2257    root  cwd    DIR   0,40        8    3 /home/delphix
delphix-s   2258    root  cwd    DIR   0,40        8    3 /home/delphix
delphix-s   2260    root  cwd    DIR   0,40        8    3 /home/delphix
delphix-s   2263    root  cwd    DIR   0,40        8    3 /home/delphix
delphix-s   2270    root  cwd    DIR   0,40        8    3 /home/delphix
delphix-s   2292    root  cwd    DIR   0,40        8    3 /home/delphix
delphix-s   2307    root  cwd    DIR   0,40        8    3 /home/delphix
delphix-s   2309    root  cwd    DIR   0,40        8    3 /home/delphix
delphix-s   2318    root  cwd    DIR   0,40        8    3 /home/delphix
delphix-s   2335    root  cwd    DIR   0,40        8    3 /home/delphix
nfs_delet   2337    root  cwd    DIR   0,40        8    3 /home/delphix
bpftrace    2602    root  cwd    DIR   0,40        8    3 /home/delphix
nfs_delet   2603    root  cwd    DIR   0,40        8    3 /home/delphix
java        4364    root  cwd    DIR   0,40        8    3 /home/delphix
python3     5191    root  cwd    DIR   0,40        8    3 /home/delphix
python3     5195    root  cwd    DIR   0,40        8    3 /home/delphix
python3     5199    root  cwd    DIR   0,40        8    3 /home/delphix
python3     5203    root  cwd    DIR   0,40        8    3 /home/delphix
timeout   112744    root  cwd    DIR   0,40        8    3 /home/delphix
iostat    112745    root  cwd    DIR   0,40        8    3 /home/delphix
timeout   112747    root  cwd    DIR   0,40        8    3 /home/delphix
vmstat    112748    root  cwd    DIR   0,40        8    3 /home/delphix
timeout   112750    root  cwd    DIR   0,40        8    3 /home/delphix
zpool     112751    root  cwd    DIR   0,40        8    3 /home/delphix
timeout   112757    root  cwd    DIR   0,40        8    3 /home/delphix
zpool     112758    root  cwd    DIR   0,40        8    3 /home/delphix
sleep     113720    root  cwd    DIR   0,40        8    3 /home/delphix
sleep     114212    root  cwd    DIR   0,40        8    3 /home/delphix
sleep     114216    root  cwd    DIR   0,40        8    3 /home/delphix
sleep     114222    root  cwd    DIR   0,40        8    3 /home/delphix
sleep     114335    root  cwd    DIR   0,40        8    3 /home/delphix
timeout   114525    root  cwd    DIR   0,40        8    3 /home/delphix
mpstat    114526    root  cwd    DIR   0,40        8    3 /home/delphix
sleep     114689    root  cwd    DIR   0,40        8    3 /home/delphix
sleep     114690    root  cwd    DIR   0,40        8    3 /home/delphix
timeout   114874    root  cwd    DIR   0,40        8    3 /home/delphix
profile-b 114875    root  cwd    DIR   0,40        8    3 /home/delphix
sleep     114952    root  cwd    DIR   0,40        8    3 /home/delphix
sleep     114960    root  cwd    DIR   0,40        8    3 /home/delphix
sleep     114964    root  cwd    DIR   0,40        8    3 /home/delphix
sleep     114968    root  cwd    DIR   0,40        8    3 /home/delphix
sleep     114972    root  cwd    DIR   0,40        8    3 /home/delphix
sleep     114976    root  cwd    DIR   0,40        8    3 /home/delphix
sleep     114992    root  cwd    DIR   0,40        8    3 /home/delphix
supportlo 115096 delphix  cwd    DIR   0,40        8    3 /home/delphix
supportlo 115109 delphix  cwd    DIR   0,40        8    3 /home/delphix
script    115110 delphix  cwd    DIR   0,40        8    3 /home/delphix
bash      115111 delphix  cwd    DIR   0,40        8    3 /home/delphix
sleep     115123    root  cwd    DIR   0,40        8    3 /home/delphix
sleep     115129    root  cwd    DIR   0,40        8    3 /home/delphix
sleep     115134    root  cwd    DIR   0,40        8    3 /home/delphix
sudo      115144    root  cwd    DIR   0,40        8    3 /home/delphix
sudo      115145    root  cwd    DIR   0,40        8    3 /home/delphix
lsof      115146    root  cwd    DIR   0,40        8    3 /home/delphix
lsof      115147    root  cwd    DIR   0,40        8    3 /home/delphix
delphix@ip-10-110-239-15:~$ 
````



**The `/export/home -> /home`** is a symbolic link pointing from /export/home to /home. This means:
- Any access to /export/home is transparently redirected to /home
- /export/home/delphix is actually /home/delphix
- There is no separate filesystem or directory tree under /export/home


````
delphix@ip-10-110-239-15:~$ ls -ltr /export/
total 1
lrwxrwxrwx 1 root root 5 Jan 13 05:25 home -> /home
delphix@ip-10-110-239-15:~$ 
````


</details>

<!--
<details>
<summary><h2> Implementation </h2></summary>

Describe the implementation details of the solution. Generally the
reasoning behind any non-obvious code should be recorded in code
comments. However, code comments should always describe the current
state of the code; in contrast, this section may be useful to describe
the relationship between the original code and the code being proposed
in this pull request.
</details>

<--
<details>
<summary><h2> Notes to Reviewers </h2></summary>
</details>
-->

<!--
<details>
<summary><h2> Deployment Plan </h2></summary>

Describe how the code in this pull request will be deployed. Some
deployments are complicated and may require flag days between multiple
repositories or the provisioning of new infrastructure. Describing your
deployment plan allows reviewers to ensure that your work will not cause
any unnecessary interruption to end users.
</details>
-->

<!--
<details>
<summary><h2> Future Work </h2></summary>

Provide a description of any possible follow-up work that is explicitly
not being done in this pull request.
</details>
-->

<!--
<details>
<summary><h2> Bonus </h2></summary>

Provide a description of any extra problems you have solved in this pull
request.
</details>
-->
