### PR TITLE
DLPX-90976 add "--debug-image=all" to grub-install

### DIFF
--- a/upgrade/upgrade-scripts/rootfs-container
+++ b/upgrade/upgrade-scripts/rootfs-container
@@ -153,7 +153,8 @@ function set_bootfs_not_mounted() {
 			die "bootloader device '/dev/$dev' not block device"
 
 		chroot "/var/lib/machines/$CONTAINER" \
-			grub-install --root-directory=/mnt "/dev/$dev" ||
+			grub-install -v --debug-image=all \
+			--root-directory=/mnt "/dev/$dev" ||
 			die "'grub-install' for '$dev' failed in '$CONTAINER'"
 	done
 
@@ -206,7 +207,8 @@ function set_bootfs_mounted() {
 		[[ -b "/dev/$dev" ]] ||
 			die "bootloader device '/dev/$dev' not block device"
 
-		grub-install --root-directory=/mnt "/dev/$dev" ||
+		grub-install -v --debug-image=all \
+			--root-directory=/mnt "/dev/$dev" ||
 			die "'grub-install' for '$dev' failed in '$CONTAINER'"
 	done
 


### PR DESCRIPTION
To help try and debug our grub/boot problems, this PR adds "--debug-image=all" when installing the bootloader. This will cause more debug output to be emitted during boot; it's unclear if this output will help us root cause, but it shouldn't hurt.

- `git-ab-pre-push` is [here](http://selfservice.jenkins.delphix.com/job/appliance-build-orchestrator-pre-push/8443/)
