### PR TITLE
DLPX-91182 [Backport of DLPX-91169] Full upgrade failed from 22.0 to 23.0 (AWS) because the engine become unresponsive during finish_deferred step.

### DIFF
--- a/upgrade/upgrade-scripts/rootfs-container
+++ b/upgrade/upgrade-scripts/rootfs-container
@@ -153,8 +153,7 @@ function set_bootfs_not_mounted() {
 			die "bootloader device '/dev/$dev' not block device"
 
 		chroot "/var/lib/machines/$CONTAINER" \
-			grub-install -v --debug-image=all \
-			--root-directory=/mnt "/dev/$dev" ||
+			grub-install --root-directory=/mnt "/dev/$dev" ||
 			die "'grub-install' for '$dev' failed in '$CONTAINER'"
 	done
 
@@ -207,8 +206,7 @@ function set_bootfs_mounted() {
 		[[ -b "/dev/$dev" ]] ||
 			die "bootloader device '/dev/$dev' not block device"
 
-		grub-install -v --debug-image=all \
-			--root-directory=/mnt "/dev/$dev" ||
+		grub-install --root-directory=/mnt "/dev/$dev" ||
 			die "'grub-install' for '$dev' failed in '$CONTAINER'"
 	done
 


### PR DESCRIPTION
clean backport of https://github.com/delphix/appliance-build/pull/760

- `git-ab-pre-push` is [here](http://selfservice.jenkins.delphix.com/job/appliance-build-orchestrator-pre-push/8596/)