### PR TITLE
DLPX-91309 Add debug to grub for ESX and OCI platforms

### DIFF
--- a/upgrade/upgrade-scripts/rootfs-container
+++ b/upgrade/upgrade-scripts/rootfs-container
@@ -145,6 +145,8 @@ function set_bootfs_not_mounted() {
 	mount -t zfs rpool/grub "/var/lib/machines/$CONTAINER/mnt" ||
 		die "'mount -t zfs rpool/grub' failed for '$CONTAINER'"
 
+	PLATFORM=$(get_appliance_platform)
+
 	for dev in $(get_bootloader_devices); do
 		[[ -e "/dev/$dev" ]] ||
 			die "bootloader device '/dev/$dev' not found"
@@ -152,8 +154,16 @@ function set_bootfs_not_mounted() {
 		[[ -b "/dev/$dev" ]] ||
 			die "bootloader device '/dev/$dev' not block device"
 
+		opts="--root-directory=/mnt"
+
+		if [[ "$PLATFORM" == "esx" ]] || [[ "$PLATFORM" == "oci" ]]; then
+			opts+=" --debug-image=all"
+			opts+=" -v"
+		fi
+
+		# shellcheck disable=SC2086
 		chroot "/var/lib/machines/$CONTAINER" \
-			grub-install --root-directory=/mnt "/dev/$dev" ||
+			grub-install $opts "/dev/$dev" ||
 			die "'grub-install' for '$dev' failed in '$CONTAINER'"
 	done
 
@@ -199,6 +209,8 @@ function set_bootfs_mounted() {
 	mount -t zfs rpool/grub "/mnt" ||
 		die "'mount -t zfs rpool/grub' failed for '$CONTAINER'"
 
+	PLATFORM=$(get_appliance_platform)
+
 	for dev in $(get_bootloader_devices); do
 		[[ -e "/dev/$dev" ]] ||
 			die "bootloader device '/dev/$dev' not found"
@@ -206,7 +218,15 @@ function set_bootfs_mounted() {
 		[[ -b "/dev/$dev" ]] ||
 			die "bootloader device '/dev/$dev' not block device"
 
-		grub-install --root-directory=/mnt "/dev/$dev" ||
+		opts="--root-directory=/mnt"
+
+		if [[ "$PLATFORM" == "esx" ]] || [[ "$PLATFORM" == "oci" ]]; then
+			opts+=" --debug-image=all"
+			opts+=" -v"
+		fi
+
+		# shellcheck disable=SC2086
+		grub-install $opts "/dev/$dev" ||
 			die "'grub-install' for '$dev' failed in '$CONTAINER'"
 	done
 


### PR DESCRIPTION
Reapply #759 but only on the 2 platforms we've been able to reproduce internally on, and not on the platform that we found that it was problematic (AWS).

- `git-ab-pre-push` is [here](http://selfservice.jenkins.delphix.com/job/appliance-build-orchestrator-pre-push/8693/)