### PR TITLE
DLPX-91390 mount /proc during appliance-build when running ansible

### DIFF
--- a/live-build/config/hooks/configuration/80-build-configuration.binary
+++ b/live-build/config/hooks/configuration/80-build-configuration.binary
@@ -29,7 +29,16 @@ if [[ -e /etc/resolv.conf ]]; then
 	cp /etc/resolv.conf binary/etc/resolv.conf
 fi
 
+for dir in /proc /sys /dev; do
+	mount --rbind "$dir" "binary/${dir}"
+	mount --make-rslave "binary/${dir}"
+done
+
 ansible-playbook -vv -c chroot -i binary, ansible/playbook.yml
+
+for dir in /proc /sys /dev; do
+	umount -R "binary/${dir}"
+done
 
 if [[ -e binary/etc/resolv.conf ]]; then
 	rm binary/etc/resolv.conf


### PR DESCRIPTION
### Problem

The `ca-certificates-java` package fails to install when it's installed inside of a chroot environment that does not have a `/proc` available within the chroot. As part of installing Java 17, that package is pulled in as a dependency, and fails to install.

### Solution

The solution taken in this PR, is to bind mount `/proc` (and a couple other related directories) into the chroot environment, so that when the `ca-certificates-java` package is installed as a dependency of the `delphix-masking` package, `/proc` will be available and allow the install to succeed.

### Testing

Verified this works in conjunction with https://github.com/delphix/dms-core-gate/pull/1295