### PR TITLE
DLPX-91434 cloud-init config to disable it should be copied due to conflict with upstream naming found in DLPX-91387

### DIFF
--- a/upgrade/upgrade-scripts/execute
+++ b/upgrade/upgrade-scripts/execute
@@ -345,8 +345,8 @@ apt-mark manual "delphix-entire-$opt_p" ||
 #
 # In DLPX-91387, we discovered that cloud-init's preinst script was
 # removing '/etc/cloud/cloud.cfg.d/99-disable-network-config.cfg', which
-# was created by created by the delphix-osadmin service to disable
-# cloud-init from overwriting the netplan file after the initial boot.
+# was created by the delphix-osadmin service to disable cloud-init from
+# overwriting the netplan file after the initial boot.
 # To prevent this from happening, DLPX-91387 renamed the file to
 # '99-delphix-disable-network-config.cfg'. Here, we copy the file to the new location
 # before installing the new packages so that the upgrade of cloud-init

--- a/upgrade/upgrade-scripts/execute
+++ b/upgrade/upgrade-scripts/execute
@@ -342,6 +342,23 @@ apt-mark manual "delphix-entire-$opt_p" ||
 [[ -f "/usr/share/doc/delphix-entire-$opt_p/packages.list.gz" ]] ||
 	die "delphix-entire's packages.list.gz file is missing"
 
+#
+# In DLPX-91387, we discovered that cloud-init's preinst script was
+# removing '/etc/cloud/cloud.cfg.d/99-disable-network-config.cfg', which
+# was created by created by the delphix-osadmin service to disable
+# cloud-init from overwriting the netplan file after the initial boot.
+# To prevent this from happening, DLPX-91387 renamed the file to
+# '99-delphix-disable-network-config.cfg'. Here, we copy the file to the new location
+# before installing the new packages so that the upgrade of cloud-init
+# does not cause this configuration to be lost.
+#
+if [[ -f "/etc/cloud/cloud.cfg.d/99-disable-network-config.cfg" ]]; then
+	cp "/etc/cloud/cloud.cfg.d/99-disable-network-config.cfg" \
+		"/etc/cloud/cloud.cfg.d/99-delphix-disable-network-config.cfg" ||
+		die "failed to copy /etc/cloud/cloud.cfg.d/99-disable-network-config.cfg" \
+			" to /etc/cloud/cloud.cfg.d/99-delphix-disable-network-config.cfg"
+fi
+
 zcat "/usr/share/doc/delphix-entire-$opt_p/packages.list.gz" |
 	xargs_apt_get install -y --allow-downgrades ||
 	die "failed to install packages listed in packages.list.gz file"

--- a/upgrade/upgrade-scripts/upgrade-container
+++ b/upgrade/upgrade-scripts/upgrade-container
@@ -759,6 +759,7 @@ function migrate_configuration() {
 	done <<-EOF
 		/etc/challenge_response.key
 		/etc/cloud/cloud.cfg.d/99-disable-network-config.cfg
+		/etc/cloud/cloud.cfg.d/99-delphix-disable-network-config.cfg
 		/etc/delphix-interface-names.yaml
 		/etc/default/locale
 		/etc/engine-code


### PR DESCRIPTION
<!--
<details open>
<summary><h2> Background </h2></summary>


</details>
-->

<details open>
<summary><h2> Problem </h2></summary>

cloud-init introduced logic to remove a configuration file that our app stack creates and expects
after the first boot. This configuration is supposed to disable cloud-init from overwriting the netplan
file that the app stack creates after the first boot.
Beginning end of May or early June, we started seeing that OCI upgrade runs had failing tests because `delphix-osadmin`
failed to start after the upgrade. `cloud-init`'s upgrade removed the configuration that the osadmin service expected
to be present.
I am still not sure why we have started seeing this now since the upstream changes landed in our fork in July of last year. What I have verified is that the following commit in our repo is a good version (23.4.4):
```
commit 41b9123a50d71d9a5ca708a79a9fe959bc7bb304 (tag: release/23.0.0.0, tag: release/22.0.0.1, tag: release
/22.0.0.0, origin/projects/HF-1365, origin/projects/HF-1361, origin/projects/HF-1359, origin/projects/HF-13
55, origin/projects/HF-1351, origin/patch)
Merge: 5e72921 ad10748
Author: John Wren Kennedy <john.kennedy@delphix.com>
Date:   Mon Mar 4 14:08:40 2024 -0700
```
and this is a bad version (24.1.3):
```
commit 25ce69265022d300f167cea7d92be86e8251bfd4 (origin/release, origin/dlpx/test/___develop___/pgandhi-del
phix/25ce69265022d300f167cea7d92be86e8251bfd4)
Merge: 41b9123 e4a13f5
Author: George Wilson <george.wilson@delphix.com>
Date:   Wed May 29 22:41:14 2024 -0400

    Merge pull request #86 from grwilson/merge

    DLPX-91090 cloud-init merge conflict
```
</details>

<!--
<details>
<summary><h2> Evaluation </h2></summary>

If the cause of the problem is not obvious, provide a root-cause
analysis (RCA), ideally using the Five Whys iterative interrogative
technique or some other form of analytical reasoning.
</details>
-->

<details open>
<summary><h2> Solution </h2></summary>

To resolve the naming conflict, https://github.com/delphix/dlpx-app-gate/pull/2244 renames the file from
`99-disable-network-config.cfg` to `99-delphix-disable-network-config.cfg`. This PR updates the upgrade scripts to
copy the old config file to the new file.
</details>


<details open>
<summary><h2> Testing Done </h2></summary>

ab-pre-push with both changes: http://selfservice.jenkins.delphix.com/job/appliance-build-orchestrator-pre-push/8756/console
OCI upgrade from 24.0 to resulting 25.0 upgrade image: http://selfservice.jenkins.delphix.com/job/blackbox-chained/6508/console
Verified that delphix-osadmin is up and that the cloud-init configuration was copied over.
```
delphix@dlpx-qa-24000-bb-chain-6508-8532dd44-nic-1:~$ sudo systemctl status delphix-osadmin
● delphix-osadmin.service - Delphix osadmin service
     Loaded: loaded (/lib/systemd/system/delphix-osadmin.service; enabled; vendor preset: enabled)
     Active: active (running) since Tue 2024-06-18 05:45:34 UTC; 9h ago

delphix@dlpx-qa-24000-bb-chain-6508-8532dd44-nic-1:~$ get-appliance-version
25.0.0.0-snapshot.20240617223424240+jenkins-selfservice-appliance-build-develop-pre-push-2938

delphix@dlpx-qa-24000-bb-chain-6508-8532dd44-nic-1:~$ get-appliance-platform
oci

delphix@dlpx-qa-24000-bb-chain-6508-8532dd44-nic-1:~$ ls /etc/cloud/cloud.cfg.d/
05_logging.cfg  91-delphix-platform.cfg    99-delphix-disable-network-config.cfg  README
90_dpkg.cfg     99-delphix-datasource.cfg  99-delphix-internal.cfg

delphix@dlpx-qa-24000-bb-chain-6508-8532dd44-nic-1:~$ cat /etc/cloud/cloud.cfg.d/99-delphix-disable-network-config.cfg
---
network:
  config: "disabled"
```
</details>

<!--
<details>
<summary><h2> Implementation </h2></summary>

Describe the implementation details of the solution. Generally the
reasoning behind any non-obvious code should be recorded in code
comments. However, code comments should always describe the current
state of the code; in contrast, this section may be useful to describe
the relationship between the original code and the code being proposed
in this pull request.
</details>
-->

<!--
<details>
<summary><h2> Notes to Reviewers </h2></summary>

Provide any extra information a reviewer may need to know before
evaluating your pull request. For example, you may wish to describe
which files should be reviewed first or which files are auto-generated.
If the review tool cannot detect a file move, you may wish to link to a
patch comparing the old file and the new file.
</details>
-->

<!--
<details>
<summary><h2> Deployment Plan </h2></summary>

Describe how the code in this pull request will be deployed. Some
deployments are complicated and may require flag days between multiple
repositories or the provisioning of new infrastructure. Describing your
deployment plan allows reviewers to ensure that your work will not cause
any unnecessary interruption to end users.
</details>
-->

<!--
<details>
<summary><h2> Future Work </h2></summary>

Provide a description of any possible follow-up work that is explicitly
not being done in this pull request.
</details>
-->

<!--
<details>
<summary><h2> Bonus </h2></summary>

Provide a description of any extra problems you have solved in this pull
request.
</details>
-->
