### PR TITLE
TOOL-25768 Add initial "internal-dct" variant

### DIFF
--- a/live-build/misc/ansible-roles/appliance-build.dct-common/tasks/main.yml
+++ b/live-build/misc/ansible-roles/appliance-build.dct-common/tasks/main.yml
@@ -1,0 +1,20 @@
+#
+# Copyright 2024 Delphix
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+---
+- apt:
+    name: delphix-dct
+    state: present

--- a/live-build/variants/internal-dct/ansible/playbook.yml
+++ b/live-build/variants/internal-dct/ansible/playbook.yml
@@ -1,0 +1,27 @@
+#
+# Copyright 2024 Delphix
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+---
+- hosts: all
+  gather_facts: no
+  vars:
+    ansible_python_interpreter: /usr/bin/python3
+  roles:
+    - appliance-build.minimal-common
+    - appliance-build.minimal-internal
+    - appliance-build.dct-common
+    - appliance-build.masking-common
+    - appliance-build.virtualization-common

--- a/live-build/variants/internal-dct/ansible/roles
+++ b/live-build/variants/internal-dct/ansible/roles
@@ -1,0 +1,1 @@
+../../../misc/ansible-roles

--- a/scripts/build-ancillary-repository.sh
+++ b/scripts/build-ancillary-repository.sh
@@ -85,6 +85,8 @@ mkdir -p "$WORK_DIRECTORY/artifacts"
 download_combined_packages_artifacts "$AWS_S3_URI_COMBINED_PACKAGES" \
 	"$WORK_DIRECTORY/artifacts"
 
+download_dct_artifacts "$AWS_S3_URI_DCT_PACKAGES" "$WORK_DIRECTORY/artifacts"
+
 #
 # Create a delphix-build-info package from the build metadata of each
 # package and of appliance-build itself and store it along with the other

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -125,6 +125,31 @@ function download_combined_packages_artifacts() {
 	popd &>/dev/null
 }
 
+function download_dct_artifacts() {
+	local dct_artifacts_uri="$1"
+	local target_dir="$2"
+
+	if [[ -z "$dct_artifacts_uri" ]]; then
+		DCT_S3_DIR="s3://snapshot-de-images"
+		DCT_LATEST_PREFIX="builds/jenkins-ops/dct/develop/post-push/latest"
+
+		aws s3 cp "$DCT_S3_DIR/$DCT_LATEST_PREFIX" .
+
+		DCT_PACKAGE_PREFIX=$(cat latest)
+		rm -f latest
+
+		dct_artifacts_uri="$DCT_S3_DIR/$DCT_PACKAGE_PREFIX"
+	fi
+
+	mkdir "$target_dir/dct"
+	pushd "$target_dir/dct" &>/dev/null || exit 1
+
+	aws s3 sync "$DCT_S3_DIR/$DCT_PACKAGE_PREFIX" .
+	sha256sum -c SHA256SUMS
+
+	popd &>/dev/null || exit 1
+}
+
 #
 # Find all .deb and .ddeb packages in source directory tree and move them
 # to target directory.


### PR DESCRIPTION
This PR adds a new "internal-dct" variant, such that we'll use this new variant to generate an appliance with DCT installed.

- `git ab-pre-push -v internal-dct --no-tests` is [here](http://selfservice.jenkins.delphix.com/job/appliance-build-orchestrator-pre-push/9111/)