### PR TITLE
TOOL-25941 add "external-dct" variant to appliance-build

### DIFF
--- a/live-build/variants/external-dct/ansible/playbook.yml
+++ b/live-build/variants/external-dct/ansible/playbook.yml
@@ -1,0 +1,26 @@
+#
+# Copyright 2024 Delphix
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+---
+- hosts: all
+  gather_facts: no
+  vars:
+    ansible_python_interpreter: /usr/bin/python3
+  roles:
+    - appliance-build.minimal-common
+    - appliance-build.dct-common
+    - appliance-build.masking-common
+    - appliance-build.virtualization-common

--- a/live-build/variants/external-dct/ansible/roles
+++ b/live-build/variants/external-dct/ansible/roles
@@ -1,0 +1,1 @@
+../../../misc/ansible-roles


### PR DESCRIPTION
<details open>
<summary><h2> Problem </h2></summary>
We don't have a DCT variant that is specific to be distributed to customers.
</details>

<details open>
<summary><h2> Solution </h2></summary>
Add an "external-dct" variant that mimics "external-standard" but comes with the DCT package installed.
</details>
