### PR TITLE
APIGW-9501 Appliance build to take as input DCT S3 URL and app version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -54,7 +54,7 @@ for (variant in allVariants) {
         for (envVar in ["DELPHIX_PLATFORMS",
                         "DELPHIX_HOTFIX_VERSION",
                         "DELPHIX_MINIMUM_VERSION",
-                        "DELPHIX_APP_VERSION",
+                        "DELPHIX_PACKAGED_APP_VERSION",
                         "AWS_S3_URI_LIVEBUILD_ARTIFACTS",
                         "AWS_S3_URI_COMBINED_PACKAGES"]) {
             inputs.property(envVar, System.getenv(envVar)).optional(true)

--- a/build.gradle
+++ b/build.gradle
@@ -54,6 +54,7 @@ for (variant in allVariants) {
         for (envVar in ["DELPHIX_PLATFORMS",
                         "DELPHIX_HOTFIX_VERSION",
                         "DELPHIX_MINIMUM_VERSION",
+                        "DELPHIX_APP_VERSION",
                         "AWS_S3_URI_LIVEBUILD_ARTIFACTS",
                         "AWS_S3_URI_COMBINED_PACKAGES"]) {
             inputs.property(envVar, System.getenv(envVar)).optional(true)

--- a/live-build/build.gradle
+++ b/live-build/build.gradle
@@ -101,7 +101,7 @@ for (variant in allVariants) {
 
                 for (envVar in ["APPLIANCE_PASSWORD",
                                 "DELPHIX_APPLIANCE_VERSION",
-                                "DELPHIX_APP_VERSION",
+                                "DELPHIX_PACKAGED_APP_VERSION",
                                 "DELPHIX_HOTFIX_VERSION",
                                 "DELPHIX_PACKAGE_MIRROR_MAIN",
                                 "DELPHIX_PACKAGE_MIRROR_SECONDARY",

--- a/live-build/build.gradle
+++ b/live-build/build.gradle
@@ -101,6 +101,7 @@ for (variant in allVariants) {
 
                 for (envVar in ["APPLIANCE_PASSWORD",
                                 "DELPHIX_APPLIANCE_VERSION",
+                                "DELPHIX_APP_VERSION",
                                 "DELPHIX_HOTFIX_VERSION",
                                 "DELPHIX_PACKAGE_MIRROR_MAIN",
                                 "DELPHIX_PACKAGE_MIRROR_SECONDARY",

--- a/live-build/config/hooks/vm-artifacts/90-raw-disk-image.binary
+++ b/live-build/config/hooks/vm-artifacts/90-raw-disk-image.binary
@@ -167,9 +167,9 @@ if [[ -n "$DELPHIX_HOTFIX_VERSION" ]]; then
 		"$FSNAME/ROOT/$FSNAME"
 fi
 
-if [[ -n "$DELPHIX_APP_VERSION" ]]; then
+if [[ -n "$DELPHIX_PACKAGED_APP_VERSION" ]]; then
 	zfs set \
-		"com.delphix:app-version=$DELPHIX_APP_VERSION" \
+		"com.delphix:packaged-app-version=$DELPHIX_PACKAGED_APP_VERSION" \
 		"$FSNAME/ROOT/$FSNAME"
 fi
 

--- a/live-build/config/hooks/vm-artifacts/90-raw-disk-image.binary
+++ b/live-build/config/hooks/vm-artifacts/90-raw-disk-image.binary
@@ -167,6 +167,12 @@ if [[ -n "$DELPHIX_HOTFIX_VERSION" ]]; then
 		"$FSNAME/ROOT/$FSNAME"
 fi
 
+if [[ -n "$DELPHIX_APP_VERSION" ]]; then
+	zfs set \
+		"com.delphix:app-version=$DELPHIX_APP_VERSION" \
+		"$FSNAME/ROOT/$FSNAME"
+fi
+
 if [[ -n "$DELPHIX_MINIMUM_VERSION" ]]; then
 	zfs set \
 		"com.delphix:minimum-version=$DELPHIX_MINIMUM_VERSION" \

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -144,7 +144,7 @@ function download_dct_artifacts() {
 	mkdir "$target_dir/dct"
 	pushd "$target_dir/dct" &>/dev/null || exit 1
 
-	aws s3 sync "$DCT_S3_DIR/$DCT_PACKAGE_PREFIX" .
+	aws s3 sync "$dct_artifacts_uri" .
 	sha256sum -c SHA256SUMS
 
 	popd &>/dev/null || exit 1

--- a/scripts/create-build-info-package.sh
+++ b/scripts/create-build-info-package.sh
@@ -94,6 +94,9 @@ check_env DELPHIX_APPLIANCE_VERSION
 echo "$DELPHIX_APPLIANCE_VERSION" >"$target/appliance-build/DELPHIX_APPLIANCE_VERSION"
 check_env AWS_S3_HOTFIX_METADATA
 echo "$AWS_S3_HOTFIX_METADATA" >"$target/appliance-build/HOTFIX_METDATA"
+if [[ -n "$DELPHIX_APP_VERSION" ]]; then
+	echo "$DELPHIX_APP_VERSION" >"$target/appliance-build/DELPHIX_APP_VERSION"
+fi
 
 #
 # Build the package

--- a/scripts/create-build-info-package.sh
+++ b/scripts/create-build-info-package.sh
@@ -94,8 +94,8 @@ check_env DELPHIX_APPLIANCE_VERSION
 echo "$DELPHIX_APPLIANCE_VERSION" >"$target/appliance-build/DELPHIX_APPLIANCE_VERSION"
 check_env AWS_S3_HOTFIX_METADATA
 echo "$AWS_S3_HOTFIX_METADATA" >"$target/appliance-build/HOTFIX_METDATA"
-if [[ -n "$DELPHIX_APP_VERSION" ]]; then
-	echo "$DELPHIX_APP_VERSION" >"$target/appliance-build/DELPHIX_APP_VERSION"
+if [[ -n "$DELPHIX_PACKAGED_APP_VERSION" ]]; then
+	echo "$DELPHIX_PACKAGED_APP_VERSION" >"$target/appliance-build/DELPHIX_PACKAGED_APP_VERSION"
 fi
 
 #

--- a/scripts/upgrade-image-from-aptly-repo.sh
+++ b/scripts/upgrade-image-from-aptly-repo.sh
@@ -87,13 +87,17 @@ sed -i "s/@@VERSION@@/$VERSION/" version.info ||
 	die "failed to set VERSION in version.info file"
 
 #
-# The DELPHIX_HOTFIX_VERSION variable is optional, and thus it may not
-# be set at this point. That is by design, and when that's the case, we
-# still need to do this replacement, such that the version information
-# file properly reflects an empty value for the hotfix version.
+# The DELPHIX_HOTFIX_VERSION and DELPHIX_APP_VERSION variable are optional,
+# optional, and thus may not be set at this point. That is by design, and
+# when that's the case, we still need to do these replacements, such that
+# the version information file properly reflects empty values for the
+# hotfix and app versions.
 #
 sed -i "s/@@HOTFIX@@/$DELPHIX_HOTFIX_VERSION/" version.info ||
 	die "failed to set HOTFIX in version.info file"
+
+sed -i "s/@@APP_VERSION@@/$DELPHIX_APP_VERSION/" version.info ||
+	die "failed to set APP_VERSION in version.info file"
 
 #
 # On 6.0 versions, the virtualization application expects to find the

--- a/scripts/upgrade-image-from-aptly-repo.sh
+++ b/scripts/upgrade-image-from-aptly-repo.sh
@@ -87,7 +87,7 @@ sed -i "s/@@VERSION@@/$VERSION/" version.info ||
 	die "failed to set VERSION in version.info file"
 
 #
-# The DELPHIX_HOTFIX_VERSION and DELPHIX_APP_VERSION variable are optional,
+# The DELPHIX_HOTFIX_VERSION and DELPHIX_PACKAGED_APP_VERSION variable are optional,
 # optional, and thus may not be set at this point. That is by design, and
 # when that's the case, we still need to do these replacements, such that
 # the version information file properly reflects empty values for the
@@ -96,8 +96,8 @@ sed -i "s/@@VERSION@@/$VERSION/" version.info ||
 sed -i "s/@@HOTFIX@@/$DELPHIX_HOTFIX_VERSION/" version.info ||
 	die "failed to set HOTFIX in version.info file"
 
-sed -i "s/@@APP_VERSION@@/$DELPHIX_APP_VERSION/" version.info ||
-	die "failed to set APP_VERSION in version.info file"
+sed -i "s/@@PACKAGED_APP_VERSION@@/$DELPHIX_PACKAGED_APP_VERSION/" version.info ||
+	die "failed to set PACKAGED_APP_VERSION in version.info file"
 
 #
 # On 6.0 versions, the virtualization application expects to find the

--- a/upgrade/prepare
+++ b/upgrade/prepare
@@ -109,8 +109,8 @@ popd &>/dev/null || die "'popd' failed"
 if [[ -n "$HOTFIX" ]]; then
 	VERSION="$VERSION-$HOTFIX"
 fi
-if [[ -n "$APP_VERSION" ]]; then
-	VERSION="$VERSION-$APP_VERSION"
+if [[ -n "$PACKAGED_APP_VERSION" ]]; then
+	VERSION="$VERSION-$PACKAGED_APP_VERSION"
 fi
 
 $opt_f && rm -rf "${UPDATE_DIR:?}/$VERSION" >/dev/null 2>&1

--- a/upgrade/prepare
+++ b/upgrade/prepare
@@ -109,6 +109,9 @@ popd &>/dev/null || die "'popd' failed"
 if [[ -n "$HOTFIX" ]]; then
 	VERSION="$VERSION-$HOTFIX"
 fi
+if [[ -n "$APP_VERSION" ]]; then
+	VERSION="$VERSION-$APP_VERSION"
+fi
 
 $opt_f && rm -rf "${UPDATE_DIR:?}/$VERSION" >/dev/null 2>&1
 

--- a/upgrade/upgrade-scripts/common.sh
+++ b/upgrade/upgrade-scripts/common.sh
@@ -49,7 +49,7 @@ PROP_CURRENT_VERSION="com.delphix:current-version"
 PROP_INITIAL_VERSION="com.delphix:initial-version"
 PROP_HOTFIX_VERSION="com.delphix:hotfix-version"
 PROP_MINIMUM_VERSION="com.delphix:minimum-version"
-PROP_APP_VERSION="com.delphix:app-version"
+PROP_PACKAGED_APP_VERSION="com.delphix:packaged-app-version"
 
 #
 # To better enable root cause analysis of any upgrade failures, we
@@ -203,8 +203,8 @@ function get_hotfix_version() {
 	get_version_property "$PROP_HOTFIX_VERSION"
 }
 
-function get_app_version() {
-	get_version_property "$PROP_APP_VERSION"
+function get_packaged_app_version() {
+	get_version_property "$PROP_PACKAGED_APP_VERSION"
 }
 
 function copy_required_dataset_property() {

--- a/upgrade/upgrade-scripts/common.sh
+++ b/upgrade/upgrade-scripts/common.sh
@@ -49,6 +49,7 @@ PROP_CURRENT_VERSION="com.delphix:current-version"
 PROP_INITIAL_VERSION="com.delphix:initial-version"
 PROP_HOTFIX_VERSION="com.delphix:hotfix-version"
 PROP_MINIMUM_VERSION="com.delphix:minimum-version"
+PROP_APP_VERSION="com.delphix:app-version"
 
 #
 # To better enable root cause analysis of any upgrade failures, we
@@ -200,6 +201,10 @@ function get_current_version() {
 
 function get_hotfix_version() {
 	get_version_property "$PROP_HOTFIX_VERSION"
+}
+
+function get_app_version() {
+	get_version_property "$PROP_APP_VERSION"
 }
 
 function copy_required_dataset_property() {

--- a/upgrade/upgrade-scripts/execute
+++ b/upgrade/upgrade-scripts/execute
@@ -182,7 +182,7 @@ if [[ -n "$CURRENT_VERSION" ]]; then
 		"$ROOTFS_CONTAINER" "$ROOTFS_CONTAINER@execute-upgrade.$UNIQUE"
 	copy_optional_dataset_property "$PROP_HOTFIX_VERSION" \
 		"$ROOTFS_CONTAINER" "$ROOTFS_CONTAINER@execute-upgrade.$UNIQUE"
-	copy_optional_dataset_property "$PROP_APP_VERSION" \
+	copy_optional_dataset_property "$PROP_PACKAGED_APP_VERSION" \
 		"$ROOTFS_CONTAINER" "$ROOTFS_CONTAINER@execute-upgrade.$UNIQUE"
 fi
 
@@ -554,13 +554,13 @@ else
 			"for '$ROOTFS_CONTAINER'"
 fi
 
-if [[ -n "$APP_VERSION" ]]; then
-	zfs set "$PROP_APP_VERSION=$APP_VERSION" "$ROOTFS_CONTAINER" ||
-		die "failed to set property '$PROP_APP_VERSION'" \
-			"to '$APP_VERSION' for '$ROOTFS_CONTAINER'"
+if [[ -n "$PACKAGED_APP_VERSION" ]]; then
+	zfs set "$PROP_PACKAGED_APP_VERSION=$PACKAGED_APP_VERSION" "$ROOTFS_CONTAINER" ||
+		die "failed to set property '$PROP_PACKAGED_APP_VERSION'" \
+			"to '$PACKAGED_APP_VERSION' for '$ROOTFS_CONTAINER'"
 else
-	zfs inherit "$PROP_APP_VERSION" "$ROOTFS_CONTAINER" ||
-		die "failed to inherit property '$PROP_APP_VERSION'" \
+	zfs inherit "$PROP_PACKAGED_APP_VERSION" "$ROOTFS_CONTAINER" ||
+		die "failed to inherit property '$PROP_PACKAGED_APP_VERSION'" \
 			"for '$ROOTFS_CONTAINER'"
 fi
 

--- a/upgrade/upgrade-scripts/execute
+++ b/upgrade/upgrade-scripts/execute
@@ -182,6 +182,8 @@ if [[ -n "$CURRENT_VERSION" ]]; then
 		"$ROOTFS_CONTAINER" "$ROOTFS_CONTAINER@execute-upgrade.$UNIQUE"
 	copy_optional_dataset_property "$PROP_HOTFIX_VERSION" \
 		"$ROOTFS_CONTAINER" "$ROOTFS_CONTAINER@execute-upgrade.$UNIQUE"
+	copy_optional_dataset_property "$PROP_APP_VERSION" \
+		"$ROOTFS_CONTAINER" "$ROOTFS_CONTAINER@execute-upgrade.$UNIQUE"
 fi
 
 if [[ -f /etc/apt/sources.list ]]; then
@@ -549,6 +551,16 @@ if [[ -n "$HOTFIX" ]]; then
 else
 	zfs inherit "$PROP_HOTFIX_VERSION" "$ROOTFS_CONTAINER" ||
 		die "failed to inherit property '$PROP_HOTFIX_VERSION'" \
+			"for '$ROOTFS_CONTAINER'"
+fi
+
+if [[ -n "$APP_VERSION" ]]; then
+	zfs set "$PROP_APP_VERSION=$APP_VERSION" "$ROOTFS_CONTAINER" ||
+		die "failed to set property '$PROP_APP_VERSION'" \
+			"to '$APP_VERSION' for '$ROOTFS_CONTAINER'"
+else
+	zfs inherit "$PROP_APP_VERSION" "$ROOTFS_CONTAINER" ||
+		die "failed to inherit property '$PROP_APP_VERSION'" \
 			"for '$ROOTFS_CONTAINER'"
 fi
 

--- a/upgrade/upgrade-scripts/upgrade
+++ b/upgrade/upgrade-scripts/upgrade
@@ -311,6 +311,7 @@ function rollback() {
 	[[ -n "$ROLLBACK_BASE_VERSION" ]] ||
 		die "unable to determine current appliance version"
 	ROLLBACK_BASE_HOTFIX="$(get_hotfix_version)"
+	ROLLBACK_BASE_APP_VERSION="$(get_app_version)"
 
 	set_upgrade_property "ROLLBACK_BASE_CONTAINER" "$ROLLBACK_BASE_CONTAINER" ||
 		die "failed setting 'ROLLBACK_BASE_CONTAINER' property"
@@ -320,6 +321,11 @@ function rollback() {
 	if [[ -n "$ROLLBACK_BASE_HOTFIX" ]]; then
 		set_upgrade_property "ROLLBACK_BASE_HOTFIX" "$ROLLBACK_BASE_HOTFIX" ||
 			die "failed setting 'ROLLBACK_BASE_HOTFIX' property"
+	fi
+	if [[ -n "$ROLLBACK_BASE_APP_VERSION" ]]; then
+		set_upgrade_property "ROLLBACK_BASE_APP_VERSION" \
+			"$ROLLBACK_BASE_APP_VERSION" ||
+			die "failed setting 'ROLLBACK_BASE_APP_VERSION' property"
 	fi
 
 	if [[ "$UPGRADE_BASE_CONTAINER" == "$ROLLBACK_BASE_CONTAINER" ]]; then

--- a/upgrade/upgrade-scripts/upgrade
+++ b/upgrade/upgrade-scripts/upgrade
@@ -311,7 +311,7 @@ function rollback() {
 	[[ -n "$ROLLBACK_BASE_VERSION" ]] ||
 		die "unable to determine current appliance version"
 	ROLLBACK_BASE_HOTFIX="$(get_hotfix_version)"
-	ROLLBACK_BASE_APP_VERSION="$(get_app_version)"
+	ROLLBACK_BASE_PACKAGED_APP_VERSION="$(get_packaged_app_version)"
 
 	set_upgrade_property "ROLLBACK_BASE_CONTAINER" "$ROLLBACK_BASE_CONTAINER" ||
 		die "failed setting 'ROLLBACK_BASE_CONTAINER' property"
@@ -322,10 +322,10 @@ function rollback() {
 		set_upgrade_property "ROLLBACK_BASE_HOTFIX" "$ROLLBACK_BASE_HOTFIX" ||
 			die "failed setting 'ROLLBACK_BASE_HOTFIX' property"
 	fi
-	if [[ -n "$ROLLBACK_BASE_APP_VERSION" ]]; then
-		set_upgrade_property "ROLLBACK_BASE_APP_VERSION" \
-			"$ROLLBACK_BASE_APP_VERSION" ||
-			die "failed setting 'ROLLBACK_BASE_APP_VERSION' property"
+	if [[ -n "$ROLLBACK_BASE_PACKAGED_APP_VERSION" ]]; then
+		set_upgrade_property "ROLLBACK_BASE_PACKAGED_APP_VERSION" \
+			"$ROLLBACK_BASE_PACKAGED_APP_VERSION" ||
+			die "failed setting 'ROLLBACK_BASE_PACKAGED_APP_VERSION' property"
 	fi
 
 	if [[ "$UPGRADE_BASE_CONTAINER" == "$ROLLBACK_BASE_CONTAINER" ]]; then

--- a/upgrade/version.info.template
+++ b/upgrade/version.info.template
@@ -42,7 +42,7 @@ HOTFIX=@@HOTFIX@@
 #
 # The app version contained in the upgrade image (if any)
 #
-APP_VERSION=@@APP_VERSION@@
+PACKAGED_APP_VERSION=@@PACKAGED_APP_VERSION@@
 
 #
 # The minimum product version an engine must have installed, in order to

--- a/upgrade/version.info.template
+++ b/upgrade/version.info.template
@@ -40,6 +40,11 @@ VERSION=@@VERSION@@
 HOTFIX=@@HOTFIX@@
 
 #
+# The app version contained in the upgrade image (if any)
+#
+APP_VERSION=@@APP_VERSION@@
+
+#
 # The minimum product version an engine must have installed, in order to
 # upgrade using this upgrade image.
 #


### PR DESCRIPTION
When building release DCT engine images, the appliance build needs two customization points which will be provided by Jenkins jobs (see https://github.com/delphix/devops-gate/pull/3340 for the corresponding devops-gate change):

1. AWS_S3_URI_DCT_PACKAGES, which was introduced in https://github.com/delphix/appliance-build/pull/765 but wasn't read correctly (see changes to download_dct_artifacts) indicates that the DCT debian packages should be pulled from that location instead of fetching the latest images (dev builds pull the latest image).
This location will be passed in by a new Jenkins job (coming soon) for building DCT engine images, which itself might eventually be trigered as a downstream of the dct release process (see https://github.com/delphix/devops-gate/pull/3222 for the changes producing the debian image for dct releases).

2. DELPHIX_APP_VERSION is a new property which will allow the mgmt stack to identify the DCT version (or Hyperscale version or other similar app running on the engine). The proposal is to set this version on the root dataset, mirroring the existing logic for the appliance version and hotfix version, which will then be read by the mgmt stack (see https://github.com/delphix/dlpx-app-gate/pull/2367/files#diff-0de62ad8e4f9b74e6357f3816ae7574bfb73cf5e2c92b09a8872f0bab4b4ab09R71 for a work in progress to read this version in the mgmt stack). Similarly, we are also including the version in upgrade bundle metadata.
The mgmt stack will use this version for 2 purposes:
 a. Display the DCT version in the UI (API, ...) as we'll communicate to customers in terms of DCT version (and not engine version)
 b. Allow upgrades using an upgrade image wich has the same appliance version, if the app version is different, as long as the app version is more recent (that is, the engine will allow upgrading to DCT engine with app version Y from DCT engine version with app X iff Y > X, even if both have been built on top of the same appliance version. For this situtation, today, the mgmt stack would only allow a "finished deferred" upgrade as it does not understand that some packages might be different). Incidentally, this will also prevent a non DCT engine to be upgraded to a DCT engine or vice versa as the app version check would detect a mismatch).
 
 <details open>
<summary><h2> Testing Done </h2></summary>

Ran appliance-build on my test Jenkins instance with new parameters set: http://ops.jenkins-eyal.dcol2.delphix.com/job/appliance-build-stage1/job/post-push/1/
Cloned the dcenter VM and verified the app version was set as a property of the ZFS dataset:
```
delphix@ip-10-110-206-157:~$ zfs get -Hpo value "com.delphix:app-version" "$(dirname "$(zfs list -Hpo name /)")"
22.0.0-eyal-testing
```
In the job logs, we can see the job fetching the DCT package from the parameter instead of latest
```
2:24:34  + download_dct_artifacts s3://snapshot-de-images/builds/jenkins-ops/dct/develop/post-push/2023 /var/tmp/jenkins/workspace/appliance-build-stage1/post-push/appliance-build/build/tmp.pkgs.p3jb8QEhN4/artifacts
12:24:34  + local dct_artifacts_uri=s3://snapshot-de-images/builds/jenkins-ops/dct/develop/post-push/2023
12:24:34  + local target_dir=/var/tmp/jenkins/workspace/appliance-build-stage1/post-push/appliance-build/build/tmp.pkgs.p3jb8QEhN4/artifacts
12:24:34  + [[ -z s3://snapshot-de-images/builds/jenkins-ops/dct/develop/post-push/2023 ]]
12:24:34  + mkdir /var/tmp/jenkins/workspace/appliance-build-stage1/post-push/appliance-build/build/tmp.pkgs.p3jb8QEhN4/artifacts/dct
12:24:34  + pushd /var/tmp/jenkins/workspace/appliance-build-stage1/post-push/appliance-build/build/tmp.pkgs.p3jb8QEhN4/artifacts/dct
12:24:34  + aws s3 sync s3://snapshot-de-images/builds/jenkins-ops/dct/develop/post-push/2023 .
12:24:34  Completed 122 Bytes/2.0 GiB (884 Bytes/s) with 2 file(s) remaining
12:24:34  download: s3://snapshot-de-images/builds/jenkins-ops/dct/develop/post-push/2023/SHA256SUMS to ./SHA256SUMS
...
12:24:45  download: s3://snapshot-de-images/builds/jenkins-ops/dct/develop/post-push/2023/delphix-dct_21.0.0-1723763188834.dd927eccac5e_amd64.deb to ./delphix-dct_21.0.0-1723763188834.dd927eccac5e_amd64.deb
12:26:24  delphix-dct_21.0.0-1723763188834.dd927eccac5e_amd64.deb: OK

```
Build info included
```
delphix@ip-10-110-206-157:~$ cat  /var/delphix-buildinfo/appliance-build/DELPHIX_APP_VERSION
22.0.0-eyal-testing
```

Upgrade image contains app version
```
delphix@ip-10-110-206-157:~$ tar -xvf internal-dct.upgrade.tar version.info
version.info
delphix@ip-10-110-206-157:~$ grep APP_VERSION version.info
APP_VERSION=22.0.0-eyal-testing
```
</details>

