### PR TITLE
TOOL-25955 nightly builds failing due to ENOSPC on the filesystem after adding DCT variants

### DIFF
--- a/live-build/config/hooks/vm-artifacts/90-raw-disk-image.binary
+++ b/live-build/config/hooks/vm-artifacts/90-raw-disk-image.binary
@@ -74,7 +74,7 @@ external-* | internal-dcenter)
 	RAW_DISK_SIZE_GB=127
 	;;
 internal-buildserver)
-	RAW_DISK_SIZE_GB=256
+	RAW_DISK_SIZE_GB=512
 	;;
 internal-*)
 	RAW_DISK_SIZE_GB=70


### PR DESCRIPTION
<details open>
<summary><h2> Problem </h2></summary>
We appear to need rpool space on the build server that scales with the number of variants built by the nightly appliance-build job. Since adding the DCT variants, we’re running out of space.
</details>

<details open>
<summary><h2> Solution </h2></summary>
Increase the rpool space to account for the additional rpool space needed to build the new variants.
</details>
