### PR TITLE
test: check contents of ca-certificates

### DIFF
--- a/live-build/config/hooks/vm-artifacts/90-raw-disk-image.binary
+++ b/live-build/config/hooks/vm-artifacts/90-raw-disk-image.binary
@@ -279,6 +279,10 @@ mount -t zfs "$FSNAME/crashdump" "/var/crash"
 #
 rsync --info=stats3 -Wa binary/* "$DIRECTORY/"
 
+sudo chroot "$DIRECTORY" /bin/bash <<-EOF
+	awk -v cmd='openssl x509 -noout -subject' '/BEGIN/{close(cmd)};{print | cmd}' < /etc/ssl/certs/ca-certificates.crt | grep 'Go Daddy'
+EOF
+
 #
 # We rely on the "/etc/fstab" file to mount the non-root ZFS
 # filesystems, so that when a specific rootfs dataset is booted, it'll


### PR DESCRIPTION
- `git-ab-pre-push -v internal-dct --no-tests` is [here](http://selfservice.jenkins.delphix.com/job/appliance-build-orchestrator-pre-push/9216/)