### PR TITLE
DLPX-86541 CIS: /dev/shm filesystem and mount options

### DIFF
--- a/live-build/config/hooks/vm-artifacts/90-raw-disk-image.binary
+++ b/live-build/config/hooks/vm-artifacts/90-raw-disk-image.binary
@@ -298,6 +298,12 @@ cat <<-EOF >"$DIRECTORY/etc/fstab"
 	rpool/crashdump  /var/crash     zfs defaults,x-systemd.before=zfs-import-cache.service,x-systemd.before=kdump-tools.service 0 0
 EOF
 
+cat <<-EOF >>"$DIRECTORY/etc/fstab"
+	tmpfs /dev/shm tmpfs defaults,noexec,nosuid,nodev 0 0
+EOF
+
+mount -o remount /dev/shm
+
 #
 # Now we need to install the bootloader. In order to do that, we'll chroot
 # into the newly populated root filesystem, so that we use the grub-install

--- a/upgrade/upgrade-scripts/execute
+++ b/upgrade/upgrade-scripts/execute
@@ -621,6 +621,16 @@ if [[ -f "$UPDATE_DIR/upgrade.properties" ]]; then
 	source_upgrade_properties
 fi
 
+FSTAB_FILE_PATH="$DIRECTORY/etc/fstab"
+DEV_SHM_LINE="tmpfs /dev/shm tmpfs defaults,noexec,nosuid,nodev 0 0"
+
+# Check if the /dev/shm exec permission block line exists in the file
+if ! grep -Fxq "$DEV_SHM_LINE" "$FSTAB_FILE_PATH"; then
+	# If the /dev/shm exec permission block line doesn't exist, append it to the file
+	echo "$DEV_SHM_LINE" >>"$FSTAB_FILE_PATH"
+	mount -o remount /dev/shm
+fi
+
 #
 # On versions 18.0 and greater, we don't issue the reboot. Rather,
 # we restart the delphix services, and the reboot will be issued by

--- a/upgrade/upgrade-scripts/upgrade-container
+++ b/upgrade/upgrade-scripts/upgrade-container
@@ -302,12 +302,6 @@ function create_upgrade_container() {
 		rpool/crashdump           /var/crash    zfs defaults,x-systemd.before=zfs-import-cache.service,x-systemd.before=kdump-tools.service 0 0
 	EOF
 
-	cat <<-EOF >>"$DIRECTORY/etc/fstab"
-		tmpfs /dev/shm tmpfs defaults,noexec,nosuid,nodev 0 0
-	EOF
-
-	mount -o remount /dev/shm
-
 	#
 	# DLPX-75089 - Since older versions of Delphix did not properly
 	# disable the NFS services within the upgrade container, we have

--- a/upgrade/upgrade-scripts/upgrade-container
+++ b/upgrade/upgrade-scripts/upgrade-container
@@ -302,6 +302,12 @@ function create_upgrade_container() {
 		rpool/crashdump           /var/crash    zfs defaults,x-systemd.before=zfs-import-cache.service,x-systemd.before=kdump-tools.service 0 0
 	EOF
 
+	cat <<-EOF >>"$DIRECTORY/etc/fstab"
+		tmpfs /dev/shm tmpfs defaults,noexec,nosuid,nodev 0 0
+	EOF
+
+	mount -o remount /dev/shm
+
 	#
 	# DLPX-75089 - Since older versions of Delphix did not properly
 	# disable the NFS services within the upgrade container, we have


### PR DESCRIPTION
# Problem

Any user can upload and execute files inside the /dev/shm similar to the /tmp partition. Configuring /dev/shm allows an administrator to set the noexec option on the mount, making /dev/shm useless for an attacker to install executable code. It would also prevent an attacker from establishing a hardlink to a system setuid program and wait for it to be updated. Once the program was updated, the hardlink would be broken and the attacker would have his own copy of the program. If the program happened to have a security vulnerability, the attacker could continue to exploit the known flaw.

<img width="834" alt="Screenshot 2024-09-11 at 8 11 59 PM" src="https://github.com/user-attachments/assets/45ceeea4-d46e-40fd-8901-23083d9ea0d5">


# Solution

- For new installations, during installation create a custom partition setup and specify a separate partition for /dev/shm.
- For systems that were previously installed, create a new partition and configure /etc/fstab as appropriate.

# Implementation

- For new installation did the below change in `live-build/config/hooks/vm-artifacts/90-raw-disk-image.binary`

```
cat <<-EOF >>"$DIRECTORY/etc/fstab"
	tmpfs /dev/shm tmpfs defaults,noexec,nosuid,nodev 0 0
EOF

mount -o remount /dev/shm
```

- For the upgrade did the below change in 

```
FSTAB_FILE_PATH="$DIRECTORY/etc/fstab"
DEV_SHM_LINE="tmpfs /dev/shm tmpfs defaults,noexec,nosuid,nodev 0 0"

# Check if the /dev/shm exec permission block line exists in the file
if ! grep -Fxq "$DEV_SHM_LINE" "$FSTAB_FILE_PATH"; then
	# If the /dev/shm exec permission block line doesn't exist, append it to the file
  echo "$DEV_SHM_LINE" >>"$FSTAB_FILE_PATH"
  mount -o remount /dev/shm
fi
```

# Testing

- 