### PR TITLE
Install libtool-bin specifically

### DIFF
--- a/live-build/misc/ansible-roles/appliance-build.zfsonlinux-development/tasks/main.yml
+++ b/live-build/misc/ansible-roles/appliance-build.zfsonlinux-development/tasks/main.yml
@@ -40,7 +40,7 @@
       - libelf-dev
       - libselinux-dev
       - libssl-dev
-      - libtool
+      - libtool-bin
       - libudev-dev
       - llvm-12
       - lsscsi


### PR DESCRIPTION
We use libtool to analyze ztest core files when zloop crashes, but it actually needs the libtool utility, not just the libraries. The libraries are dependencies of the bin package.