### PR TITLE
DLPX-86532 & DLPX-86542 - CIS: /tmp filesystem and mount options & CIS: /var/tmp filesystem and mount options

### DIFF
--- a/live-build/config/hooks/vm-artifacts/90-raw-disk-image.binary
+++ b/live-build/config/hooks/vm-artifacts/90-raw-disk-image.binary
@@ -326,6 +326,35 @@ for dir in /dev /proc /sys; do
 	mount --make-rslave "${DIRECTORY}${dir}"
 done
 
+for dir in tmp var/tmp; do
+
+	# Check if the directory is already mounted using 'findmnt'
+	if ! findmnt "/$dir" >/dev/null 2>&1; then
+
+		# Convert all forward slashes (/) in the directory path to hyphens (-)
+		# and store the result in the variable 'mount_dir', e.g. var/tmp -> var-tmp
+		mount_dir=$(echo "$dir" | sed 's/\//-/g')
+
+		# If the directory is not mounted, create a ZFS dataset with the legacy mountpoint option
+		# $FSNAME is the name of the ZFS filesystem, and the dataset is created under $FSNAME/ROOT/$FSNAME/$dir
+		zfs create -o mountpoint=legacy "$FSNAME/ROOT/$FSNAME/$mount_dir"
+
+		# Create the directory if it doesn't already exist
+		mkdir -p "/$dir"
+
+		# Mount the newly created ZFS filesystem to the directory
+		mount -t zfs "$FSNAME/ROOT/$FSNAME/$mount_dir" "/$dir"
+	fi
+
+	# Define the entry to be added to /etc/fstab
+	fstab_entry="rpool/ROOT/$FSNAME/$mount_dir /$dir zfs defaults,nosuid,nodev,noexec,x-systemd.before=zfs-import-cache.service 0 0"
+
+	if ! grep -qF "$fstab_entry" "$DIRECTORY/etc/fstab"; then
+		# If the entry is not present, append it to the /etc/fstab file
+		echo "$fstab_entry" >>"$DIRECTORY/etc/fstab"
+	fi
+done
+
 #
 # We need to use the dedicated grub dataset when running "grub-install"
 # and "grub-mkconfig", so we need to mount this dataset first.

--- a/live-build/config/hooks/vm-artifacts/90-raw-disk-image.binary
+++ b/live-build/config/hooks/vm-artifacts/90-raw-disk-image.binary
@@ -315,8 +315,8 @@ cat <<-EOF >"$DIRECTORY/etc/fstab"
 	rpool/ROOT/$FSNAME/home /export/home zfs defaults,x-systemd.before=zfs-import-cache.service 0 0
 	rpool/ROOT/$FSNAME/data /var/delphix zfs defaults,x-systemd.before=zfs-import-cache.service 0 0
 	rpool/ROOT/$FSNAME/log  /var/log     zfs defaults,x-systemd.before=zfs-import-cache.service 0 0
-	rpool/ROOT/$FSNAME/tmp  /tmp     zfs defaults,nosuid,nodev,exec,x-systemd.before=zfs-import-cache.service 0 0
-	rpool/ROOT/$FSNAME/vartmp  /var/tmp     zfs defaults,nosuid,nodev,exec,x-systemd.before=zfs-import-cache.service 0 0
+	rpool/ROOT/$FSNAME/tmp  /tmp     zfs defaults,nosuid,nodev,noexec,x-systemd.before=zfs-import-cache.service 0 0
+	rpool/ROOT/$FSNAME/vartmp  /var/tmp     zfs defaults,nosuid,nodev,noexec,x-systemd.before=zfs-import-cache.service 0 0
 	rpool/crashdump  /var/crash     zfs defaults,x-systemd.before=zfs-import-cache.service,x-systemd.before=kdump-tools.service 0 0
 EOF
 
@@ -341,6 +341,7 @@ for dir in /dev /proc /sys; do
 	#
 	mount --make-rslave "${DIRECTORY}${dir}"
 done
+
 #
 # We need to use the dedicated grub dataset when running "grub-install"
 # and "grub-mkconfig", so we need to mount this dataset first.

--- a/live-build/config/hooks/vm-artifacts/90-raw-disk-image.binary
+++ b/live-build/config/hooks/vm-artifacts/90-raw-disk-image.binary
@@ -229,6 +229,14 @@ zfs create \
 	-o mountpoint=legacy \
 	"$FSNAME/ROOT/$FSNAME/log"
 
+zfs create \
+	-o mountpoint=legacy \
+	"$FSNAME/ROOT/$FSNAME/tmp"
+
+zfs create \
+	-o mountpoint=legacy \
+	"$FSNAME/ROOT/$FSNAME/vartmp"
+
 #
 # Initialize the grub dataset. This dataset will be used to contain all
 # of the grub-specific files; this includes the "grub.cfg" file, along
@@ -276,6 +284,12 @@ mount -t zfs "$FSNAME/ROOT/$FSNAME/data" "$DIRECTORY/var/delphix"
 mkdir -p "$DIRECTORY/var/log"
 mount -t zfs "$FSNAME/ROOT/$FSNAME/log" "$DIRECTORY/var/log"
 
+mkdir -p "$DIRECTORY/tmp"
+mount -t zfs "$FSNAME/ROOT/$FSNAME/tmp" "$DIRECTORY/tmp"
+
+mkdir -p "$DIRECTORY/var/tmp"
+mount -t zfs "$FSNAME/ROOT/$FSNAME/vartmp" "$DIRECTORY/var/tmp"
+
 mkdir -p "/var/crash"
 mount -t zfs "$FSNAME/crashdump" "/var/crash"
 
@@ -301,6 +315,8 @@ cat <<-EOF >"$DIRECTORY/etc/fstab"
 	rpool/ROOT/$FSNAME/home /export/home zfs defaults,x-systemd.before=zfs-import-cache.service 0 0
 	rpool/ROOT/$FSNAME/data /var/delphix zfs defaults,x-systemd.before=zfs-import-cache.service 0 0
 	rpool/ROOT/$FSNAME/log  /var/log     zfs defaults,x-systemd.before=zfs-import-cache.service 0 0
+	rpool/ROOT/$FSNAME/tmp  /tmp     zfs defaults,nosuid,nodev,exec,x-systemd.before=zfs-import-cache.service 0 0
+	rpool/ROOT/$FSNAME/vartmp  /var/tmp     zfs defaults,nosuid,nodev,exec,x-systemd.before=zfs-import-cache.service 0 0
 	rpool/crashdump  /var/crash     zfs defaults,x-systemd.before=zfs-import-cache.service,x-systemd.before=kdump-tools.service 0 0
 EOF
 
@@ -325,36 +341,6 @@ for dir in /dev /proc /sys; do
 	#
 	mount --make-rslave "${DIRECTORY}${dir}"
 done
-
-for dir in tmp var/tmp; do
-
-	# Check if the directory is already mounted using 'findmnt'
-	if ! findmnt "/$dir" >/dev/null 2>&1; then
-
-		# Convert all forward slashes (/) in the directory path to hyphens (-)
-		# and store the result in the variable 'mount_dir', e.g. var/tmp -> var-tmp
-		mount_dir=$(echo "$dir" | sed 's/\//-/g')
-
-		# If the directory is not mounted, create a ZFS dataset with the legacy mountpoint option
-		# $FSNAME is the name of the ZFS filesystem, and the dataset is created under $FSNAME/ROOT/$FSNAME/$dir
-		zfs create -o mountpoint=legacy "$FSNAME/ROOT/$FSNAME/$mount_dir"
-
-		# Create the directory if it doesn't already exist
-		mkdir -p "/$dir"
-
-		# Mount the newly created ZFS filesystem to the directory
-		mount -t zfs "$FSNAME/ROOT/$FSNAME/$mount_dir" "/$dir"
-	fi
-
-	# Define the entry to be added to /etc/fstab
-	fstab_entry="rpool/ROOT/$FSNAME/$mount_dir /$dir zfs defaults,nosuid,nodev,noexec,x-systemd.before=zfs-import-cache.service 0 0"
-
-	if ! grep -qF "$fstab_entry" "$DIRECTORY/etc/fstab"; then
-		# If the entry is not present, append it to the /etc/fstab file
-		echo "$fstab_entry" >>"$DIRECTORY/etc/fstab"
-	fi
-done
-
 #
 # We need to use the dedicated grub dataset when running "grub-install"
 # and "grub-mkconfig", so we need to mount this dataset first.
@@ -371,6 +357,8 @@ done
 umount "$DIRECTORY/var/log"
 umount "$DIRECTORY/var/delphix"
 umount "$DIRECTORY/export/home"
+umount "$DIRECTORY/tmp"
+umount "$DIRECTORY/var/tmp"
 umount "/var/crash"
 retry 5 10 zfs umount "$FSNAME/ROOT/$FSNAME/root"
 retry 5 10 zpool export "$FSNAME"

--- a/upgrade/upgrade-scripts/upgrade-container
+++ b/upgrade/upgrade-scripts/upgrade-container
@@ -24,7 +24,10 @@ CONTAINER=
 
 TMP_DATASETS_EXIST=false
 
-# Check if both datasets exist
+# Verify whether both /tmp and /var/tmp ZFS datasets exist for the specified container.
+# If both datasets are present, the system is considered CIS compliant.
+# In such cases, handle the /tmp and /var/tmp mounts appropriately during the upgrade process.
+# To ensure this handling, set the TMP_DATASETS_EXIST variable to true.
 if zfs list "rpool/ROOT/$CONTAINER/tmp" >/dev/null 2>&1 && zfs list "rpool/ROOT/$CONTAINER/vartmp" >/dev/null 2>&1; then
 	TMP_DATASETS_EXIST=true
 fi
@@ -337,8 +340,8 @@ function create_upgrade_container() {
 
 	if $TMP_DATASETS_EXIST; then
 		cat <<-EOF >>"$DIRECTORY/etc/fstab"
-			         rpool/ROOT/$CONTAINER/tmp  /tmp         zfs defaults,nosuid,nodev,exec,x-systemd.before=zfs-import-cache.service 0 0
-			         rpool/ROOT/$CONTAINER/vartmp  /var/tmp  zfs defaults,nosuid,nodev,exec,x-systemd.before=zfs-import-cache.service 0 0
+			         rpool/ROOT/$CONTAINER/tmp  /tmp         zfs defaults,nosuid,nodev,noexec,x-systemd.before=zfs-import-cache.service 0 0
+			         rpool/ROOT/$CONTAINER/vartmp  /var/tmp  zfs defaults,nosuid,nodev,noexec,x-systemd.before=zfs-import-cache.service 0 0
 		EOF
 	fi
 
@@ -610,10 +613,10 @@ function destroy() {
 		#
 		# In order to safely perform the recursive destroy below,
 		# we need to ensure the filesystems are unmounted in the
-		# correct order. Since the "log", "data", and "home"
-		# datasets are mounted inside the "root" dataset, we need
-		# to unmount these two datasets before attempting to
-		# unmount (and/or destroy) the "root" dataset.
+		# correct order. Since the "log", "data", "home", "tmp" and
+		# "vartmp" datasets are mounted inside the "root" dataset,
+		# we need to unmount these datasets before attempting
+		# to unmount (and/or destroy) the "root" dataset.
 		#
 		# Further, we don't check the return value of these
 		# commands for simplicity's sake. If these fail, it could

--- a/upgrade/upgrade-scripts/upgrade-container
+++ b/upgrade/upgrade-scripts/upgrade-container
@@ -22,6 +22,13 @@ IMAGE_PATH=$(get_image_path)
 
 CONTAINER=
 
+TMP_DATASETS_EXIST=false
+
+# Check if both datasets exist
+if zfs list "rpool/ROOT/$CONTAINER/tmp" >/dev/null 2>&1 && zfs list "rpool/ROOT/$CONTAINER/vartmp" >/dev/null 2>&1; then
+	TMP_DATASETS_EXIST=true
+fi
+
 function create_cleanup() {
 	#
 	# Upon successful creation of the container, don't perform any
@@ -216,17 +223,19 @@ function create_upgrade_container() {
 		"rpool/ROOT/$CONTAINER/log" ||
 		die "failed to create upgrade /var/log clone"
 
-	zfs clone \
-		-o mountpoint=legacy \
-		"$ROOTFS_DATASET/tmp@$SNAPSHOT_NAME" \
-		"rpool/ROOT/$CONTAINER/tmp" ||
-		die "failed to create upgrade /tmp clone"
+	if $TMP_DATASETS_EXIST; then
+		zfs clone \
+			-o mountpoint=legacy \
+			"$ROOTFS_DATASET/tmp@$SNAPSHOT_NAME" \
+			"rpool/ROOT/$CONTAINER/tmp" ||
+			die "failed to create upgrade /tmp clone"
 
-	zfs clone \
-		-o mountpoint=legacy \
-		"$ROOTFS_DATASET/vartmp@$SNAPSHOT_NAME" \
-		"rpool/ROOT/$CONTAINER/vartmp" ||
-		die "failed to create upgrade /var/tmp clone"
+		zfs clone \
+			-o mountpoint=legacy \
+			"$ROOTFS_DATASET/vartmp@$SNAPSHOT_NAME" \
+			"rpool/ROOT/$CONTAINER/vartmp" ||
+			die "failed to create upgrade /var/tmp clone"
+	fi
 
 	case "$type" in
 	not-in-place)
@@ -244,10 +253,13 @@ function create_upgrade_container() {
 			"rpool/ROOT/$CONTAINER/data" "$DIRECTORY/var/delphix"
 		mount_upgrade_container_dataset \
 			"rpool/ROOT/$CONTAINER/log" "$DIRECTORY/var/log"
-		mount_upgrade_container_dataset \
-			"rpool/ROOT/$CONTAINER/tmp" "$DIRECTORY/tmp"
-		mount_upgrade_container_dataset \
-			"rpool/ROOT/$CONTAINER/vartmp" "$DIRECTORY/var/tmp"
+
+		if $TMP_DATASETS_EXIST; then
+			mount_upgrade_container_dataset \
+				"rpool/ROOT/$CONTAINER/tmp" "$DIRECTORY/tmp"
+			mount_upgrade_container_dataset \
+				"rpool/ROOT/$CONTAINER/vartmp" "$DIRECTORY/var/tmp"
+		fi
 
 		#
 		# This function needs to return the container's name to
@@ -299,10 +311,13 @@ function create_upgrade_container() {
 		# unmount these datasets that were mounted above.
 		#
 		unmount_upgrade_container_dataset "rpool/ROOT/$CONTAINER/log"
-		unmount_upgrade_container_dataset "rpool/ROOT/$CONTAINER/tmp"
-		unmount_upgrade_container_dataset "rpool/ROOT/$CONTAINER/vartmp"
 		unmount_upgrade_container_dataset "rpool/ROOT/$CONTAINER/data"
 		unmount_upgrade_container_dataset "rpool/ROOT/$CONTAINER/home"
+
+		if $TMP_DATASETS_EXIST; then
+			unmount_upgrade_container_dataset "rpool/ROOT/$CONTAINER/tmp"
+			unmount_upgrade_container_dataset "rpool/ROOT/$CONTAINER/vartmp"
+		fi
 		;;
 	esac
 
@@ -317,10 +332,15 @@ function create_upgrade_container() {
 		rpool/ROOT/$CONTAINER/home /export/home zfs defaults,x-systemd.before=zfs-import-cache.service 0 0
 		rpool/ROOT/$CONTAINER/data /var/delphix zfs defaults,x-systemd.before=zfs-import-cache.service 0 0
 		rpool/ROOT/$CONTAINER/log  /var/log     zfs defaults,x-systemd.before=zfs-import-cache.service 0 0
-		rpool/ROOT/$CONTAINER/tmp  /tmp         zfs defaults,nosuid,nodev,exec,x-systemd.before=zfs-import-cache.service 0 0
-		rpool/ROOT/$CONTAINER/vartmp  /var/tmp  zfs defaults,nosuid,nodev,exec,x-systemd.before=zfs-import-cache.service 0 0
 		rpool/crashdump            /var/crash   zfs defaults,x-systemd.before=zfs-import-cache.service,x-systemd.before=kdump-tools.service 0 0
 	EOF
+
+	if $TMP_DATASETS_EXIST; then
+		cat <<-EOF >>"$DIRECTORY/etc/fstab"
+			         rpool/ROOT/$CONTAINER/tmp  /tmp         zfs defaults,nosuid,nodev,exec,x-systemd.before=zfs-import-cache.service 0 0
+			         rpool/ROOT/$CONTAINER/vartmp  /var/tmp  zfs defaults,nosuid,nodev,exec,x-systemd.before=zfs-import-cache.service 0 0
+		EOF
+	fi
 
 	#
 	# DLPX-75089 - Since older versions of Delphix did not properly
@@ -494,8 +514,10 @@ function start() {
 		! zfs list "rpool/ROOT/$CONTAINER/home" &>/dev/null ||
 		! zfs list "rpool/ROOT/$CONTAINER/data" &>/dev/null ||
 		! zfs list "rpool/ROOT/$CONTAINER/log" &>/dev/null ||
-		! zfs list "rpool/ROOT/$CONTAINER/tmp" &>/dev/null ||
-		! zfs list "rpool/ROOT/$CONTAINER/vartmp" &>/dev/null; then
+		($TMP_DATASETS_EXIST && {
+			! zfs list "rpool/ROOT/$CONTAINER/tmp" &>/dev/null ||
+				! zfs list "rpool/ROOT/$CONTAINER/vartmp" &>/dev/null
+		}); then
 		die "container '$CONTAINER' non-existent or mis-configured"
 	fi
 
@@ -601,10 +623,12 @@ function destroy() {
 		# which we will catch, and then notify the user.
 		#
 		umount "rpool/ROOT/$CONTAINER/log" &>/dev/null
-		umount "rpool/ROOT/$CONTAINER/tmp" &>/dev/null
-		umount "rpool/ROOT/$CONTAINER/vartmp" &>/dev/null
 		umount "rpool/ROOT/$CONTAINER/data" &>/dev/null
 		umount "rpool/ROOT/$CONTAINER/home" &>/dev/null
+		if $TMP_DATASETS_EXIST; then
+			umount "rpool/ROOT/$CONTAINER/tmp" &>/dev/null
+			umount "rpool/ROOT/$CONTAINER/vartmp" &>/dev/null
+		fi
 		umount "rpool/ROOT/$CONTAINER/root" &>/dev/null
 
 		zfs destroy -r "rpool/ROOT/$CONTAINER" ||

--- a/upgrade/upgrade-scripts/upgrade-container
+++ b/upgrade/upgrade-scripts/upgrade-container
@@ -302,6 +302,33 @@ function create_upgrade_container() {
 		rpool/crashdump           /var/crash    zfs defaults,x-systemd.before=zfs-import-cache.service,x-systemd.before=kdump-tools.service 0 0
 	EOF
 
+	for dir in tmp var/tmp; do
+
+		# Check if the directory is already mounted using 'findmnt'
+		if ! findmnt "/$dir" >/dev/null 2>&1; then
+
+			mount_dir=$(echo "$dir" | sed 's/\//-/g')
+
+			# If the directory is not mounted, create a ZFS dataset with the legacy mountpoint option
+			# $FSNAME is the name of the ZFS filesystem, and the dataset is created under $FSNAME/ROOT/$FSNAME/$dir
+			zfs create -o mountpoint=legacy "$FSNAME/ROOT/$FSNAME/$mount_dir"
+
+			# Create the directory if it doesn't already exist
+			mkdir -p "/$dir"
+
+			# Mount the newly created ZFS filesystem to the directory
+			mount -t zfs "$FSNAME/ROOT/$FSNAME/$mount_dir" "/$dir"
+		fi
+
+		# Define the entry to be added to /etc/fstab
+		fstab_entry="rpool/ROOT/$FSNAME/$mount_dir /$dir zfs defaults,nosuid,nodev,noexec,x-systemd.before=zfs-import-cache.service 0 0"
+
+		if ! grep -qF "$fstab_entry" "$DIRECTORY/etc/fstab"; then
+			# If the entry is not present, append it to the /etc/fstab file
+			echo "$fstab_entry" >>"$DIRECTORY/etc/fstab"
+		fi
+	done
+
 	#
 	# DLPX-75089 - Since older versions of Delphix did not properly
 	# disable the NFS services within the upgrade container, we have

--- a/upgrade/upgrade-scripts/upgrade-container
+++ b/upgrade/upgrade-scripts/upgrade-container
@@ -216,6 +216,18 @@ function create_upgrade_container() {
 		"rpool/ROOT/$CONTAINER/log" ||
 		die "failed to create upgrade /var/log clone"
 
+	zfs clone \
+		-o mountpoint=legacy \
+		"$ROOTFS_DATASET/tmp@$SNAPSHOT_NAME" \
+		"rpool/ROOT/$CONTAINER/tmp" ||
+		die "failed to create upgrade /tmp clone"
+
+	zfs clone \
+		-o mountpoint=legacy \
+		"$ROOTFS_DATASET/vartmp@$SNAPSHOT_NAME" \
+		"rpool/ROOT/$CONTAINER/vartmp" ||
+		die "failed to create upgrade /var/tmp clone"
+
 	case "$type" in
 	not-in-place)
 		#
@@ -232,6 +244,10 @@ function create_upgrade_container() {
 			"rpool/ROOT/$CONTAINER/data" "$DIRECTORY/var/delphix"
 		mount_upgrade_container_dataset \
 			"rpool/ROOT/$CONTAINER/log" "$DIRECTORY/var/log"
+		mount_upgrade_container_dataset \
+			"rpool/ROOT/$CONTAINER/tmp" "$DIRECTORY/tmp"
+		mount_upgrade_container_dataset \
+			"rpool/ROOT/$CONTAINER/vartmp" "$DIRECTORY/var/tmp"
 
 		#
 		# This function needs to return the container's name to
@@ -283,6 +299,8 @@ function create_upgrade_container() {
 		# unmount these datasets that were mounted above.
 		#
 		unmount_upgrade_container_dataset "rpool/ROOT/$CONTAINER/log"
+		unmount_upgrade_container_dataset "rpool/ROOT/$CONTAINER/tmp"
+		unmount_upgrade_container_dataset "rpool/ROOT/$CONTAINER/vartmp"
 		unmount_upgrade_container_dataset "rpool/ROOT/$CONTAINER/data"
 		unmount_upgrade_container_dataset "rpool/ROOT/$CONTAINER/home"
 		;;
@@ -299,35 +317,10 @@ function create_upgrade_container() {
 		rpool/ROOT/$CONTAINER/home /export/home zfs defaults,x-systemd.before=zfs-import-cache.service 0 0
 		rpool/ROOT/$CONTAINER/data /var/delphix zfs defaults,x-systemd.before=zfs-import-cache.service 0 0
 		rpool/ROOT/$CONTAINER/log  /var/log     zfs defaults,x-systemd.before=zfs-import-cache.service 0 0
-		rpool/crashdump           /var/crash    zfs defaults,x-systemd.before=zfs-import-cache.service,x-systemd.before=kdump-tools.service 0 0
+		rpool/ROOT/$CONTAINER/tmp  /tmp         zfs defaults,nosuid,nodev,exec,x-systemd.before=zfs-import-cache.service 0 0
+		rpool/ROOT/$CONTAINER/vartmp  /var/tmp  zfs defaults,nosuid,nodev,exec,x-systemd.before=zfs-import-cache.service 0 0
+		rpool/crashdump            /var/crash   zfs defaults,x-systemd.before=zfs-import-cache.service,x-systemd.before=kdump-tools.service 0 0
 	EOF
-
-	for dir in tmp var/tmp; do
-
-		# Check if the directory is already mounted using 'findmnt'
-		if ! findmnt "/$dir" >/dev/null 2>&1; then
-
-			mount_dir=$(echo "$dir" | sed 's/\//-/g')
-
-			# If the directory is not mounted, create a ZFS dataset with the legacy mountpoint option
-			# $FSNAME is the name of the ZFS filesystem, and the dataset is created under $FSNAME/ROOT/$FSNAME/$dir
-			zfs create -o mountpoint=legacy "$FSNAME/ROOT/$FSNAME/$mount_dir"
-
-			# Create the directory if it doesn't already exist
-			mkdir -p "/$dir"
-
-			# Mount the newly created ZFS filesystem to the directory
-			mount -t zfs "$FSNAME/ROOT/$FSNAME/$mount_dir" "/$dir"
-		fi
-
-		# Define the entry to be added to /etc/fstab
-		fstab_entry="rpool/ROOT/$FSNAME/$mount_dir /$dir zfs defaults,nosuid,nodev,noexec,x-systemd.before=zfs-import-cache.service 0 0"
-
-		if ! grep -qF "$fstab_entry" "$DIRECTORY/etc/fstab"; then
-			# If the entry is not present, append it to the /etc/fstab file
-			echo "$fstab_entry" >>"$DIRECTORY/etc/fstab"
-		fi
-	done
 
 	#
 	# DLPX-75089 - Since older versions of Delphix did not properly
@@ -500,7 +493,9 @@ function start() {
 		! zfs list "rpool/ROOT/$CONTAINER/root" &>/dev/null ||
 		! zfs list "rpool/ROOT/$CONTAINER/home" &>/dev/null ||
 		! zfs list "rpool/ROOT/$CONTAINER/data" &>/dev/null ||
-		! zfs list "rpool/ROOT/$CONTAINER/log" &>/dev/null; then
+		! zfs list "rpool/ROOT/$CONTAINER/log" &>/dev/null ||
+		! zfs list "rpool/ROOT/$CONTAINER/tmp" &>/dev/null ||
+		! zfs list "rpool/ROOT/$CONTAINER/vartmp" &>/dev/null; then
 		die "container '$CONTAINER' non-existent or mis-configured"
 	fi
 
@@ -606,6 +601,8 @@ function destroy() {
 		# which we will catch, and then notify the user.
 		#
 		umount "rpool/ROOT/$CONTAINER/log" &>/dev/null
+		umount "rpool/ROOT/$CONTAINER/tmp" &>/dev/null
+		umount "rpool/ROOT/$CONTAINER/vartmp" &>/dev/null
 		umount "rpool/ROOT/$CONTAINER/data" &>/dev/null
 		umount "rpool/ROOT/$CONTAINER/home" &>/dev/null
 		umount "rpool/ROOT/$CONTAINER/root" &>/dev/null


### PR DESCRIPTION
It depended on https://github.com/delphix/pipeline-shared/pull/306 - MERGED to pass test cases.

# Problem
- The '/var/tmp' directory and `/tmp` directory are world-writable directories used for temporary storage by all users and some applications. Since the directories '/var/tmp' and `/tmp` are used for temporary storage and are intended to be world-writable these directories, these directories should have a separate partition to avoid the risk of resource exhaustion and appropriate security options such as `nodev`, `noexec` and `nosuid` set for the partition to avoid security vulnerabilities.

# Solution
- Created a separate mount point for the `/tmp` and `/var/tmp` directories. And added them inside the `/etc/fstab` to restrict the `suid, dev and exec` permissions. 
- Also updated for the upgrade to handle the below 2 scenarios: 
    - Upgrade from a system that does not have a separate `/tmp` and `/var/tmp` filesystem: In this case, do nothing related to `/tmp` and `/var/tmp`; proceed with the upgrade as is. Even after the upgrade, the system will still not be a CIS compliant.
    - Upgrade from a system that does have a separate `/tmp` and `/var/tmp` filesystem: In this scenario, upgrade with the mount, ensuring that it remains CIS compliant.

# Testing
- Ran ab-pre-push https://selfservice-jenkins.eng-tools-prd.aws.delphixcloud.com/job/appliance-build-orchestrator-pre-push/9600/ - PASSED
 
### Manual
- Created VM from the ab-pre push image and checked the mount for the `/tmp` and `/var/tmp`
<img width="1115" alt="Screenshot 2024-10-14 at 11 42 18 AM" src="https://github.com/user-attachments/assets/cc1d1860-9364-4695-b464-5e842030d9be">

- Checked the above two upgrade scenarios, and they are working as expected. For CIS-compliant systems, the upgrade maintains CIS compliance, and for non-CIS-compliant systems, the upgrade proceeds without changes to the compliance status.