### PR TITLE
DLPX-92280 [Backport of Issue DLPX-92279] Appliance build to take as input DCT S3 URL and app version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -54,6 +54,7 @@ for (variant in allVariants) {
         for (envVar in ["DELPHIX_PLATFORMS",
                         "DELPHIX_HOTFIX_VERSION",
                         "DELPHIX_MINIMUM_VERSION",
+                        "DELPHIX_PACKAGED_APP_VERSION",
                         "AWS_S3_URI_LIVEBUILD_ARTIFACTS",
                         "AWS_S3_URI_COMBINED_PACKAGES"]) {
             inputs.property(envVar, System.getenv(envVar)).optional(true)

--- a/live-build/build.gradle
+++ b/live-build/build.gradle
@@ -101,6 +101,7 @@ for (variant in allVariants) {
 
                 for (envVar in ["APPLIANCE_PASSWORD",
                                 "DELPHIX_APPLIANCE_VERSION",
+                                "DELPHIX_PACKAGED_APP_VERSION",
                                 "DELPHIX_HOTFIX_VERSION",
                                 "DELPHIX_PACKAGE_MIRROR_MAIN",
                                 "DELPHIX_PACKAGE_MIRROR_SECONDARY",

--- a/live-build/config/hooks/vm-artifacts/90-raw-disk-image.binary
+++ b/live-build/config/hooks/vm-artifacts/90-raw-disk-image.binary
@@ -167,6 +167,12 @@ if [[ -n "$DELPHIX_HOTFIX_VERSION" ]]; then
 		"$FSNAME/ROOT/$FSNAME"
 fi
 
+if [[ -n "$DELPHIX_PACKAGED_APP_VERSION" ]]; then
+	zfs set \
+		"com.delphix:packaged-app-version=$DELPHIX_PACKAGED_APP_VERSION" \
+		"$FSNAME/ROOT/$FSNAME"
+fi
+
 if [[ -n "$DELPHIX_MINIMUM_VERSION" ]]; then
 	zfs set \
 		"com.delphix:minimum-version=$DELPHIX_MINIMUM_VERSION" \

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -144,7 +144,7 @@ function download_dct_artifacts() {
 	mkdir "$target_dir/dct"
 	pushd "$target_dir/dct" &>/dev/null || exit 1
 
-	aws s3 sync "$DCT_S3_DIR/$DCT_PACKAGE_PREFIX" .
+	aws s3 sync "$dct_artifacts_uri" .
 	sha256sum -c SHA256SUMS
 
 	popd &>/dev/null || exit 1

--- a/scripts/create-build-info-package.sh
+++ b/scripts/create-build-info-package.sh
@@ -94,6 +94,9 @@ check_env DELPHIX_APPLIANCE_VERSION
 echo "$DELPHIX_APPLIANCE_VERSION" >"$target/appliance-build/DELPHIX_APPLIANCE_VERSION"
 check_env AWS_S3_HOTFIX_METADATA
 echo "$AWS_S3_HOTFIX_METADATA" >"$target/appliance-build/HOTFIX_METDATA"
+if [[ -n "$DELPHIX_PACKAGED_APP_VERSION" ]]; then
+	echo "$DELPHIX_PACKAGED_APP_VERSION" >"$target/appliance-build/DELPHIX_PACKAGED_APP_VERSION"
+fi
 
 #
 # Build the package

--- a/scripts/upgrade-image-from-aptly-repo.sh
+++ b/scripts/upgrade-image-from-aptly-repo.sh
@@ -87,13 +87,17 @@ sed -i "s/@@VERSION@@/$VERSION/" version.info ||
 	die "failed to set VERSION in version.info file"
 
 #
-# The DELPHIX_HOTFIX_VERSION variable is optional, and thus it may not
-# be set at this point. That is by design, and when that's the case, we
-# still need to do this replacement, such that the version information
-# file properly reflects an empty value for the hotfix version.
+# The DELPHIX_HOTFIX_VERSION and DELPHIX_PACKAGED_APP_VERSION variable are optional,
+# optional, and thus may not be set at this point. That is by design, and
+# when that's the case, we still need to do these replacements, such that
+# the version information file properly reflects empty values for the
+# hotfix and app versions.
 #
 sed -i "s/@@HOTFIX@@/$DELPHIX_HOTFIX_VERSION/" version.info ||
 	die "failed to set HOTFIX in version.info file"
+
+sed -i "s/@@PACKAGED_APP_VERSION@@/$DELPHIX_PACKAGED_APP_VERSION/" version.info ||
+	die "failed to set PACKAGED_APP_VERSION in version.info file"
 
 #
 # On 6.0 versions, the virtualization application expects to find the

--- a/upgrade/prepare
+++ b/upgrade/prepare
@@ -109,6 +109,9 @@ popd &>/dev/null || die "'popd' failed"
 if [[ -n "$HOTFIX" ]]; then
 	VERSION="$VERSION-$HOTFIX"
 fi
+if [[ -n "$PACKAGED_APP_VERSION" ]]; then
+	VERSION="$VERSION-$PACKAGED_APP_VERSION"
+fi
 
 $opt_f && rm -rf "${UPDATE_DIR:?}/$VERSION" >/dev/null 2>&1
 

--- a/upgrade/upgrade-scripts/common.sh
+++ b/upgrade/upgrade-scripts/common.sh
@@ -49,6 +49,7 @@ PROP_CURRENT_VERSION="com.delphix:current-version"
 PROP_INITIAL_VERSION="com.delphix:initial-version"
 PROP_HOTFIX_VERSION="com.delphix:hotfix-version"
 PROP_MINIMUM_VERSION="com.delphix:minimum-version"
+PROP_PACKAGED_APP_VERSION="com.delphix:packaged-app-version"
 
 #
 # To better enable root cause analysis of any upgrade failures, we
@@ -200,6 +201,10 @@ function get_current_version() {
 
 function get_hotfix_version() {
 	get_version_property "$PROP_HOTFIX_VERSION"
+}
+
+function get_packaged_app_version() {
+	get_version_property "$PROP_PACKAGED_APP_VERSION"
 }
 
 function copy_required_dataset_property() {

--- a/upgrade/upgrade-scripts/execute
+++ b/upgrade/upgrade-scripts/execute
@@ -182,6 +182,8 @@ if [[ -n "$CURRENT_VERSION" ]]; then
 		"$ROOTFS_CONTAINER" "$ROOTFS_CONTAINER@execute-upgrade.$UNIQUE"
 	copy_optional_dataset_property "$PROP_HOTFIX_VERSION" \
 		"$ROOTFS_CONTAINER" "$ROOTFS_CONTAINER@execute-upgrade.$UNIQUE"
+	copy_optional_dataset_property "$PROP_PACKAGED_APP_VERSION" \
+		"$ROOTFS_CONTAINER" "$ROOTFS_CONTAINER@execute-upgrade.$UNIQUE"
 fi
 
 if [[ -f /etc/apt/sources.list ]]; then
@@ -549,6 +551,16 @@ if [[ -n "$HOTFIX" ]]; then
 else
 	zfs inherit "$PROP_HOTFIX_VERSION" "$ROOTFS_CONTAINER" ||
 		die "failed to inherit property '$PROP_HOTFIX_VERSION'" \
+			"for '$ROOTFS_CONTAINER'"
+fi
+
+if [[ -n "$PACKAGED_APP_VERSION" ]]; then
+	zfs set "$PROP_PACKAGED_APP_VERSION=$PACKAGED_APP_VERSION" "$ROOTFS_CONTAINER" ||
+		die "failed to set property '$PROP_PACKAGED_APP_VERSION'" \
+			"to '$PACKAGED_APP_VERSION' for '$ROOTFS_CONTAINER'"
+else
+	zfs inherit "$PROP_PACKAGED_APP_VERSION" "$ROOTFS_CONTAINER" ||
+		die "failed to inherit property '$PROP_PACKAGED_APP_VERSION'" \
 			"for '$ROOTFS_CONTAINER'"
 fi
 

--- a/upgrade/upgrade-scripts/upgrade
+++ b/upgrade/upgrade-scripts/upgrade
@@ -311,6 +311,7 @@ function rollback() {
 	[[ -n "$ROLLBACK_BASE_VERSION" ]] ||
 		die "unable to determine current appliance version"
 	ROLLBACK_BASE_HOTFIX="$(get_hotfix_version)"
+	ROLLBACK_BASE_PACKAGED_APP_VERSION="$(get_packaged_app_version)"
 
 	set_upgrade_property "ROLLBACK_BASE_CONTAINER" "$ROLLBACK_BASE_CONTAINER" ||
 		die "failed setting 'ROLLBACK_BASE_CONTAINER' property"
@@ -320,6 +321,11 @@ function rollback() {
 	if [[ -n "$ROLLBACK_BASE_HOTFIX" ]]; then
 		set_upgrade_property "ROLLBACK_BASE_HOTFIX" "$ROLLBACK_BASE_HOTFIX" ||
 			die "failed setting 'ROLLBACK_BASE_HOTFIX' property"
+	fi
+	if [[ -n "$ROLLBACK_BASE_PACKAGED_APP_VERSION" ]]; then
+		set_upgrade_property "ROLLBACK_BASE_PACKAGED_APP_VERSION" \
+			"$ROLLBACK_BASE_PACKAGED_APP_VERSION" ||
+			die "failed setting 'ROLLBACK_BASE_PACKAGED_APP_VERSION' property"
 	fi
 
 	if [[ "$UPGRADE_BASE_CONTAINER" == "$ROLLBACK_BASE_CONTAINER" ]]; then

--- a/upgrade/version.info.template
+++ b/upgrade/version.info.template
@@ -40,6 +40,11 @@ VERSION=@@VERSION@@
 HOTFIX=@@HOTFIX@@
 
 #
+# The app version contained in the upgrade image (if any)
+#
+PACKAGED_APP_VERSION=@@PACKAGED_APP_VERSION@@
+
+#
 # The minimum product version an engine must have installed, in order to
 # upgrade using this upgrade image.
 #


### PR DESCRIPTION
<h2> Background </h2>

This is a backport of all the necessary changes for the DCT closed appliance to release on top of 27.0.0.1.

I listed all the changes made after the cut of the patch branch:
```
$ git log --pretty='format:%C(auto)%h (%an, %s, %ad)' origin/develop --since 2024/08/21
bda104f (Paul Dagnelie, Install libtool-bin specifically (#773), Thu Sep 26 12:03:58 2024 -0700)
09a7a65 (eyalkaspi-delphix, Merge pull request #768 from delphix/dlpx/pr/eyalkaspi-delphix/6c97b1cd-e613-42c4-a41c-0137e797f8c5, Wed Sep 25 11:15:37 2024 +0200)
42cccb7 (eyalkaspi-delphix, Merge branch 'develop' into dlpx/pr/eyalkaspi-delphix/6c97b1cd-e613-42c4-a41c-0137e797f8c5, Wed Sep 25 11:13:43 2024 +0200)
99651d3 (Eyal Kaspi, rename to packaged app version, Wed Sep 4 10:53:31 2024 +0200)
d856da1 (Eyal Kaspi, Setting the app version on upgrade, Thu Aug 29 14:56:02 2024 +0200)
84a6ab3 (Eyal Kaspi, version directory must include app-version, Thu Aug 29 14:06:51 2024 +0200)02:50:17 2024 +0200)
```

Among these, only `09a7a65` is relevant as it is a non-squashed merge commit that includes all commits below it (all by Eyal Kaspi). Refer to the original PR for details: #768 and comparison.

The top commit by pdagnelie is not relevant for this patch release.

<h2> Solution </h2>

Cleanly cherry-picked commit `09a7a65` without any conflicts.

<h2> Testing Done </h2>

- [In progress] Kicked off a DCT release job pointing to this branch: http://ops.ops-em.dcol2.delphix.com/job/dct-engine-release/7/
- This will run appliance-rebuild and consume these changes.