### PR TITLE
DLPX-86539 CIS: postgres user account settings

### DIFF
--- a/live-build/misc/ansible-roles/appliance-build.minimal-common/tasks/main.yml
+++ b/live-build/misc/ansible-roles/appliance-build.minimal-common/tasks/main.yml
@@ -43,6 +43,11 @@
     password:
       "{{ lookup('env', 'APPLIANCE_PASSWORD') | password_hash('sha512') }}"
 
+- file:
+    path: /export/home/delphix
+    mode: '0750'
+    state: directory
+
 - user:
     name: root
     password:


### PR DESCRIPTION
# Problem
Status of the home directory ownership and permissions for the user accounts (non-system users) defined within the /etc/passwd file

A home directory or the login directory is a directory assigned to each user account that serves as the repository to store personal files, directories, programs and the user profiles to set local environment variables. Since each user is accountable for the files stored in their home directory, the respective user must be the owner of the directory and the permissions should be set accordingly. As unrestricted ownership/permissions could allow unauthorized access to files and directories containing sensitive and restricted information, which could lead to privilege escalation exploits. Ownership and permissions for the home directories should be restricted as appropriate to the needs of the business.

We currently have three non-system users:

`/var/lib/postgresql (user: postgres)`: Owner = postgres:postgres, Permissions = drwxr-xr-x

`/export/home/delphix (user: delphix)`: Owner = delphix:staff, Permissions = drwxr-xr-x

`/export/home/cli (user: cli)`: Owner = cli:staff, Permissions = drwxr-xr-x

All three directories have 755 permissions. This should be 750 for all 3.

# Solution

# Testing
- http://selfservice.jenkins.delphix.com/job/appliance-build-orchestrator-pre-push/9438/ - Running