### PR TITLE
Add xxhash to support upstream ZFS test changes

### DIFF
--- a/live-build/misc/ansible-roles/appliance-build.zfsonlinux-development/tasks/main.yml
+++ b/live-build/misc/ansible-roles/appliance-build.zfsonlinux-development/tasks/main.yml
@@ -55,6 +55,7 @@
       - unzip
       - uuid-dev
       - wget
+      - xxhash
       - zlib1g-dev
     state: present
   register: result


### PR DESCRIPTION
In order to run the zfs-test suite, we need to have xxhash installed. This PR adds it as a dependency for the zfsonlinux-development role, so it should be installed on all the images that need to run the ZFS test suite.