### PR TITLE
DLPX-92515 Make /tmp and /var/tmp exec

### DIFF
--- a/live-build/config/hooks/vm-artifacts/90-raw-disk-image.binary
+++ b/live-build/config/hooks/vm-artifacts/90-raw-disk-image.binary
@@ -315,8 +315,8 @@ cat <<-EOF >"$DIRECTORY/etc/fstab"
 	rpool/ROOT/$FSNAME/home /export/home zfs defaults,x-systemd.before=zfs-import-cache.service 0 0
 	rpool/ROOT/$FSNAME/data /var/delphix zfs defaults,x-systemd.before=zfs-import-cache.service 0 0
 	rpool/ROOT/$FSNAME/log  /var/log     zfs defaults,x-systemd.before=zfs-import-cache.service 0 0
-	rpool/ROOT/$FSNAME/tmp  /tmp     zfs defaults,nosuid,nodev,noexec,x-systemd.before=zfs-import-cache.service 0 0
-	rpool/ROOT/$FSNAME/vartmp  /var/tmp     zfs defaults,nosuid,nodev,noexec,x-systemd.before=zfs-import-cache.service 0 0
+	rpool/ROOT/$FSNAME/tmp  /tmp     zfs defaults,nosuid,nodev,exec,x-systemd.before=zfs-import-cache.service 0 0
+	rpool/ROOT/$FSNAME/vartmp  /var/tmp     zfs defaults,nosuid,nodev,exec,x-systemd.before=zfs-import-cache.service 0 0
 	rpool/crashdump  /var/crash     zfs defaults,x-systemd.before=zfs-import-cache.service,x-systemd.before=kdump-tools.service 0 0
 EOF
 

--- a/upgrade/upgrade-scripts/upgrade-container
+++ b/upgrade/upgrade-scripts/upgrade-container
@@ -340,8 +340,8 @@ function create_upgrade_container() {
 
 	if $TMP_DATASETS_EXIST; then
 		cat <<-EOF >>"$DIRECTORY/etc/fstab"
-			         rpool/ROOT/$CONTAINER/tmp  /tmp         zfs defaults,nosuid,nodev,noexec,x-systemd.before=zfs-import-cache.service 0 0
-			         rpool/ROOT/$CONTAINER/vartmp  /var/tmp  zfs defaults,nosuid,nodev,noexec,x-systemd.before=zfs-import-cache.service 0 0
+			         rpool/ROOT/$CONTAINER/tmp  /tmp         zfs defaults,nosuid,nodev,exec,x-systemd.before=zfs-import-cache.service 0 0
+			         rpool/ROOT/$CONTAINER/vartmp  /var/tmp  zfs defaults,nosuid,nodev,exec,x-systemd.before=zfs-import-cache.service 0 0
 		EOF
 	fi
 


### PR DESCRIPTION
# Problem
- After merging the PR https://github.com/delphix/appliance-build/pull/774, unit test and black-box tests start failing, as in dx-tests it takes unittest-develop image all the time so it worked in PR but after merging, unit test image got updated which leading to below failure: 
link: https://selfservice-jenkins.eng-tools-prd.aws.delphixcloud.com/job/integration-tests/job/split-precommit-unittest/job/develop/1880/console
```
09:55:11  + sshpass -p **** ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -l delphix split-precommit-unittest-1880-422dfe1b-2.dlpxdc.co /tmp/enable-swap.sh -s 4096
09:55:11  Warning: Permanently added 'split-precommit-unittest-1880-422dfe1b-2.dlpxdc.co,10.110.211.240' (ECDSA) to the list of known hosts.
09:55:12  bash: /tmp/enable-swap.sh: Permission denied
```

We fixed it as part of https://github.com/delphix/pipeline-shared/pull/309 but then we started getting:
link: http://selfservice.dbs.dcol2.delphix.com/job/integration-tests/job/split-precommit-unittest/job/pre-push/1/console
```
Caused by: java.lang.UnsatisfiedLinkError: /tmp/libjunixsocket-native-2.0.44897595271091496283.so: /tmp/libjunixsocket-native-2.0.44897595271091496283.so: failed to map segment from shared object
15:57:12  	at java.lang.ClassLoader$NativeLibrary.load(Native Method)
15:57:12  	at java.lang.ClassLoader.loadLibrary0(ClassLoader.java:1934)
15:57:12  	at java.lang.ClassLoader.loadLibrary(ClassLoader.java:1817)
15:57:12  	at java.lang.Runtime.load0(Runtime.java:782)
15:57:12  	at java.lang.System.load(System.java:1100)
15:57:12  	at org.newsclub.net.unix.NarSystem.loadLibrary(NarSystem.java:39)
15:57:12  	... 35 more
```

# Solution

- As there are so many issues revert `/tmp` and `/var/tmp` to exec and then handle that separately to unblock tests.

# Testing
- No possible to pass as it will take unittest-develop image.