### PR TITLE
DLPX-92566 Third-party source list file prevented upgrade

### DIFF
--- a/upgrade/upgrade-scripts/execute
+++ b/upgrade/upgrade-scripts/execute
@@ -191,15 +191,8 @@ fi
 # /etc/apt/sources.list.d/ because only the Delphix repository
 # from the upgrade image must be used to install/upgrade packages.
 #
-if [[ -f /etc/apt/sources.list ]]; then
-	rm /etc/apt/sources.list || die "failed to delete /etc/apt/sources.list"
-fi
-
-if [[ -d /etc/apt/sources.list.d ]]; then
-	for file in /etc/apt/sources.list.d/*; do
-		rm "$file" || die "failed to delete $file"
-	done
-fi
+rm -f /etc/apt/sources.list
+rm -f /etc/apt/sources.list.d/*
 
 #
 # Create a new sources.list that only contains the Delphix repository from
@@ -470,11 +463,11 @@ dpkg-query -Wf '${Conffiles}\n' | awk '$3 == "obsolete" {print $1}' |
 
 #
 # Now that all the packages have been installed, delete the newly created
-# central /etc/apt/sources.list.
+# central /etc/apt/sources.list and also empty out the /etc/apt/sources.list.d/ directory
+# again in case packages added their own sources.
 #
-if [[ -f /etc/apt/sources.list ]]; then
-	rm /etc/apt/sources.list || die "failed to delete /etc/apt/sources.list"
-fi
+rm -f /etc/apt/sources.list
+rm -f /etc/apt/sources.list.d/*
 
 #
 # Due to https://github.com/influxdata/telegraf/issues/14052, telegraf must be masked after

--- a/upgrade/upgrade-scripts/execute
+++ b/upgrade/upgrade-scripts/execute
@@ -186,11 +186,26 @@ if [[ -n "$CURRENT_VERSION" ]]; then
 		"$ROOTFS_CONTAINER" "$ROOTFS_CONTAINER@execute-upgrade.$UNIQUE"
 fi
 
+#
+# Delete the central /etc/apt/sources.list and also all files in
+# /etc/apt/sources.list.d/ because only the Delphix repository
+# from the upgrade image must be used to install/upgrade packages.
+#
 if [[ -f /etc/apt/sources.list ]]; then
-	mv /etc/apt/sources.list /etc/apt/sources.list.orig ||
-		die "failed to save /etc/apt/sources.list"
+	rm /etc/apt/sources.list || die "failed to delete /etc/apt/sources.list"
 fi
 
+if [[ -d /etc/apt/sources.list.d ]]; then
+	for file in /etc/apt/sources.list.d/*; do
+		rm "$file" || die "failed to delete $file"
+	done
+fi
+
+#
+# Create a new sources.list that only contains the Delphix repository from
+# the image. This ensures packages are only sourced from the upgrade
+# image.
+#
 cat <<EOF >/etc/apt/sources.list ||
 deb [trusted=yes] file://$IMAGE_PATH focal delphix
 EOF
@@ -454,6 +469,14 @@ dpkg-query -Wf '${Conffiles}\n' | awk '$3 == "obsolete" {print $1}' |
 	done || die "failed to remove obsolete package configuration files"
 
 #
+# Now that all the packages have been installed, delete the newly created
+# central /etc/apt/sources.list.
+#
+if [[ -f /etc/apt/sources.list ]]; then
+	rm /etc/apt/sources.list || die "failed to delete /etc/apt/sources.list"
+fi
+
+#
 # Due to https://github.com/influxdata/telegraf/issues/14052, telegraf must be masked after
 # packages are upgraded. The telegraf package removes /etc/systemd/system/telegraf.service thus
 # reversing the `systemctl mask` operation performed before the packages are upgraded.
@@ -485,19 +508,6 @@ zcat "/usr/share/doc/delphix-entire-$opt_p/packages.list.gz" | sed 's/=/ /' |
 			die "'$name' package version incompatible;" \
 				"'$installed' '=' '$version'"
 	done || die "verification of package versions failed"
-
-if [[ -f /etc/apt/sources.list.orig ]]; then
-	mv /etc/apt/sources.list.orig /etc/apt/sources.list ||
-		die "failed to restore /etc/apt/sources.list"
-else
-	#
-	# If "/etc/apt/sources.list.orig" does not exist, then it likely
-	# means the system didn't have a "/etc/apt/sources.list" file to
-	# begin with; so we restore that state by simply removing our
-	# dynamically generated "sources.list" file (generated earlier).
-	#
-	rm /etc/apt/sources.list
-fi
 
 #
 # As mentioned in an earlier comment, when $CURRENT_VERSION is not set,


### PR DESCRIPTION
<!--
<details open>
<summary><h2> Background </h2></summary>

Provide a clear description of the high-level effort with which this
pull request is associated. Recall that while anyone in the organization
can see this pull request, not everyone necessarily has the same context
as you. If applicable, link to design documents or high-level tracking
epics here.
</details>
-->

<details open>
<summary><h2> Problem </h2></summary>

We have logic in our upgrade scripts that temporarily creates a backup
copy of `/etc/apt/sources.list`, writes a new one that points to the 
upgrade image and restores the original file after the upgrade. Recent
cases have revealed that this is insufficient since the upgrade scripts
do not delete list files in `/etc/apt/sources.list.d/` and also since
we can completely remove `/etc/apt/sources.list` before and after the
upgrade because that is the only time we will install/upgrade packages.
</details>

<!--
<details>
<summary><h2> Evaluation </h2></summary>

If the cause of the problem is not obvious, provide a root-cause
analysis (RCA), ideally using the Five Whys iterative interrogative
technique or some other form of analytical reasoning.
</details>
-->

<details open>
<summary><h2> Solution </h2></summary>

Add logic to remove `/etc/apt/sources.list`, all files under `/etc/apt/sources.list.d/`
and also permanently delete `/etc/apt/sources.list` after packages have been installed.
</details>


<details open>
<summary><h2> Testing Done </h2></summary>

ab-pre-push: https://selfservice-jenkins.eng-tools-prd.aws.delphixcloud.com/job/appliance-build-orchestrator-pre-push/9910/console

Manual test:
Before upgrade, I created file `/etc/apt/sources.list.d/aptly-sources-test.list`:
```
delphix@ip-10-110-247-208:~$ ls /etc/apt/sources.list
/etc/apt/sources.list
delphix@ip-10-110-247-208:~$ cat /etc/apt/sources.list.d/aptly-sources-test.list
deb [signed-by=/etc/apt/keyrings/aptly.asc] http://repo.aptly.info/ squeeze main
```
Started an [upgrade](https://selfservice-jenkins.eng-tools-prd.aws.delphixcloud.com/job/blackbox-self-service/155795/consoleFull)
During the upgrade:
```
Nov 28 05:25:49 ip-10-110-247-208 upgrade-scripts:execute[34514]: /var/dlpx-update/30.0.0.0-snapshot.20241127201739948+jenkins-selfservice-appliance-build-develop-pre-push-3770/execute::194 rm -f /etc/apt/sources.list
Nov 28 05:25:49 ip-10-110-247-208 upgrade-scripts:execute[34514]: /var/dlpx-update/30.0.0.0-snapshot.20241127201739948+jenkins-selfservice-appliance-build-develop-pre-push-3770/execute::195 rm -f /etc/apt/sources.list.d/aptly-sources-test.list
```
After the upgrade:
```
delphix@ip-10-110-247-208:~$ ls /etc/apt/sources.list
ls: cannot access '/etc/apt/sources.list': No such file or directory
delphix@ip-10-110-247-208:~$ ls /etc/apt/sources.list.d/aptly-sources-test.list
ls: cannot access '/etc/apt/sources.list.d/aptly-sources-test.list': No such file or directory
```
</details>


<!--
<details>
<summary><h2> Implementation </h2></summary>

Describe the implementation details of the solution. Generally the
reasoning behind any non-obvious code should be recorded in code
comments. However, code comments should always describe the current
state of the code; in contrast, this section may be useful to describe
the relationship between the original code and the code being proposed
in this pull request.
</details>
-->

<!--
<details>
<summary><h2> Notes to Reviewers </h2></summary>

Provide any extra information a reviewer may need to know before
evaluating your pull request. For example, you may wish to describe
which files should be reviewed first or which files are auto-generated.
If the review tool cannot detect a file move, you may wish to link to a
patch comparing the old file and the new file.
</details>
-->

<!--
<details>
<summary><h2> Deployment Plan </h2></summary>

Describe how the code in this pull request will be deployed. Some
deployments are complicated and may require flag days between multiple
repositories or the provisioning of new infrastructure. Describing your
deployment plan allows reviewers to ensure that your work will not cause
any unnecessary interruption to end users.
</details>
-->

<!--
<details>
<summary><h2> Future Work </h2></summary>

Provide a description of any possible follow-up work that is explicitly
not being done in this pull request.
</details>
-->

<!--
<details>
<summary><h2> Bonus </h2></summary>

Provide a description of any extra problems you have solved in this pull
request.
</details>
-->
