### PR TITLE
DLPX-93224 Remove unnecessary tasks related to python3.11 added by previous os-upgrade PRs

### DIFF
--- a/bootstrap/roles/appliance-build.bootstrap/tasks/main.yml
+++ b/bootstrap/roles/appliance-build.bootstrap/tasks/main.yml
@@ -51,6 +51,7 @@
       - openjdk-8-jdk-headless
       - pigz
       - python3-passlib
+      - python3-pip
       - qemu-system
       - rename
       - shellcheck
@@ -59,12 +60,13 @@
     state: present
     update_cache: true
 
-# aws-cli is distributed via snap on 24.04. While the package is not required by the product,
+# awscli is distributed via pip or snap on 24.04. While the package is not required by the product,
 # it is required by appliance-build itself.
-- name: Install aws-cli snap package
-  community.general.snap:
-    name: aws-cli
-    classic: true
+- name: Install awscli python package
+  ansible.builtin.pip:
+    name: awscli
+    break_system_packages: true
+  become: true
 
 - name: Load ZFS kernel module.
   community.general.modprobe:

--- a/bootstrap/roles/appliance-build.bootstrap/tasks/main.yml
+++ b/bootstrap/roles/appliance-build.bootstrap/tasks/main.yml
@@ -50,6 +50,7 @@
       - man
       - openjdk-8-jdk-headless
       - pigz
+      - python3-passlib
       - qemu-system
       - rename
       - shellcheck

--- a/bootstrap/roles/appliance-build.bootstrap/tasks/main.yml
+++ b/bootstrap/roles/appliance-build.bootstrap/tasks/main.yml
@@ -15,11 +15,19 @@
 #
 
 ---
-# The VSDK plugin requires python3.11. The deadsnakes PPA provides python3.11 on 24.04.
-- name: Add deadsnakes PPA for python3.11 for vSDK
-  ansible.builtin.apt_repository:
-    repo: ppa:deadsnakes/ppa
-    state: present
+- name: Stop unattended-upgrades systemd service in preparation for package removal
+  ansible.builtin.systemd:
+    name: unattended-upgrades
+    state: stopped
+  register: result_systemd_stop
+  failed_when: "result_systemd_stop is failed and 'Could not find the requested service' not in result_systemd_stop.msg"
+
+- name: Remove unattended-upgrades package
+  ansible.builtin.apt:
+    name:
+      - unattended-upgrades
+    state: absent
+    purge: true
 
 - name: Update apt cache and install apt packages
   ansible.builtin.apt:
@@ -42,8 +50,6 @@
       - man
       - openjdk-8-jdk-headless
       - pigz
-      # The VSDK plugin requires python3.11
-      - python3.11
       - qemu-system
       - rename
       - shellcheck
@@ -51,20 +57,6 @@
       - zfsutils-linux
     state: present
     update_cache: true
-
-- name: Stop unattended-upgrades systemd service in preparation for package removal
-  ansible.builtin.systemd:
-    name: unattended-upgrades
-    state: stopped
-  register: result_systemd_stop
-  failed_when: "result_systemd_stop is failed and 'Could not find the requested service' not in result_systemd_stop.msg"
-
-- name: Remove unattended-upgrades package
-  ansible.builtin.apt:
-    name:
-      - unattended-upgrades
-    state: absent
-    purge: true
 
 # aws-cli is distributed via snap on 24.04. While the package is not required by the product,
 # it is required by appliance-build itself.


### PR DESCRIPTION
<!--
<details open>
<summary><h2> Background </h2></summary>

Provide a clear description of the high-level effort with which this
pull request is associated. Recall that while anyone in the organization
can see this pull request, not everyone necessarily has the same context
as you. If applicable, link to design documents or high-level tracking
epics here.
</details>
-->

<details open>
<summary><h2> Problem </h2></summary>

In my previous PRs on this branch, I added `python3.11` as a dependency in the bootstrap role.
Prakash pointed out that this was not required since it is already listed as a build dependency of
the virtualization package and will be installed at build time. As such, I am undoing my previous changes
around python3.11 and the associated PPA.
Prakash also pointed out that unattended-upgrades should be stopped and removed before we install
any packages.

This PR also addresses some other bugs found during testing using the resulting DE-based buildserver:
1. appliance-build fails in [this task](https://github.com/delphix/appliance-build/blob/develop/live-build/misc/ansible-roles/appliance-build.minimal-common/tasks/main.yml#L33) while trying to hash a password. Apparently, ansible needs `passlib` to be installed. I tried installing it directly in the role but ansible still could not find the module. I tried installing it in the chroot env via [apt](https://ops-jenkins.eng-tools-prd.aws.delphixcloud.com/job/appliance-build-stage1/job/post-push/194142/console) and also via [pip](https://ops-jenkins.eng-tools-prd.aws.delphixcloud.com/job/appliance-build-stage1/job/post-push/194163/console), none of those worked. I finally resorted to installing it via bootstrap.
2. appliance-build fails when trying to run `aws` commands because it's not available in the path. It was found that `snapd` is not installed on DE-based buildservers and is in fact installed via a dependency by the bootstrap role. The bootstrap role then goes on to install `aws-cli` via snap but the Jenkins job continues to use the same shell which is why the path is not updated. When I tried to update the path and run the job, I realized that snap didn't allow the `aws` command to run because the home directory on a DE-based buildserver is not in `/home`:
```
delphix@ip-10-110-219-152:~$ aws
Sorry, home directories outside of /home needs configuration.
See https://forum.snapcraft.io/t/11209 for details.
```
I finally resorted to installing awscli via pip, system-wide.
</details>

<details open>
<summary><h2> Testing Done </h2></summary>

https://ops-jenkins.eng-tools-prd.aws.delphixcloud.com/job/appliance-build/job/os-upgrade/job/pre-push/137/console
</details>

<!--
<details>
<summary><h2> Implementation </h2></summary>

Describe the implementation details of the solution. Generally the
reasoning behind any non-obvious code should be recorded in code
comments. However, code comments should always describe the current
state of the code; in contrast, this section may be useful to describe
the relationship between the original code and the code being proposed
in this pull request.
</details>
-->

<!--
<details>
<summary><h2> Notes to Reviewers </h2></summary>

Provide any extra information a reviewer may need to know before
evaluating your pull request. For example, you may wish to describe
which files should be reviewed first or which files are auto-generated.
If the review tool cannot detect a file move, you may wish to link to a
patch comparing the old file and the new file.
</details>
-->

<!--
<details>
<summary><h2> Deployment Plan </h2></summary>

Describe how the code in this pull request will be deployed. Some
deployments are complicated and may require flag days between multiple
repositories or the provisioning of new infrastructure. Describing your
deployment plan allows reviewers to ensure that your work will not cause
any unnecessary interruption to end users.
</details>
-->

<!--
<details>
<summary><h2> Future Work </h2></summary>

Provide a description of any possible follow-up work that is explicitly
not being done in this pull request.
</details>
-->

<!--
<details>
<summary><h2> Bonus </h2></summary>

Provide a description of any extra problems you have solved in this pull
request.
</details>
-->
