### PR TITLE
DLPX-93298 Have live-build set hostname to empty string to avoid static hostname leak

### DIFF
--- a/live-build/config/hooks/vm-artifacts/85-clear-etc-hostname.binary
+++ b/live-build/config/hooks/vm-artifacts/85-clear-etc-hostname.binary
@@ -1,0 +1,24 @@
+#!/bin/bash -eux
+#
+# Copyright 2019 Delphix
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+#
+# Set /etc/hostname to an empty string to allow transient hostnames to be set
+# by systemd-hostnamed. systemd-hostnamed gives precedence to static hostnames
+# if set. Since live-build sets a static hostname, we need to clear it to allow
+# transient hostnames to be set.
+#
+chroot binary truncate -s 0 /etc/hostname


### PR DESCRIPTION
<!--
<details open>
<summary><h2> Background </h2></summary>

Provide a clear description of the high-level effort with which this
pull request is associated. Recall that while anyone in the organization
can see this pull request, not everyone necessarily has the same context
as you. If applicable, link to design documents or high-level tracking
epics here.
</details>
-->

<details open>
<summary><h2> Problem </h2></summary>

20.04 and 24.04 engines both have `localhost.localdomain` set by live-build in `/etc/hostname`.
```
07:49:17  [2025-01-31 15:49:16] lb_chroot_hostname install
07:49:17  P: Configuring file /etc/hostname
07:49:17  P: Configuring file /bin/hostname
```
Source code: https://git.launchpad.net/ubuntu/+source/live-build/tree/scripts/build/lb_chroot_hostname?h=ubuntu/noble-updates#n30
```
		# Create hostname file
		echo "localhost.localdomain" > chroot/etc/hostname
```

While this live-build code also exists on 20.04, a change in `systemd-hostnamed`'s behavior is now causing the static
hostname to take precedence over transient hostnames provided by DHCP. This change in behavior was introduced in
December 2020 - https://github.com/systemd/systemd/pull/17859/commits/d39079fcaa05e23540d2b1f0270fa31c22a7e9f1. This is why we are only seeing this now, in 24.04.
</details>

<!--
<details>
<summary><h2> Evaluation </h2></summary>

If the cause of the problem is not obvious, provide a root-cause
analysis (RCA), ideally using the Five Whys iterative interrogative
technique or some other form of analytical reasoning.
</details>
-->

<details open>
<summary><h2> Solution </h2></summary>

Force live-build to empty out `/etc/hostname`.
</details>


<details open>
<summary><h2> Testing Done </h2></summary>

appliance-build: https://ops-jenkins.eng-tools-prd.aws.delphixcloud.com/job/appliance-build/job/os-upgrade/job/pre-push/154/console
```
 $ ssh delphix@pg-os-upgrade.dcol2
Warning: Permanently added 'pg-os-upgrade.dcol2.delphix.com' (ED25519) to the list of known hosts.
delphix@pg-os-upgrade.dcol2.delphix.com's password:
delphix@pg-os-upgrade:~$ cat /etc/hostname
delphix@pg-os-upgrade:~$ hostnamectl status
   Static hostname: (unset)
Transient hostname: pg-os-upgrade.dcol2
         Icon name: computer-vm
```
</details>

<!--
<details>
<summary><h2> Implementation </h2></summary>

Describe the implementation details of the solution. Generally the
reasoning behind any non-obvious code should be recorded in code
comments. However, code comments should always describe the current
state of the code; in contrast, this section may be useful to describe
the relationship between the original code and the code being proposed
in this pull request.
</details>
-->

<!--
<details>
<summary><h2> Notes to Reviewers </h2></summary>

Provide any extra information a reviewer may need to know before
evaluating your pull request. For example, you may wish to describe
which files should be reviewed first or which files are auto-generated.
If the review tool cannot detect a file move, you may wish to link to a
patch comparing the old file and the new file.
</details>
-->

<!--
<details>
<summary><h2> Deployment Plan </h2></summary>

Describe how the code in this pull request will be deployed. Some
deployments are complicated and may require flag days between multiple
repositories or the provisioning of new infrastructure. Describing your
deployment plan allows reviewers to ensure that your work will not cause
any unnecessary interruption to end users.
</details>
-->

<!--
<details>
<summary><h2> Future Work </h2></summary>

Provide a description of any possible follow-up work that is explicitly
not being done in this pull request.
</details>
-->

<!--
<details>
<summary><h2> Bonus </h2></summary>

Provide a description of any extra problems you have solved in this pull
request.
</details>
-->
