### PR TITLE
DLPX-93328 LTS upgrade: appliance-build: Replace ntp with ntpsec as part of DLPX-93325

### DIFF
--- a/live-build/misc/ansible-roles/appliance-build.dcenter/tasks/main.yml
+++ b/live-build/misc/ansible-roles/appliance-build.dcenter/tasks/main.yml
@@ -86,5 +86,5 @@
 #
 - name: Enable NTP systemd service
   ansible.builtin.systemd_service:
-    name: ntp.service
+    name: ntpsec.service
     enabled: true

--- a/live-build/misc/ansible-roles/appliance-build.virtualization-common/tasks/main.yml
+++ b/live-build/misc/ansible-roles/appliance-build.virtualization-common/tasks/main.yml
@@ -80,7 +80,7 @@
   with_items:
     - delphix-fluentd.service
     - delphix-masking.service
-    - ntp.service
+    - ntpsec.service
     - snmpd.service
 
 #

--- a/upgrade/upgrade-scripts/common.sh
+++ b/upgrade/upgrade-scripts/common.sh
@@ -491,7 +491,7 @@ function fix_and_migrate_services() {
 		delphix-masking.service
 		nfs-mountd.service
 		nginx.service
-		ntp.service
+		ntpsec.service
 		postgresql.service
 		rpc-statd.service
 		rpcbind.service

--- a/upgrade/upgrade-scripts/execute
+++ b/upgrade/upgrade-scripts/execute
@@ -372,9 +372,9 @@ zcat "/usr/share/doc/delphix-entire-$opt_p/packages.list.gz" |
 
 #
 # As part of the LTS upgrade project to 24.04, `ntp` was replaced by `ntpsec`.
-# To preserve and restore the NTP configuration, we need to copy the
-# NTP configuration files to the new location after the upgrade so that NTP
-# continues to function as expected.
+# To preserve and migrate the NTP configuration, we need to copy the
+# NTP configuration file to the new location after packages are upgraded,
+# but before they are removed so that NTP continues to function as expected.
 #
 if [[ -f "/etc/ntp/ntp.conf" ]]; then
 	cp /etc/ntp/ntp.conf /etc/ntpsec/ntp.conf ||

--- a/upgrade/upgrade-scripts/execute
+++ b/upgrade/upgrade-scripts/execute
@@ -344,7 +344,6 @@ apt-mark manual "delphix-entire-$opt_p" ||
 [[ -f "/usr/share/doc/delphix-entire-$opt_p/packages.list.gz" ]] ||
 	die "delphix-entire's packages.list.gz file is missing"
 
-
 #
 # In DLPX-91387, we discovered that cloud-init's preinst script was
 # removing '/etc/cloud/cloud.cfg.d/99-disable-network-config.cfg', which

--- a/upgrade/upgrade-scripts/execute
+++ b/upgrade/upgrade-scripts/execute
@@ -344,6 +344,7 @@ apt-mark manual "delphix-entire-$opt_p" ||
 [[ -f "/usr/share/doc/delphix-entire-$opt_p/packages.list.gz" ]] ||
 	die "delphix-entire's packages.list.gz file is missing"
 
+
 #
 # In DLPX-91387, we discovered that cloud-init's preinst script was
 # removing '/etc/cloud/cloud.cfg.d/99-disable-network-config.cfg', which
@@ -368,6 +369,20 @@ zcat "/usr/share/doc/delphix-entire-$opt_p/packages.list.gz" |
 zcat "/usr/share/doc/delphix-entire-$opt_p/packages.list.gz" |
 	cut -d= -f1 | xargs apt-mark manual ||
 	die "failed to mark as manual packages listed in packages.list.gz file"
+
+#
+# As part of the LTS upgrade project to 24.04, `ntp` was replaced by `ntpsec`.
+# To preserve and restore the NTP configuration, we need to copy the
+# NTP configuration files to the new location after the upgrade so that NTP
+# continues to function as expected.
+#
+if [[ -f "/etc/ntp/ntp.conf" ]]; then
+	cp /etc/ntp/ntp.conf /etc/ntpsec/ntp.conf ||
+		die "failed to copy /etc/ntp/ntp.conf to /etc/ntpsec/ntp.conf"
+	if [[ "$(systemctl is-enabled ntp.service)" == enabled ]]; then
+		systemctl enable ntpsec.service
+	fi
+fi
 
 #
 # After we've successfully installed the new packages and marked them


### PR DESCRIPTION
Associated change of https://github.com/delphix/dlpx-app-gate/pull/2845. 