### PR TITLE
DLPX-93370 Logrotate blackbox tests fail because /var/log/fluent/fluentd.log does not exist

### DIFF
--- a/live-build/misc/ansible-roles/appliance-build.virtualization-common/tasks/main.yml
+++ b/live-build/misc/ansible-roles/appliance-build.virtualization-common/tasks/main.yml
@@ -104,3 +104,16 @@
   command: "systemctl disable {{ item }}"
   with_items:
     - docker.service
+
+#
+# We mask delphix-fluentd, which means that fluentd does not run on boot.
+# The fluentd log file /var/log/fluent/fluentd.log is not created until fluentd
+# is started. Yet, the upstream package `fluent-package` creates a logrotate
+# configuration for this log file. logrotate will fail unless `missingok` is
+# set in the logrotate configuration.
+#
+- name: Have logrotate ignore missing log files
+  lineinfile:
+    path: /etc/logrotate.d/fluentd
+    line: "  missingok"
+    insertafter: "daily"


### PR DESCRIPTION
<!--
<details open>
<summary><h2> Background </h2></summary>

Provide a clear description of the high-level effort with which this
pull request is associated. Recall that while anyone in the organization
can see this pull request, not everyone necessarily has the same context
as you. If applicable, link to design documents or high-level tracking
epics here.
</details>
-->

<details open>
<summary><h2> Problem </h2></summary>

Logrotate Blackbox tests failed with:
```
Error executing command "sudo logrotate /etc/logrotate.conf". Code: 1. Error: error: stat of /var/log/fluent/fluentd.log failed: No such file or directory.
```
I found that on both, `develop` and `os-upgrade` that log file is not created. However, with the new version of `fluent-package`, a logrotate configuration ships as part of the package:
```
delphix@dlpx-palashgandhi-os-upgrade-qar-162282-766f97e2:~$ dpkg -S /etc/logrotate.d/fluentd
fluent-package: /etc/logrotate.d/fluentd

delphix@dlpx-palashgandhi-os-upgrade-qar-162282-766f97e2:~$ cat /etc/logrotate.d/fluentd
/var/log/fluent/fluentd.log {
  daily
  rotate 30
  compress
  delaycompress
  notifempty
  create 640 _fluentd _fluentd
  sharedscripts
  postrotate
    pid=/var/run/fluent/fluentd.pid
    if [ -s "$pid" ]
    then
      kill -USR1 "$(cat $pid)"
    fi
  endscript
}
```

While I do think this is also an upstream bug (& filed https://github.com/fluent/fluent-package-builder/issues/796), I feel our usage of `fluentd` might be to blame equally. 
</details>

<!--
<details>
<summary><h2> Evaluation </h2></summary>

If the cause of the problem is not obvious, provide a root-cause
analysis (RCA), ideally using the Five Whys iterative interrogative
technique or some other form of analytical reasoning.
</details>
-->

<details open>
<summary><h2> Solution </h2></summary>

Add a `missingok` directive in the logrotate configuration for fluentd.
</details>


<details open>
<summary><h2> Testing Done </h2></summary>

https://ops-jenkins.eng-tools-prd.aws.delphixcloud.com/job/appliance-build/job/os-upgrade/job/pre-push/188/

```
delphix@pg-fluentd:~$ cat /etc/logrotate.d/fluentd
/var/log/fluent/fluentd.log {
  daily
  missingok
  rotate 30
  compress
  delaycompress
  notifempty
  create 640 _fluentd _fluentd
  sharedscripts
  postrotate
    pid=/var/run/fluent/fluentd.pid
    if [ -s "$pid" ]
    then
      kill -USR1 "$(cat $pid)"
    fi
  endscript
}

delphix@pg-fluentd:~$ sudo logrotate /etc/logrotate.conf
delphix@pg-fluentd:~$ echo $?
0
```
</details>

<!--
<details>
<summary><h2> Implementation </h2></summary>

Describe the implementation details of the solution. Generally the
reasoning behind any non-obvious code should be recorded in code
comments. However, code comments should always describe the current
state of the code; in contrast, this section may be useful to describe
the relationship between the original code and the code being proposed
in this pull request.
</details>
-->

<!--
<details>
<summary><h2> Notes to Reviewers </h2></summary>

Provide any extra information a reviewer may need to know before
evaluating your pull request. For example, you may wish to describe
which files should be reviewed first or which files are auto-generated.
If the review tool cannot detect a file move, you may wish to link to a
patch comparing the old file and the new file.
</details>
-->

<!--
<details>
<summary><h2> Deployment Plan </h2></summary>

Describe how the code in this pull request will be deployed. Some
deployments are complicated and may require flag days between multiple
repositories or the provisioning of new infrastructure. Describing your
deployment plan allows reviewers to ensure that your work will not cause
any unnecessary interruption to end users.
</details>
-->

<!--
<details>
<summary><h2> Future Work </h2></summary>

Provide a description of any possible follow-up work that is explicitly
not being done in this pull request.
</details>
-->

<!--
<details>
<summary><h2> Bonus </h2></summary>

Provide a description of any extra problems you have solved in this pull
request.
</details>
-->
