### PR TITLE
DLPX-93455 LTS 24.04: Add required ZFS build dependencies to dev role to allow building ZFS on appliance

### DIFF
--- a/live-build/misc/ansible-roles/appliance-build.zfsonlinux-development/tasks/main.yml
+++ b/live-build/misc/ansible-roles/appliance-build.zfsonlinux-development/tasks/main.yml
@@ -27,6 +27,7 @@
       - curl
       - delphix-go
       - delphix-rust
+      - dh-dkms
       - dwarves
       - emacs-nox
       - fakeroot
@@ -40,6 +41,7 @@
       - libelf-dev
       - libselinux-dev
       - libssl-dev
+      - libtirpc-dev
       - libtool-bin
       - libudev-dev
       - llvm-14


### PR DESCRIPTION
<!--
<details open>
<summary><h2> Background </h2></summary>

Provide a clear description of the high-level effort with which this
pull request is associated. Recall that while anyone in the organization
can see this pull request, not everyone necessarily has the same context
as you. If applicable, link to design documents or high-level tracking
epics here.
</details>
-->

<details open>
<summary><h2> Problem </h2></summary>

I ran `zfs-make` on a 24.04 appliance and that failed due to missing
build dependencies.
```
checking for libtirpc... no
...
configure: WARNING: cannot find tirpc via pkg-config or in the standard locations
configure: error: in `/export/home/delphix/zfs':
configure: error: neither libc sunrpc support nor libtirpc is available, try installing libtirpc-devel
See `config.log' for more details
failed: './configure' in /export/home/delphix/zfs
running as user 'delphix' on ''
git-zfs-make took 73 seconds
```
The problem is that these build dependencies need to be installed on dev variants
in order for zfs-make to work.
</details>

<!--
<details>
<summary><h2> Evaluation </h2></summary>

If the cause of the problem is not obvious, provide a root-cause
analysis (RCA), ideally using the Five Whys iterative interrogative
technique or some other form of analytical reasoning.
</details>
-->

<details open>
<summary><h2> Solution </h2></summary>

Install them like we install other build deps.
</details>


<details open>
<summary><h2> Testing Done </h2></summary>

ab-pre-push: https://selfservice-jenkins.eng-tools-prd.aws.delphixcloud.com/job/appliance-build-orchestrator-pre-push/10442/

```
$ dpkg -l | grep -E "dh-dkms|libtirpc-dev"
ii  dh-dkms                                                     3.0.11-1ubuntu13                                                                                 all          debhelper addon for the Dynamic Kernel Module System (DKMS)
ii  libtirpc-dev:amd64                                          1.3.4+ds-1.1build1                                                                               amd64        transport-independent RPC library - development files
```

Ran zfs-make:
```
 $ git zfs-make pg-os-upg-zfs-build-deps.dcol1
BUILD MACHINE: pg-os-upg-zfs-build-deps.dcol1
...
checking for libtirpc... yes
...
```
</details>

<!--
<details>
<summary><h2> Implementation </h2></summary>

Describe the implementation details of the solution. Generally the
reasoning behind any non-obvious code should be recorded in code
comments. However, code comments should always describe the current
state of the code; in contrast, this section may be useful to describe
the relationship between the original code and the code being proposed
in this pull request.
</details>
-->

<!--
<details>
<summary><h2> Notes to Reviewers </h2></summary>

Provide any extra information a reviewer may need to know before
evaluating your pull request. For example, you may wish to describe
which files should be reviewed first or which files are auto-generated.
If the review tool cannot detect a file move, you may wish to link to a
patch comparing the old file and the new file.
</details>
-->

<!--
<details>
<summary><h2> Deployment Plan </h2></summary>

Describe how the code in this pull request will be deployed. Some
deployments are complicated and may require flag days between multiple
repositories or the provisioning of new infrastructure. Describing your
deployment plan allows reviewers to ensure that your work will not cause
any unnecessary interruption to end users.
</details>
-->

<!--
<details>
<summary><h2> Future Work </h2></summary>

Provide a description of any possible follow-up work that is explicitly
not being done in this pull request.
</details>
-->

<!--
<details>
<summary><h2> Bonus </h2></summary>

Provide a description of any extra problems you have solved in this pull
request.
</details>
-->
