### PR TITLE
DLPX-93453 run "dpkg --configure -a" as part of upgrade's "execute" script

### DIFF
--- a/upgrade/upgrade-scripts/execute
+++ b/upgrade/upgrade-scripts/execute
@@ -224,6 +224,12 @@ fix_and_migrate_services
 systemctl mask docker.service
 
 #
+# When an upgrade gets interrupted while it’s in the middle of upgrading
+# packages, the package manager can get into a state where “dpkg --configure -a”
+# needs to be manually run to enable the upgrade to be restarted.
+dpkg --configure -a || die "failed to run dpkg --configure -a"
+
+#
 # Older versions (i.e. before 9.0.0.0 release) of the "nfs-kernel-server"
 # package had "rmtab" file delivered as part of the package. Thus, when
 # upgrading the package, the existing "rmtab" file would get replaced


### PR DESCRIPTION
<!--
<details open>
<summary><h2> Background </h2></summary>

Provide a clear description of the high-level effort with which this
pull request is associated. Recall that while anyone in the organization
can see this pull request, not everyone necessarily has the same context
as you. If applicable, link to design documents or high-level tracking
epics here.
</details>
-->

<details open>
<summary><h2> Problem </h2></summary>

When an upgrade gets interrupted while it’s in the middle of upgrading packages, the package manager can get into a state where “dpkg --configure -a” needs to be manually run to enable the upgrade to be restarted. We should add this command to the “execute” script, so the product can resolve this problem by itself.
</details>

<!--
<details>
<summary><h2> Evaluation </h2></summary>

If the cause of the problem is not obvious, provide a root-cause
analysis (RCA), ideally using the Five Whys iterative interrogative
technique or some other form of analytical reasoning.
</details>
-->

<details open>
<summary><h2> Solution </h2></summary>

Add command, `dpkg --configure -a`, in the execute script running before `apt_get update` so it can resolve any issues that might caused previous interruption.
</details>


<details>
<summary><h2> Testing Done </h2></summary>

Interrupted an upgrade (kill the process) when packages are being installed and verified upgrade failed because of that.

delphix@ip-10-110-232-40:~$ sudo /var/dlpx-update/latest/upgrade -v deferred
tr: write error: Broken pipe
tr: write error
cat: write error: Broken pipe
execute: upgrade failed; from '2025.1.0.0' to '2025.2.0.0-snapshot.20250226174502042+jenkins-ops-appliance-build-develop-post-push-2660'
upgrade-container: '/var/dlpx-update/2025.2.0.0-snapshot.20250226174502042+jenkins-ops-appliance-build-develop-post-push-2660/execute' failed in 'delphix.z1ksKFk'
upgrade: Failed to do in-place upgrade on 'delphix.z1ksKFk'
net.ipv4.ip_forward = 0

Added the command, `dpkg --configure -a`, in the execute script and verified the upgrade is succeed.

delphix@ip-10-110-232-40:/var/dlpx-update/latest$ sudo /var/dlpx-update/latest/upgrade -v deferred
tr: write error: Broken pipe
tr: write error
cat: write error: Broken pipe
net.ipv4.ip_forward = 0
Installing for i386-pc platform.
Installation finished. No error reported.
Sourcing file `/etc/default/grub'u
Sourcing file `/etc/default/grub.d/init-select.cfg'
Sourcing file `/etc/default/grub.d/kdump-tools.cfg'
Sourcing file `/etc/default/grub.d/override.cfg'
Generating grub configuration file ...
Found linux image: /boot/vmlinuz-5.15.0-1077-dx2025021320-fabac4b06-aws
Found initrd image: /boot/initrd.img-5.15.0-1077-dx2025021320-fabac4b06-aws
Found linux image: /boot/vmlinuz-5.15.0-1075-dx2025010720-80644de6e-aws
Found initrd image: /boot/initrd.img-5.15.0-1075-dx2025010720-80644de6e-aws
done

ab-pre-push done passed: https://selfservice-jenkins.eng-tools-prd.aws.delphixcloud.com/job/appliance-build-orchestrator-pre-push/10526/console

Blackbox job with normal upgrade using the updated image: https://selfservice-jenkins.eng-tools-prd.aws.delphixcloud.com/job/blackbox-chained/7230/console
</details>

<!--
<details>
<summary><h2> Implementation </h2></summary>

Describe the implementation details of the solution. Generally the
reasoning behind any non-obvious code should be recorded in code
comments. However, code comments should always describe the current
state of the code; in contrast, this section may be useful to describe
the relationship between the original code and the code being proposed
in this pull request.
</details>
-->

<!--
<details>
<summary><h2> Notes to Reviewers </h2></summary>

Provide any extra information a reviewer may need to know before
evaluating your pull request. For example, you may wish to describe
which files should be reviewed first or which files are auto-generated.
If the review tool cannot detect a file move, you may wish to link to a
patch comparing the old file and the new file.
</details>
-->

<!--
<details>
<summary><h2> Deployment Plan </h2></summary>

Describe how the code in this pull request will be deployed. Some
deployments are complicated and may require flag days between multiple
repositories or the provisioning of new infrastructure. Describing your
deployment plan allows reviewers to ensure that your work will not cause
any unnecessary interruption to end users.
</details>
-->

<!--
<details>
<summary><h2> Future Work </h2></summary>

Provide a description of any possible follow-up work that is explicitly
not being done in this pull request.
</details>
-->

<!--
<details>
<summary><h2> Bonus </h2></summary>

Provide a description of any extra problems you have solved in this pull
request.
</details>
-->
