### PR TITLE
DLPX-93750 LTS 24.04: recovery-environment postisnt hook failing due to "rsync -a" failure

### DIFF
--- a/live-build/variants/external-standard/ansible/playbook.yml
+++ b/live-build/variants/external-standard/ansible/playbook.yml
@@ -1,5 +1,5 @@
 #
-# Copyright 2018 Delphix
+# Copyright 2018, 2025 Delphix
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -23,4 +23,3 @@
     - appliance-build.minimal-common
     - appliance-build.masking-common
     - appliance-build.virtualization-common
-    - appliance-build.recovery-environment

--- a/live-build/variants/internal-dev/ansible/playbook.yml
+++ b/live-build/variants/internal-dev/ansible/playbook.yml
@@ -1,5 +1,5 @@
 #
-# Copyright 2018 Delphix
+# Copyright 2018, 2025 Delphix
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -48,4 +48,3 @@
     - appliance-build.virtualization-common
     - appliance-build.virtualization-development
     - appliance-build.zfsonlinux-development
-    - appliance-build.recovery-environment

--- a/live-build/variants/internal-qa/ansible/playbook.yml
+++ b/live-build/variants/internal-qa/ansible/playbook.yml
@@ -1,5 +1,5 @@
 #
-# Copyright 2018 Delphix
+# Copyright 2018, 2025 Delphix
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -25,4 +25,3 @@
     - appliance-build.masking-common
     - appliance-build.qa-internal
     - appliance-build.virtualization-common
-    - appliance-build.recovery-environment


### PR DESCRIPTION
<details open>
<summary><h2> Problem </h2></summary>
The postinst hook for the recovery-environment package is failing.
</details>

<details open>
<summary><h2> Solution </h2></summary>
Solution taken in this change is to remove the recovery-environment package from the appliance. This is likely a temporary solution, until we can determine a fix for the failing "rsync -a" command in the package's postinst hook.
</details>
