### PR TITLE
DLPX-93854 LTS 24.04: warnings running grub-probe in upgrade container

### DIFF
--- a/upgrade/upgrade-scripts/upgrade-container
+++ b/upgrade/upgrade-scripts/upgrade-container
@@ -314,6 +314,15 @@ function create_upgrade_container() {
 			BindReadOnly=$device
 		EOF
 			die "failed to add '$device' to container config file"
+
+		pkname=$(lsblk -pn -o pkname "$device" | head -n1)
+		if [[ -n "$pkname" ]]; then
+			cat >>"/etc/systemd/nspawn/$CONTAINER.nspawn" <<-EOF ||
+				BindReadOnly=$pkname
+			EOF
+				die "failed to add '$pkname' to container config file"
+		fi
+
 	done
 
 	#


### PR DESCRIPTION
Before:
```
root@ip-10-110-235-33:~# sudo grub-probe --device /dev/nvme0n1p1
grub-probe: warning: disk does not exist, so falling back to partition device /dev/nvme0n1p1.
grub-probe: warning: disk does not exist, so falling back to partition device /dev/nvme0n1p1.
grub-probe: warning: disk does not exist, so falling back to partition device /dev/nvme0n1p1.
zfs
```

After:
```
root@ip-10-110-235-33:~# sudo grub-probe --device /dev/nvme0n1p1
zfs
```
