### PR TITLE
DLPX-94060 LTS 24.04: engines for DCoA group dlpx-qa-dose-os-upgrade on AWS cloud do not have aws executable installed

### DIFF
--- a/live-build/misc/ansible-roles/appliance-build.minimal-internal/tasks/main.yml
+++ b/live-build/misc/ansible-roles/appliance-build.minimal-internal/tasks/main.yml
@@ -38,13 +38,13 @@
 
 # Set s3-bin-path
 - name: Set the s3_bin_path
-   set_fact:
-      s3_bin_path: /usr/local/bin
+  set_fact:
+    s3_bin_path: /usr/local/bin
 
 # Add /usr/local/bin to the PATH (awscli needs it)
 - name: Create s3-bin-path.sh under profile.d
-   ansible.builtin.copy:
-      dest: /etc/profile.d/s3-bin-path.sh
-      mode: 0644
-      content: 'PATH=$PATH:{{ s3_bin_path }}'
+  ansible.builtin.copy:
+    dest: /etc/profile.d/s3-bin-path.sh
+    mode: 0644
+    content: 'PATH=$PATH:{{ s3_bin_path }}'
 

--- a/live-build/misc/ansible-roles/appliance-build.minimal-internal/tasks/main.yml
+++ b/live-build/misc/ansible-roles/appliance-build.minimal-internal/tasks/main.yml
@@ -36,14 +36,15 @@
     break_system_packages: true
   become: true
 
-# Add /usr/local/bin to the PATH (awscli needs it)
-- name: Add s3 local bin dir to system-wide $PATH.
-   vars:
+# Set s3-bin-path
+- name: Set the s3_bin_path
+   set_fact:
       s3_bin_path: /usr/local/bin
-   tasks:
-   - name Create s3-bin-path.sh under profile.d
-      ansible.builtin.copy:
-         dest: /etc/profile.d/s3-bin-path.sh
-	 mode: 0644
-	 content: 'PATH=$PATH:{{ s3_bin_path  }}'
+
+# Add /usr/local/bin to the PATH (awscli needs it)
+- name: Create s3-bin-path.sh under profile.d
+   ansible.builtin.copy:
+      dest: /etc/profile.d/s3-bin-path.sh
+      mode: 0644
+      content: 'PATH=$PATH:{{ s3_bin_path }}'
 

--- a/live-build/misc/ansible-roles/appliance-build.minimal-internal/tasks/main.yml
+++ b/live-build/misc/ansible-roles/appliance-build.minimal-internal/tasks/main.yml
@@ -35,3 +35,13 @@
     name: awscli
     break_system_packages: true
   become: true
+
+# Add /usr/local/bin to the PATH (awscli needs it)
+- name: Add s3 local bin dir to system-wide $PATH.
+   vars:
+      s3_bin_path: /usr/local/bin
+   copy:
+      dest: /etc/profile.d/s3-bin-path.sh
+      mode: 0644
+      content: 'PATH=$PATH:{{ s3_bin_path  }}'
+

--- a/live-build/misc/ansible-roles/appliance-build.minimal-internal/tasks/main.yml
+++ b/live-build/misc/ansible-roles/appliance-build.minimal-internal/tasks/main.yml
@@ -40,8 +40,10 @@
 - name: Add s3 local bin dir to system-wide $PATH.
    vars:
       s3_bin_path: /usr/local/bin
-   copy:
-      dest: /etc/profile.d/s3-bin-path.sh
-      mode: 0644
-      content: 'PATH=$PATH:{{ s3_bin_path  }}'
+   tasks:
+   - name Create s3-bin-path.sh under profile.d
+      ansible.builtin.copy:
+         dest: /etc/profile.d/s3-bin-path.sh
+	 mode: 0644
+	 content: 'PATH=$PATH:{{ s3_bin_path  }}'
 

--- a/live-build/misc/ansible-roles/appliance-build.minimal-internal/tasks/main.yml
+++ b/live-build/misc/ansible-roles/appliance-build.minimal-internal/tasks/main.yml
@@ -47,4 +47,3 @@
     dest: /etc/profile.d/s3-bin-path.sh
     mode: 0644
     content: 'PATH=$PATH:{{ s3_bin_path }}'
-

--- a/live-build/misc/ansible-roles/appliance-build.minimal-internal/tasks/main.yml
+++ b/live-build/misc/ansible-roles/appliance-build.minimal-internal/tasks/main.yml
@@ -36,14 +36,9 @@
     break_system_packages: true
   become: true
 
-# Set s3-bin-path
-- name: Set the s3_bin_path
-  set_fact:
-    s3_bin_path: /usr/local/bin
-
 # Add /usr/local/bin to the PATH (awscli needs it)
 - name: Create s3-bin-path.sh under profile.d
   ansible.builtin.copy:
     dest: /etc/profile.d/s3-bin-path.sh
     mode: 0644
-    content: 'PATH=$PATH:{{ s3_bin_path }}'
+    content: 'PATH=$PATH:/usr/local/bin'


### PR DESCRIPTION
<!--
<details open>
<summary><h2> Background </h2></summary>
After an engine gets installed, it looks as if awscli is not installed.
However, the problem is that it cant locate s3 in the path.

This shows the engine is unable to run s3 for some test cases.

</details>
-->

<details open>
<summary><h2> Problem </h2></summary>
The awscli bin path needs to be added to the PATH. Unable to execute s3 commands.
</details>

<details open>
<summary><h2> Solution </h2></summary>
Add /usr/local/bin to the path via ansible task.
</details>


<details>
<summary><h2> Testing Done </h2></summary>
Jenkins build testing.
</details>
