### PR TITLE
DLPX-94149 LTS 24.04: mask fluentd.service

### DIFF
--- a/live-build/misc/ansible-roles/appliance-build.virtualization-common/tasks/main.yml
+++ b/live-build/misc/ansible-roles/appliance-build.virtualization-common/tasks/main.yml
@@ -64,9 +64,9 @@
     systemctl disable {{ item }}
     systemctl mask {{ item }}
   with_items:
+    - fluentd.service
     - nginx.service
     - postgresql.service
-    - td-agent.service
     - telegraf.service
 
 #

--- a/upgrade/upgrade-scripts/common.sh
+++ b/upgrade/upgrade-scripts/common.sh
@@ -489,6 +489,7 @@ function fix_and_migrate_services() {
 	done <<-EOF
 		delphix-fluentd.service
 		delphix-masking.service
+		fluentd.service
 		nfs-mountd.service
 		nginx.service
 		ntpsec.service
@@ -499,7 +500,6 @@ function fix_and_migrate_services() {
 		rpcbind.socket
 		snmpd.service
 		systemd-timesyncd.service
-		td-agent.service
 		telegraf.service
 	EOF
 }


### PR DESCRIPTION
<details open>
<summary><h2> Problem </h2></summary>
The td-agent service has been replaced by the fluentd service, but our logic to mask the service hasn't been updated.
</details>

<details open>
<summary><h2> Solution </h2></summary>
Update our logic to use the new service name.
</details>
