### PR TITLE
DLPX-94130 LTS 24.04: upgrade from 20.0.0.0 -> 2025.2.0.0 -> os-upgrade branch failed

### DIFF
--- a/upgrade/upgrade-scripts/upgrade-container
+++ b/upgrade/upgrade-scripts/upgrade-container
@@ -234,10 +234,11 @@ function create_upgrade_container() {
 	# version of Delphix we're upgrading from).
 	#
 	# DLPX-78307 - Similarly, we must disable "google-guest-agent".
+	# DLPX-94130 - Also, disable the "delphix-osadmin" service.
 	#
 	for svc in \
 		"nfs-mountd" "nfs-server" "rpc-statd" "rpc-statd-notify" \
-		"google-guest-agent"; do
+		"google-guest-agent" "delphix-osadmin"; do
 		[[ -e "$DIRECTORY/lib/systemd/system/$svc.service.d/override.conf" ]] &&
 			continue
 


### PR DESCRIPTION
<details open>
<summary><h2> Problem </h2></summary>
The delphix-osadmin services removes the netplan configuration file when it runs inside an upgrade container, due to the container not having network interfaces. This leads to networking not being configured correctly when/if that upgrade container is promoted to a the host's rootfs.
</details>

<details open>
<summary><h2> Solution </h2></summary>
Disable the delphix-osadmin service from running in the upgrade container.
</details>
