### PR TITLE
DLPX-94115 LTS 24.04: upgrade from 2025.2.0.0 to os-upgrade version generated core dump from /sbin/zed -F

### DIFF
--- a/upgrade/upgrade-scripts/upgrade-container
+++ b/upgrade/upgrade-scripts/upgrade-container
@@ -235,10 +235,11 @@ function create_upgrade_container() {
 	#
 	# DLPX-78307 - Similarly, we must disable "google-guest-agent".
 	# DLPX-94130 - Also, disable the "delphix-osadmin" service.
+	# DLPX-94115 - Also, disable "zfs-zed" service.
 	#
 	for svc in \
 		"nfs-mountd" "nfs-server" "rpc-statd" "rpc-statd-notify" \
-		"google-guest-agent" "delphix-osadmin"; do
+		"google-guest-agent" "delphix-osadmin" "zfs-zed"; do
 		[[ -e "$DIRECTORY/lib/systemd/system/$svc.service.d/override.conf" ]] &&
 			continue
 


### PR DESCRIPTION
<details open>
<summary><h2> Problem </h2></summary>
The "zfs-zed" service runs in the container, and when we upgrade various libraries as part of the LTS upgrade, it can core dump. The crash is expected, given all the libraries we're modifying as part of the upgrade, and the fact the process attempts to remain running while those libraries are modified underneath the process, but our QA tests detect the core file and fail the test run.
</details>

<details open>
<summary><h2> Solution </h2></summary>
The solution taken in this PR is to disable the service from running in the container. This should be sufficient, since we take a not-in-place upgrade approach for the LTS upgrade, and don't upgrade packages in-place while the host's software is running (or else we could hit this same crash on the host system's upgrade).
</details>


<details>
<summary><h2> Testing Done </h2></summary>

- `git-ab-pre-push` is [here](https://selfservice-jenkins.eng-tools-prd.aws.delphixcloud.com/job/appliance-build-orchestrator-pre-push/11138/)

- I manually verified this works with a 2025.3.0.0 to 2025.4.0.0 upgrade.

</details>
