### PR TITLE
DLPX-94194 debug output in resolve_s3_uri breaks build

### DIFF
--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -36,7 +36,6 @@ function resolve_s3_uri() {
 		# mirror is used.
 		#
 		UPSTREAM_BRANCH=$(get_upstream_or_fail_if_unset) || exit 1
-		echo "Running with UPSTREAM_BRANCH set to ${UPSTREAM_BRANCH}"
 		local latest_subprefix="linux-pkg/${UPSTREAM_BRANCH}/combine-packages/post-push/latest"
 		local bucket="snapshot-de-images"
 		local jenkinsid="jenkins-ops"


### PR DESCRIPTION
Remove the spurious output

ab-pre-push: https://selfservice-jenkins.eng-tools-prd.aws.delphixcloud.com/job/github/job/delphix/job/appliance-build/job/appliance-build-orchestrator/job/pre-push/713/