### PR TITLE
DLPX-94115 LTS 24.04: upgrade from 2025.2.0.0 to os-upgrade version generated core dump from /sbin/zed -F

### DIFF
--- a/upgrade/upgrade-scripts/upgrade-container
+++ b/upgrade/upgrade-scripts/upgrade-container
@@ -240,13 +240,26 @@ function create_upgrade_container() {
 	for svc in \
 		"nfs-mountd" "nfs-server" "rpc-statd" "rpc-statd-notify" \
 		"google-guest-agent" "delphix-osadmin" "zfs-zed"; do
-		[[ -e "$DIRECTORY/lib/systemd/system/$svc.service.d/override.conf" ]] &&
+
+		if [[ "$svc" == "zfs-zed" ]]; then
+			#
+			# The delphix-platform package already delivers the
+			# "override.conf" file for "zfs-zed" service. Thus, we
+			# need to use a different filename to avoid conflicting
+			# with that pre-existing override file.
+			#
+			filename="upgrade-container.conf"
+		else
+			filename="override.conf"
+		fi
+
+		[[ -e "$DIRECTORY/lib/systemd/system/$svc.service.d/$filename" ]] &&
 			continue
 
 		mkdir -p "$DIRECTORY/lib/systemd/system/$svc.service.d" ||
 			die "failed to create override directory for '$svc' service"
 
-		cat >"$DIRECTORY/lib/systemd/system/$svc.service.d/override.conf" <<-EOF ||
+		cat >"$DIRECTORY/lib/systemd/system/$svc.service.d/$filename" <<-EOF ||
 			[Unit]
 			ConditionVirtualization=!container
 		EOF


### PR DESCRIPTION
<details open>
<summary><h2> Problem </h2></summary>
Commit b912355cd4b6bc041e386d14ec0f0ebc47899ea8 doesn't work as intended, because the delphix-platform packages already delivers an "override.conf", causing the logic in the "upgrade-container" script to do nothing for the "zfs-zed" service.
</details>

<details open>
<summary><h2> Solution </h2></summary>
This change modifies the override file, to use a filename that won't conflict with any pre-existing override files.
</details>

<details open>
<summary><h2> Testing </h2></summary>

- Before:
```
delphix@ip-10-110-219-125:~$ sudo /var/dlpx-update/latest/upgrade-container create not-in-place
Created symlink /etc/systemd/system/fluentd.service → /dev/null.
Created symlink /etc/systemd/system/ntpsec.service → /dev/null.
Created symlink /etc/systemd/system/ntpsec-rotate-stats.timer → /dev/null.
Created symlink /etc/systemd/system/systemd-timesyncd.service → /dev/null.
delphix.J2QzDzs

delphix@ip-10-110-219-125:~$ sudo /var/dlpx-update/latest/upgrade-container start delphix.J2QzDzs
|
delphix@ip-10-110-219-125:~$ sudo /var/dlpx-update/latest/upgrade-container shell delphix.J2QzDzs
Connected to machine delphix.J2QzDzs. Press ^] three times within 1s to exit session.

root@ip-10-110-219-125:~# systemctl status zfs-zed
● zfs-zed.service - ZFS Event Daemon (zed)
     Loaded: loaded (/lib/systemd/system/zfs-zed.service; enabled; vendor preset: enabled)
    Drop-In: /usr/lib/systemd/system/zfs-zed.service.d
             └─override.conf
     Active: active (running) since Fri 2025-05-16 18:52:39 UTC; 3min 54s ago
       Docs: man:zed(8)
   Main PID: 118 (zed)
     CGroup: /system.slice/zfs-zed.service
             └─118 /sbin/zed -F -v

May 16 18:52:40 ip-10-110-219-125 zed[118]: Finished "all-syslog.sh" eid=129 pid=885 time=0.001723s exit=0
May 16 18:52:40 ip-10-110-219-125 zed[118]: Finished "history_event-zfs-list-cacher.sh" eid=130 pid=888 time=0.000841s exit=0
May 16 18:52:40 ip-10-110-219-125 zed[118]: Finished "all-syslog.sh" eid=130 pid=887 time=0.001572s exit=0
May 16 18:52:40 ip-10-110-219-125 zed[118]: Finished "all-syslog.sh" eid=131 pid=889 time=0.001455s exit=0
May 16 18:52:40 ip-10-110-219-125 zed[118]: Invoking "all-syslog.sh" eid=132 pid=891
May 16 18:52:40 ip-10-110-219-125 zed[118]: Finished "all-syslog.sh" eid=126 pid=879 time=0.001454s exit=0
May 16 18:52:40 ip-10-110-219-125 zed[118]: Invoking "history_event-zfs-list-cacher.sh" eid=132 pid=892
May 16 18:52:40 ip-10-110-219-125 zed[118]: Finished "history_event-zfs-list-cacher.sh" eid=131 pid=890 time=0.001054s exit=0
May 16 18:52:40 ip-10-110-219-125 zed[118]: Finished "history_event-zfs-list-cacher.sh" eid=132 pid=892 time=0.000995s exit=0
May 16 18:52:40 ip-10-110-219-125 zed[118]: Finished "all-syslog.sh" eid=132 pid=891 time=0.001631s exit=0
```

- After:
```
delphix@ip-10-110-219-125:~$ sudo /var/dlpx-update/latest/upgrade-container create not-in-place
Created symlink /etc/systemd/system/fluentd.service → /dev/null.
Created symlink /etc/systemd/system/ntpsec.service → /dev/null.
Created symlink /etc/systemd/system/ntpsec-rotate-stats.timer → /dev/null.
Created symlink /etc/systemd/system/systemd-timesyncd.service → /dev/null.
delphix.TB93DLv

delphix@ip-10-110-219-125:~$ sudo /var/dlpx-update/latest/upgrade-container start delphix.TB93DLv

delphix@ip-10-110-219-125:~$ sudo /var/dlpx-update/latest/upgrade-container shell delphix.TB93DLv
Connected to machine delphix.TB93DLv. Press ^] three times within 1s to exit session.

root@ip-10-110-219-125:~# systemctl status zfs-zed
● zfs-zed.service - ZFS Event Daemon (zed)
     Loaded: loaded (/lib/systemd/system/zfs-zed.service; enabled; vendor preset: enabled)
    Drop-In: /usr/lib/systemd/system/zfs-zed.service.d
             └─override.conf, upgrade-container.conf
     Active: inactive (dead)
  Condition: start condition failed at Fri 2025-05-16 18:58:45 UTC; 6min ago
             └─ ConditionVirtualization=!container was not met
       Docs: man:zed(8)

May 16 18:58:45 ip-10-110-219-125 systemd[1]: Condition check resulted in ZFS Event Daemon (zed) being skipped.
```

</details>