### PR TITLE
DLPX-94349 recovery-environment grub config file still present after upgrade

### DIFF
--- a/upgrade/upgrade-scripts/execute
+++ b/upgrade/upgrade-scripts/execute
@@ -435,6 +435,16 @@ apt_get purge -y $(apt-mark showauto | grep -v "$(uname -r)") ||
 	die "failed to remove no-longer-needed packages"
 
 #
+# Additionally, we've seen packages get removed but remain in the "rc"
+# state; i.e. the package is removed, but configuration files linger.
+#
+# Thus, we explicitly purge all packages in that state.
+#
+# shellcheck disable=SC2046
+apt_get purge -y $(dpkg -l | grep ^rc | awk '{print $2}') ||
+	die "failed to remove 'rc' packages"
+
+#
 # Package configuration files are only automatically removed by the
 # package manager when the package that "owns" the file is "purged".
 # Thus, when upgrading a package to a new version that no longer


### PR DESCRIPTION
<details open>
<summary><h2> Problem </h2></summary>
After upgrading from 2025.3 to 2025.4, some packages linger in the "rc" state. This isn't ideal, as it means there is differences between a 2025.4 system based on if it was a new install, or if it was upgraded from an earlier version.
</details>

<details open>
<summary><h2> Solution </h2></summary>
This change adds logic to the "execute" script, to find those packages, and explicitly purge them (which will remove the configuration files for these already "removed" packages).
</details>


<details open>
<summary><h2> Testing Done </h2></summary>

- `git-ab-pre-push` is [here](https://selfservice-jenkins.eng-tools-prd.aws.delphixcloud.com/job/appliance-build-orchestrator-pre-push/11238/)

I took a 2025.3 system, upgraded it to 2025.4, and then ran the command being added manually.. e.g.
```
$ sudo apt-get purge -y $(dpkg -l | grep ^rc | awk '{print $2}')
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
The following packages will be REMOVED:
  bsdmainutils* groff* libgdk-pixbuf2.0-0* libglib2.0-0* libgtk-3-0* libmagic1* libnginx-mod-http-image-filter* libnginx-mod-http-xslt-filter* libnginx-mod-mail* libnginx-mod-stream* libsmi2ldbl* lsb-base*
  mime-support* ntp* recovery-environment* rng-tools* td-agent* usrmerge*
0 upgraded, 0 newly installed, 18 to remove and 0 not upgraded.
After this operation, 0 B of additional disk space will be used.
(Reading database ... 215887 files and directories currently installed.)
Purging configuration files for lsb-base (11.1.0ubuntu2) ...
dpkg: warning: while removing lsb-base, directory '/lib/lsb/init-functions.d' not empty so not removed
Purging configuration files for libnginx-mod-mail (1.18.0-0ubuntu1.7) ...
Purging configuration files for mime-support (3.64ubuntu1) ...
Purging configuration files for libgtk-3-0:amd64 (3.24.20-0ubuntu1.2) ...
Purging configuration files for libnginx-mod-http-image-filter (1.18.0-0ubuntu1.7) ...
Purging configuration files for libnginx-mod-stream (1.18.0-0ubuntu1.7) ...
Purging configuration files for libmagic1:amd64 (1:5.38-4) ...
Purging configuration files for groff (1.22.4-4build1) ...
Purging configuration files for libsmi2ldbl:amd64 (0.4.8+dfsg2-16) ...
Purging configuration files for libnginx-mod-http-xslt-filter (1.18.0-0ubuntu1.7) ...
Purging configuration files for libgdk-pixbuf2.0-0:amd64 (2.40.0+dfsg-3ubuntu0.5) ...
Purging configuration files for ntp (1:4.2.8p12+dfsg-3ubuntu4.20.04.1) ...
Purging configuration files for bsdmainutils (11.1.2ubuntu3) ...
Purging configuration files for usrmerge (23) ...
debconf: unable to initialize frontend: Dialog
debconf: (No usable dialog-like program is installed, so the dialog based frontend cannot be used. at /usr/share/perl5/Debconf/FrontEnd/Dialog.pm line 79.)
debconf: falling back to frontend: Readline
Purging configuration files for rng-tools (5-1ubuntu2) ...
Purging configuration files for td-agent (4.4.2-1) ...
debconf: unable to initialize frontend: Dialog
debconf: (No usable dialog-like program is installed, so the dialog based frontend cannot be used. at /usr/share/perl5/Debconf/FrontEnd/Dialog.pm line 79.)
debconf: falling back to frontend: Readline
td-agent:x:112:118::/var/lib/td-agent:/usr/sbin/nologin
userdel: group td-agent is the primary group of another user and is not removed.
userdel: td-agent mail spool (/var/mail/td-agent) not found
Purging configuration files for recovery-environment (1.0-1+delphix.2025.01.15.17.30) ...
```

</details>
