### PR TITLE
DLPX-94397 Post-upgrade from release to develop, the 'Enable Quiesced' operation is not executing on some MSSQL VDBs, leading to BB failures.

### DIFF
--- a/upgrade/upgrade-scripts/rootfs-container
+++ b/upgrade/upgrade-scripts/rootfs-container
@@ -237,6 +237,19 @@ function set_bootfs_mounted() {
 	trap - EXIT
 }
 
+function quiesce_sources() {
+	local jmxtool="/opt/delphix/server/bin/jmxtool"
+
+	#
+	# Quiescing sources are a virtualization service concept. Thus, if
+	# we're running on a variant that doesn't have the virtualization
+	# package installed, skip the alert.
+	#
+	[[ ! -x "$jmxtool" ]] && return
+
+	$jmxtool -w upgrade quiesce_sources &>/dev/null
+}
+
 #
 # The purpose of this function is to convert an existing rootfs container
 # (specified by the $CONTAINER global variable) to be used as the boot
@@ -268,6 +281,24 @@ function set_bootfs() {
 	# the root pool (i.e. the rpool/grub dataset) are safe on disk.
 	#
 	zpool sync rpool || die "'zpool sync rpool' failed."
+
+	#
+	# This is a hack, but upgrades to 2025.4.0.0 will require a reboot,
+	# and the virtualization's upgrade logic will not quiesce sources,
+	# potentially leading to VDB outages and their inability to be
+	# properly unquiesce after the upgrade.
+	#
+	# Thus, to try and mitigate the impact, we attempt to quiesce sources
+	# here, on a best-effort basis. If quiescing fails, we don't want the
+	# entire upgrade to fail, as there's legitimate cases where this
+	# operation is not guaranteed to succeed.
+	#
+	# Further, we're assuming the virtualization's upgrade logic will
+	# perform the reboot immediately after this operation, and that
+	# sources will be unquiesced upon the system coming back up after
+	# the reboot.
+	#
+	quiesce_sources || warn "quiescing sources failed."
 }
 
 function usage() {

--- a/upgrade/upgrade-scripts/rootfs-container
+++ b/upgrade/upgrade-scripts/rootfs-container
@@ -237,16 +237,51 @@ function set_bootfs_mounted() {
 	trap - EXIT
 }
 
-function quiesce_sources() {
+function quiesce_sources_if_needed() {
 	local jmxtool="/opt/delphix/server/bin/jmxtool"
 
 	#
 	# Quiescing sources are a virtualization service concept. Thus, if
 	# we're running on a variant that doesn't have the virtualization
-	# package installed, skip the alert.
+	# package installed, don't attempt to quiesce sources.
 	#
 	[[ ! -x "$jmxtool" ]] && return
 
+	#
+	# If we're not performing an upgrade, then don't quiesce sources.
+	#
+	[[ ! -f "$UPDATE_DIR/upgrade.properties" ]] && return 0
+
+	source_upgrade_properties
+
+	#
+	# If we're not performing a FULL upgrade, then don't quiesce sources.
+	#
+	[[ "$UPGRADE_TYPE" != "FULL" ]] && return 0
+
+	#
+	# If the version we're going to is less than 2025.4.0.0, then don't
+	# quiesce sources. Only upgrades going to 2025.4.0.0 or greater need
+	# this hack to quiesce sources.
+	#
+	compare_versions "$UPGRADE_VERSION" lt "2025.4.0.0-0" || return 0
+
+	#
+	# Also, if the version we're coming from is 2025.3.0.1 or greater, then
+	# don't quiesce sources. All versions 2025.3.0.1 and greater, should
+	# quiesce sources properly from the stack's upgrade logic.
+	#
+	compare_versions "$UPGRADE_BASE_VERSION" ge "2025.3.0.1-0" || return 0
+
+	#
+	# At this point, we know we're:
+	#
+	#  1. performing an upgrade,
+	#  2. going to a version 2025.4.0.0 or greater, and
+	#  3. coming from a version 2025.3.0.0 or less.
+	#
+	# Thus, we need this hack to quiesce sources prior to the reboot.
+	#
 	$jmxtool -w upgrade quiesce_sources &>/dev/null
 }
 
@@ -298,7 +333,7 @@ function set_bootfs() {
 	# sources will be unquiesced upon the system coming back up after
 	# the reboot.
 	#
-	quiesce_sources || warn "quiescing sources failed."
+	quiesce_sources_if_needed || warn "quiescing sources failed."
 }
 
 function usage() {


### PR DESCRIPTION
<details open>
<summary><h2> Problem </h2></summary>
Upgrades to 2025.4.0.0 from earlier versions will induce a reboot without having quiesce sources prior to that reboot. As a result, VDBs may experience an outage, and not be successfully enabled after the reboot completes.
</details>

<details open>
<summary><h2> Solution </h2></summary>
The solution taken in this change is to attempt to leverage "jmxtool" to induce a "quiesce sources" operation via the upgrade scripts from 2025.4.0.0, such that we'll do the quiescing of sources prior to the reboot, no matter which version the appliance is running prior to the upgrade.
</details>


<details open>
<summary><h2> Testing Done </h2></summary>

- `git-ab-pre-push` is [here](https://selfservice-jenkins.eng-tools-prd.aws.delphixcloud.com/job/appliance-build-orchestrator-pre-push/11276/) and [here](https://selfservice-jenkins.eng-tools-prd.aws.delphixcloud.com/job/appliance-build-orchestrator-pre-push/11335/)

I applied this change on a DE with some MSSQL sources, and verified the sources get quiesced by the changes in this PR, and then later uquiesced normally after the reboot; e.g.
```
     66 | UPGRADE_VERSION-2          | UPGRADE_APPLY                               | 2025-06-02 21:29:20.851 | USER-1   |                 | 2025-06-02 22:15:38.897 | Apply upgrade version "2025.4.0.0-snapshot.20250531032947911+jenkins-ops-appliance-build-develop-post-push-2903".                                                    | COMPLETED | event.action.upgrade.apply                               | ["2025.4.0.0-snapshot.20250531032947911+jenkins-ops-appliance-build-develop-post-push-2903"] | 2025.4.0.0-snapshot.20250531032947911+jenkins-ops-appliance-build-develop-post-push-2903 | ACTION-187 | f                    |                   |                       |
     67 | DOMAIN                     | SOURCES_QUIESCE_PARALLEL                    | 2025-06-02 22:10:26.592 |          |                 | 2025-06-02 22:10:26.67  | Quiesce a group of sources in parallel.                                                                                                                              | COMPLETED | event.action.sources.quiesce.parallel                    | []                                                                                           | system                                                                                   | ACTION-190 | f                    |                   |                       |
     68 | DOMAIN                     | SOURCES_QUIESCE_PARALLEL                    | 2025-06-02 22:10:26.654 |          |                 | 2025-06-02 22:10:26.736 | Quiesce a group of sources in parallel.                                                                                                                              | COMPLETED | event.action.sources.quiesce.parallel                    | []                                                                                           | system                                                                                   | ACTION-191 | f                    |                   |                       |
     69 | DOMAIN                     | SOURCES_QUIESCE_PARALLEL                    | 2025-06-02 22:10:26.751 |          |                 | 2025-06-02 22:11:26.172 | Quiesce a group of sources in parallel.                                                                                                                              | COMPLETED | event.action.sources.quiesce.parallel                    | []                                                                                           | system                                                                                   | ACTION-192 | f                    |                   |                       |
     70 | MSSQL_LINKED_SOURCE-1      | SOURCE_QUIESCE                              | 2025-06-02 22:10:26.843 |          |                 | 2025-06-02 22:10:27.186 | Quiesce source SourceDB4-21641.                                                                                                                                      | COMPLETED | event.action.source.quiesce                              | ["SourceDB4-21641"]                                                                          | SourceDB4-21641                                                                          | ACTION-193 | f                    |                   |                       |
     71 | MSSQL_VIRTUAL_SOURCE-11    | SOURCE_QUIESCE                              | 2025-06-02 22:10:27.026 |          |                 | 2025-06-02 22:11:07.513 | Quiesce source SourceDB-JXIPXC-1748896158588.                                                                                                                        | COMPLETED | event.action.source.quiesce                              | ["SourceDB-JXIPXC-1748896158588"]                                                            | SourceDB-JXIPXC-1748896158588                                                            | ACTION-194 | f                    |                   |                       |
     72 | MSSQL_VIRTUAL_SOURCE-8     | SOURCE_QUIESCE                              | 2025-06-02 22:10:27.119 |          |                 | 2025-06-02 22:11:07.504 | Quiesce source SourceDB-3WKCWP-1748896145149.                                                                                                                        | COMPLETED | event.action.source.quiesce                              | ["SourceDB-3WKCWP-1748896145149"]                                                            | SourceDB-3WKCWP-1748896145149                                                            | ACTION-195 | f                    |                   |                       |
     73 | MSSQL_VIRTUAL_SOURCE-3     | SOURCE_QUIESCE                              | 2025-06-02 22:10:27.249 |          |                 | 2025-06-02 22:11:07.335 | Quiesce source SourceDB-GHOM6P-1748896143785.                                                                                                                        | COMPLETED | event.action.source.quiesce                              | ["SourceDB-GHOM6P-1748896143785"]                                                            | SourceDB-GHOM6P-1748896143785                                                            | ACTION-196 | f                    |                   |                       |
     74 | MSSQL_VIRTUAL_SOURCE-4     | SOURCE_QUIESCE                              | 2025-06-02 22:10:27.324 |          |                 | 2025-06-02 22:11:07.507 | Quiesce source SourceDB-FFMN9W-1748896146610.                                                                                                                        | COMPLETED | event.action.source.quiesce                              | ["SourceDB-FFMN9W-1748896146610"]                                                            | SourceDB-FFMN9W-1748896146610                                                            | ACTION-197 | f                    |                   |                       |
     75 | MSSQL_VIRTUAL_SOURCE-10    | SOURCE_QUIESCE                              | 2025-06-02 22:10:27.388 |          |                 | 2025-06-02 22:11:07.649 | Quiesce source SourceDB-1DVZCN-1748896154586.                                                                                                                        | COMPLETED | event.action.source.quiesce                              | ["SourceDB-1DVZCN-1748896154586"]                                                            | SourceDB-1DVZCN-1748896154586                                                            | ACTION-198 | f                    |                   |                       |
     76 | MSSQL_VIRTUAL_SOURCE-2     | SOURCE_QUIESCE                              | 2025-06-02 22:10:27.482 |          |                 | 2025-06-02 22:11:07.532 | Quiesce source SourceDB-83KIE4-1748896153275.                                                                                                                        | COMPLETED | event.action.source.quiesce                              | ["SourceDB-83KIE4-1748896153275"]                                                            | SourceDB-83KIE4-1748896153275                                                            | ACTION-199 | f                    |                   |                       |
     77 | MSSQL_VIRTUAL_SOURCE-7     | SOURCE_QUIESCE                              | 2025-06-02 22:10:27.565 |          |                 | 2025-06-02 22:11:07.251 | Quiesce source SourceDB-7SC2SW-1748896151911.                                                                                                                        | COMPLETED | event.action.source.quiesce                              | ["SourceDB-7SC2SW-1748896151911"]                                                            | SourceDB-7SC2SW-1748896151911                                                            | ACTION-200 | f                    |                   |                       |
     78 | MSSQL_VIRTUAL_SOURCE-1     | SOURCE_QUIESCE                              | 2025-06-02 22:10:27.636 |          |                 | 2025-06-02 22:11:07.491 | Quiesce source SourceDB-H866U2-1748896149271.                                                                                                                        | COMPLETED | event.action.source.quiesce                              | ["SourceDB-H866U2-1748896149271"]                                                            | SourceDB-H866U2-1748896149271                                                            | ACTION-201 | f                    |                   |                       |
     79 | MSSQL_VIRTUAL_SOURCE-6     | SOURCE_QUIESCE                              | 2025-06-02 22:10:27.799 |          |                 | 2025-06-02 22:11:07.355 | Quiesce source SourceDB-H13E52-1748896157275.                                                                                                                        | COMPLETED | event.action.source.quiesce                              | ["SourceDB-H13E52-1748896157275"]                                                            | SourceDB-H13E52-1748896157275                                                            | ACTION-202 | f                    |                   |                       |
     80 | MSSQL_VIRTUAL_SOURCE-5     | SOURCE_QUIESCE                              | 2025-06-02 22:10:27.881 |          |                 | 2025-06-02 22:11:07.591 | Quiesce source SourceDB-K76YRM-1748896147918.                                                                                                                        | COMPLETED | event.action.source.quiesce                              | ["SourceDB-K76YRM-1748896147918"]                                                            | SourceDB-K76YRM-1748896147918                                                            | ACTION-203 | f                    |                   |                       |
     81 | MSSQL_VIRTUAL_SOURCE-12    | SOURCE_QUIESCE                              | 2025-06-02 22:10:27.951 |          |                 | 2025-06-02 22:11:26.127 | Quiesce source SourceDB-3A6ZSD-1748896155916.                                                                                                                        | COMPLETED | event.action.source.quiesce                              | ["SourceDB-3A6ZSD-1748896155916"]                                                            | SourceDB-3A6ZSD-1748896155916                                                            | ACTION-204 | f                    |                   |                       |
     82 | MSSQL_VIRTUAL_SOURCE-9     | SOURCE_QUIESCE                              | 2025-06-02 22:10:28.018 |          |                 | 2025-06-02 22:11:26.131 | Quiesce source SourceDB-WV86HD-1748896150590.                                                                                                                        | COMPLETED | event.action.source.quiesce                              | ["SourceDB-WV86HD-1748896150590"]                                                            | SourceDB-WV86HD-1748896150590                                                            | ACTION-205 | f                    |                   |                       |
     83 | MSSQL_STAGING_SOURCE-1     | SOURCE_QUIESCE                              | 2025-06-02 22:10:28.124 |          |                 | 2025-06-02 22:11:07.396 | Quiesce source ec2e8bcb-dfd5-15dc-aeeb-1b8b1db98a53-staging-1.                                                                                                       | COMPLETED | event.action.source.quiesce                              | ["ec2e8bcb-dfd5-15dc-aeeb-1b8b1db98a53-staging-1"]                                           | ec2e8bcb-dfd5-15dc-aeeb-1b8b1db98a53-staging-1                                           | ACTION-206 | f                    |                   |                       |
     84 | DOMAIN                     | UPGRADE_CLEANUP_DISPATCH_PERSISTENT_WORKERS | 2025-06-02 22:15:39.175 |          |                 | 2025-06-02 22:18:09.301 | Perform post upgrade cleanup and dispatch persistent workers for version "2025.4.0.0-snapshot.20250531032947911+jenkins-ops-appliance-build-develop-post-push-2903". | COMPLETED | event.action.upgrade.cleanup.dispatch_persistent_workers | ["2025.4.0.0-snapshot.20250531032947911+jenkins-ops-appliance-build-develop-post-push-2903"] | system                                                                                   | ACTION-208 | f                    |                   |                       |
     85 | UPGRADE_VERSION-2          | POST_UPGRADE_CLEANUP                        | 2025-06-02 22:15:39.445 |          |                 | 2025-06-02 22:18:09.274 | Perform cleanup tasks following a Delphix Engine upgrade.                                                                                                            | COMPLETED | event.action.post.upgrade.cleanup                        | []                                                                                           | 2025.4.0.0-snapshot.20250531032947911+jenkins-ops-appliance-build-develop-post-push-2903 | ACTION-209 | f                    |                   |                       |
     86 | DOMAIN                     | ENVIRONMENT_REFRESH_ALL_WINDOWS             | 2025-06-02 22:15:54.904 |          |                 | 2025-06-02 22:17:20.219 | Refreshing all windows environments.                                                                                                                                 | COMPLETED | event.action.environment.refresh.all.windows             | []                                                                                           | system                                                                                   | ACTION-211 | f                    |                   |                       |
     87 | WINDOWS_HOST_ENVIRONMENT-1 | ENVIRONMENT_REFRESH                         | 2025-06-02 22:15:55.149 |          |                 | 2025-06-02 22:17:09.453 | Refresh environment "win2016t-lfty-qar-178038-766f97e2.dlpxdc.co".                                                                                                   | COMPLETED | event.action.environment.refresh                         | ["win2016t-lfty-qar-178038-766f97e2.dlpxdc.co"]                                              | win2016t-lfty-qar-178038-766f97e2.dlpxdc.co                                              | ACTION-212 | f                    |                   |                       |
     88 | WINDOWS_HOST-1             | HOST_REFRESH                                | 2025-06-02 22:15:55.394 |          |                 | 2025-06-02 22:17:09.331 | Refresh host "10.110.211.90".                                                                                                                                        | COMPLETED | event.action.host.refresh                                | ["10.110.211.90"]                                                                            | 10.110.211.90                                                                            | ACTION-213 | f                    |                   |                       |
     89 | WINDOWS_HOST_ENVIRONMENT-2 | ENVIRONMENT_REFRESH                         | 2025-06-02 22:17:09.524 |          |                 | 2025-06-02 22:17:20.172 | Refresh environment "win2016s-t8wo-qar-178038-766f97e2.dlpxdc.co".                                                                                                   | COMPLETED | event.action.environment.refresh                         | ["win2016s-t8wo-qar-178038-766f97e2.dlpxdc.co"]                                              | win2016s-t8wo-qar-178038-766f97e2.dlpxdc.co                                              | ACTION-214 | f                    |                   |                       |
     90 | WINDOWS_HOST-2             | HOST_REFRESH                                | 2025-06-02 22:17:09.587 |          |                 | 2025-06-02 22:17:20.095 | Refresh host "10.110.245.27".                                                                                                                                        | COMPLETED | event.action.host.refresh                                | ["10.110.245.27"]                                                                            | 10.110.245.27                                                                            | ACTION-215 | f                    |                   |                       |
     91 | DOMAIN                     | SOURCES_UNQUIESCE_PARALLEL                  | 2025-06-02 22:17:20.978 |          |                 | 2025-06-02 22:17:21.017 | Enable a group of sources in parallel.                                                                                                                               | COMPLETED | event.action.sources.unquiesce.parallel                  | []                                                                                           | system                                                                                   | ACTION-217 | f                    |                   |                       |
...
     95 | MSSQL_VIRTUAL_SOURCE-5     | SOURCE_UNQUIESCE                            | 2025-06-02 22:17:21.268 |          |                 | 2025-06-02 22:18:07.503 | Enable quiesced source SourceDB-K76YRM-1748896147918                                                                                                                 | COMPLETED | event.action.source.unquiesce                            | ["SourceDB-K76YRM-1748896147918"]                                                            | SourceDB-K76YRM-1748896147918                                                            | ACTION-221 | f                    |                   |                       |
     96 | MSSQL_VIRTUAL_SOURCE-10    | SOURCE_UNQUIESCE                            | 2025-06-02 22:17:21.385 |          |                 | 2025-06-02 22:18:06.811 | Enable quiesced source SourceDB-1DVZCN-1748896154586                                                                                                                 | COMPLETED | event.action.source.unquiesce                            | ["SourceDB-1DVZCN-1748896154586"]                                                            | SourceDB-1DVZCN-1748896154586                                                            | ACTION-222 | f                    |                   |                       |
     97 | MSSQL_VIRTUAL_SOURCE-1     | SOURCE_UNQUIESCE                            | 2025-06-02 22:17:21.492 |          |                 | 2025-06-02 22:18:09.001 | Enable quiesced source SourceDB-H866U2-1748896149271                                                                                                                 | COMPLETED | event.action.source.unquiesce                            | ["SourceDB-H866U2-1748896149271"]                                                            | SourceDB-H866U2-1748896149271                                                            | ACTION-223 | f                    |                   |                       |
     98 | MSSQL_VIRTUAL_SOURCE-2     | SOURCE_UNQUIESCE                            | 2025-06-02 22:17:21.599 |          |                 | 2025-06-02 22:18:06.83  | Enable quiesced source SourceDB-83KIE4-1748896153275                                                                                                                 | COMPLETED | event.action.source.unquiesce                            | ["SourceDB-83KIE4-1748896153275"]                                                            | SourceDB-83KIE4-1748896153275                                                            | ACTION-224 | f                    |                   |                       |
     99 | MSSQL_VIRTUAL_SOURCE-7     | SOURCE_UNQUIESCE                            | 2025-06-02 22:17:21.701 |          |                 | 2025-06-02 22:18:06.393 | Enable quiesced source SourceDB-7SC2SW-1748896151911                                                                                                                 | COMPLETED | event.action.source.unquiesce                            | ["SourceDB-7SC2SW-1748896151911"]                                                            | SourceDB-7SC2SW-1748896151911                                                            | ACTION-225 | f                    |                   |                       |
    100 | MSSQL_VIRTUAL_SOURCE-3     | SOURCE_UNQUIESCE                            | 2025-06-02 22:17:21.877 |          |                 | 2025-06-02 22:18:06.677 | Enable quiesced source SourceDB-GHOM6P-1748896143785                                                                                                                 | COMPLETED | event.action.source.unquiesce                            | ["SourceDB-GHOM6P-1748896143785"]                                                            | SourceDB-GHOM6P-1748896143785                                                            | ACTION-226 | f                    |                   |                       |
    101 | MSSQL_VIRTUAL_SOURCE-11    | SOURCE_UNQUIESCE                            | 2025-06-02 22:17:22.026 |          |                 | 2025-06-02 22:18:06.612 | Enable quiesced source SourceDB-JXIPXC-1748896158588                                                                                                                 | COMPLETED | event.action.source.unquiesce                            | ["SourceDB-JXIPXC-1748896158588"]                                                            | SourceDB-JXIPXC-1748896158588                                                            | ACTION-227 | f                    |                   |                       |
    102 | MSSQL_VIRTUAL_SOURCE-6     | SOURCE_UNQUIESCE                            | 2025-06-02 22:17:22.229 |          |                 | 2025-06-02 22:18:06.763 | Enable quiesced source SourceDB-H13E52-1748896157275                                                                                                                 | COMPLETED | event.action.source.unquiesce                            | ["SourceDB-H13E52-1748896157275"]                                                            | SourceDB-H13E52-1748896157275                                                            | ACTION-228 | f                    |                   |                       |
    103 | MSSQL_VIRTUAL_SOURCE-4     | SOURCE_UNQUIESCE                            | 2025-06-02 22:17:22.456 |          |                 | 2025-06-02 22:18:07.885 | Enable quiesced source SourceDB-FFMN9W-1748896146610                                                                                                                 | COMPLETED | event.action.source.unquiesce                            | ["SourceDB-FFMN9W-1748896146610"]                                                            | SourceDB-FFMN9W-1748896146610                                                            | ACTION-229 | f                    |                   |                       |
    104 | MSSQL_VIRTUAL_SOURCE-9     | SOURCE_UNQUIESCE                            | 2025-06-02 22:17:22.66  |          |                 | 2025-06-02 22:18:06.497 | Enable quiesced source SourceDB-WV86HD-1748896150590                                                                                                                 | COMPLETED | event.action.source.unquiesce                            | ["SourceDB-WV86HD-1748896150590"]                                                            | SourceDB-WV86HD-1748896150590                                                            | ACTION-230 | f                    |                   |                       |
    105 | MSSQL_VIRTUAL_SOURCE-12    | SOURCE_UNQUIESCE                            | 2025-06-02 22:17:22.914 |          |                 | 2025-06-02 22:18:09.223 | Enable quiesced source SourceDB-3A6ZSD-1748896155916                                                                                                                 | COMPLETED | event.action.source.unquiesce                            | ["SourceDB-3A6ZSD-1748896155916"]                                                            | SourceDB-3A6ZSD-1748896155916                                                            | ACTION-231 | f                    |                   |                       |
 ```
</details>
