### PR TITLE
TOOL-13488 appliance-build.bootstrap role fails to connect to ubuntu.com

### DIFF
--- a/bootstrap/roles/appliance-build.bootstrap/tasks/main.yml
+++ b/bootstrap/roles/appliance-build.bootstrap/tasks/main.yml
@@ -1,5 +1,5 @@
 #
-# Copyright 2018-2019 Delphix
+# Copyright 2018-2025 Delphix
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,6 +15,27 @@
 #
 
 ---
+- name: Remove default apt sources
+  ansible.builtin.command: bash -c 'rm -rf /etc/apt/sources.list.d/*'
+  changed_when: true
+
+- name: Configure apt sources
+  vars:
+    mirror_url: "{{ lookup('env', 'DELPHIX_PACKAGE_MIRROR_MAIN') }}"
+  block:
+    - name: Configure noble apt source
+      ansible.builtin.apt_repository:
+        repo: "deb {{ mirror_url }} noble main restricted multiverse universe"
+        state: present
+    - name: Configure noble-updates apt source
+      ansible.builtin.apt_repository:
+        repo: "deb {{ mirror_url }} noble-updates main restricted multiverse universe"
+        state: present
+    - name: Configure noble-security apt source
+      ansible.builtin.apt_repository:
+        repo: "deb {{ mirror_url }} noble-security main"
+        state: present
+
 - name: Stop unattended-upgrades systemd service in preparation for package removal
   ansible.builtin.systemd:
     name: unattended-upgrades

--- a/live-build/config/hooks/vm-artifacts/83-etc-apt-sources-list.binary
+++ b/live-build/config/hooks/vm-artifacts/83-etc-apt-sources-list.binary
@@ -1,6 +1,6 @@
 #!/bin/bash -eux
 #
-# Copyright 2018 Delphix
+# Copyright 2018-2025 Delphix
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -23,14 +23,19 @@
 # mechanism that is capable of upgrading itself without network
 # connectivity to these external APT repositories. Thus to avoid any
 # source of confusion or mistakes, we actually remove the default
-# list(s) here.
+# list(s) here. N.b: We use bash here so that the glob gets evaluated
+# inside of the chroot environment.
 #
-chroot binary rm -f /etc/apt/sources.list
+chroot binary bash -c 'rm -f /etc/apt/sources.list /etc/apt/sources.list.d/*'
 
 #
-# We must use bash here, so the glob gets evaluated inside the chroot
-# environment, and matches the files installed in the chroot's
-# directory. Otherwise it would evaluate on the host system, and
-# matching the files found on the host system.
+# For developer convenience, we configure the internal-dev variant with an apt
+# sources configuration that points to our internal Ubuntu mirror.
 #
-chroot binary bash -c 'rm -f /etc/apt/sources.list.d/*.list'
+if [[ $APPLIANCE_VARIANT = "internal-dev" ]]; then
+	cat <<-EOF >/etc/apt/sources.list.d/delphix.list
+		deb http://linux-package-mirror-v2.delphix.com/develop/latest/ubuntu noble main restricted multiverse universe
+		deb http://linux-package-mirror-v2.delphix.com/develop/latest/ubuntu noble-updates main restricted multiverse universe
+		deb http://linux-package-mirror-v2.delphix.com/develop/latest/ubuntu noble-security main
+	EOF
+fi

--- a/live-build/misc/ansible-roles/appliance-build.minimal-development/tasks/main.yml
+++ b/live-build/misc/ansible-roles/appliance-build.minimal-development/tasks/main.yml
@@ -1,5 +1,5 @@
 #
-# Copyright 2018 Delphix
+# Copyright 2018-2025 Delphix
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,13 +15,6 @@
 #
 
 ---
-- copy:
-    dest: /etc/cloud/cloud.cfg.d/99-delphix-development.cfg
-    mode: 0644
-    content: |
-      apt:
-        preserve_sources_list: false
-
 #
 # We use "no_log" here to ensure we don't accidentally leak the contents
 # of these AWS_* environment variables to stdout; e.g. this would happen


### PR DESCRIPTION
Reconfigure apt early during the bootstrap phase of appliance-build to make sure that the build VM itself has apt sources pointing at the right package mirror URL. Because the internal-buildserver variant build also runs the `minimal-development` ansible role, I had to remove the ansible code in that role that enables cloud-init-based apt configuration (so that cloud-init doesn't reset the apt sources list on internal-buildserver variants). This then required that I do something explicit for `internal-dev` variants to configure their apt sources to point to the mirror. That's the change in `83-etc-apt-sources-list.binary`. While in that file, I noticed that the code that cleans up apt sources for external variants is wrong: It was only deleting files with a suffix of ".list", leaving behind a file named `ubuntu.sources`. I fixed the code to remove everything in `/etc/apt/sources.list.d/*`.

ab-pre-push: https://selfservice-jenkins.eng-tools-prd.aws.delphixcloud.com/job/appliance-build-orchestrator-pre-push/11283/
