### PR TITLE
DLPX-94449 upgrade-scripts/rootfs-container should use 'get-appliance-platform'

### DIFF
--- a/upgrade/upgrade-scripts/rootfs-container
+++ b/upgrade/upgrade-scripts/rootfs-container
@@ -145,7 +145,7 @@ function set_bootfs_not_mounted() {
 	mount -t zfs rpool/grub "/var/lib/machines/$CONTAINER/mnt" ||
 		die "'mount -t zfs rpool/grub' failed for '$CONTAINER'"
 
-	PLATFORM=$(get_appliance_platform)
+	PLATFORM=$(get-appliance-platform)
 
 	for dev in $(get_bootloader_devices); do
 		[[ -e "/dev/$dev" ]] ||
@@ -209,7 +209,7 @@ function set_bootfs_mounted() {
 	mount -t zfs rpool/grub "/mnt" ||
 		die "'mount -t zfs rpool/grub' failed for '$CONTAINER'"
 
-	PLATFORM=$(get_appliance_platform)
+	PLATFORM=$(get-appliance-platform)
 
 	for dev in $(get_bootloader_devices); do
 		[[ -e "/dev/$dev" ]] ||


### PR DESCRIPTION
<details open>
<summary><h2> Problem </h2></summary>
There's a typo, using "get_appliance_platform" instead of "get-appliance-platform".
</details>

<details open>
<summary><h2> Solution </h2></summary>
Fix the typo.
</details>
