### PR TITLE
TOOL-28181 internal-dev not configured with mirror apt sources

### DIFF
--- a/live-build/config/hooks/vm-artifacts/83-etc-apt-sources-list.binary
+++ b/live-build/config/hooks/vm-artifacts/83-etc-apt-sources-list.binary
@@ -33,9 +33,9 @@ chroot binary bash -c 'rm -f /etc/apt/sources.list /etc/apt/sources.list.d/*'
 # sources configuration that points to our internal Ubuntu mirror.
 #
 if [[ $APPLIANCE_VARIANT = "internal-dev" ]]; then
-	cat <<-EOF >/etc/apt/sources.list.d/delphix.list
+	chroot binary bash -c 'cat <<-EOF >/etc/apt/sources.list.d/delphix.list
 		deb http://linux-package-mirror-v2.delphix.com/develop/latest/ubuntu noble main restricted multiverse universe
 		deb http://linux-package-mirror-v2.delphix.com/develop/latest/ubuntu noble-updates main restricted multiverse universe
 		deb http://linux-package-mirror-v2.delphix.com/develop/latest/ubuntu noble-security main
-	EOF
+	EOF'
 fi


### PR DESCRIPTION
The fix for TOOL-1348 included logic to configure the internal-dev variant apt sources, but there’s a missing chroot in that configuration logic, which causes the configuration to apply to the build server instead of the VM being created.

This was tested by creating an internal-dev VM and verifying that `/etc/apt/sources.list.d/delphix.list` is present on it.