### PR TITLE
DLPX-94695 "ORACLE_UPGRADE_MINIMUM_UPGRADE_VERSION_TO_RELEASE_SOLARIS_11_4" fails while verifying VDB/dSource state after Upgrade.

### DIFF
--- a/upgrade/upgrade-scripts/rootfs-container
+++ b/upgrade/upgrade-scripts/rootfs-container
@@ -264,14 +264,14 @@ function quiesce_sources_if_needed() {
 	# quiesce sources. Only upgrades going to 2025.4.0.0 or greater need
 	# this hack to quiesce sources.
 	#
-	compare_versions "$UPGRADE_VERSION" lt "2025.4.0.0-0" || return 0
+	compare_versions "$UPGRADE_VERSION" lt "2025.4.0.0-0" && return 0
 
 	#
 	# Also, if the version we're coming from is 2025.3.0.1 or greater, then
 	# don't quiesce sources. All versions 2025.3.0.1 and greater, should
 	# quiesce sources properly from the stack's upgrade logic.
 	#
-	compare_versions "$UPGRADE_BASE_VERSION" ge "2025.3.0.1-0" || return 0
+	compare_versions "$UPGRADE_BASE_VERSION" ge "2025.3.0.1-0" && return 0
 
 	#
 	# At this point, we know we're:


### PR DESCRIPTION
<details open>
<summary><h2> Problem </h2></summary>
We're not properly quiescing VDBs when upgrading to 2025.4.0.0.
</details>

<details open>
<summary><h2> Solution </h2></summary>
The solution is to fix the conditionals in the "quiesce_sources_if_needed()" function, which had be accidentally inverted. This likely wasn't noticed prior to CC, since the version of develop had pre-release information embedded in it; it's not until that pre-release information was removed, that the conditional started doing the wrong thing.
</details>


<details open>
<summary><h2> Testing Done </h2></summary>

- `git-ab-pre-push` is [here](https://selfservice-jenkins.eng-tools-prd.aws.delphixcloud.com/job/appliance-build-orchestrator-pre-push/11581/)
- Deployed a 25.0.0.0 engine, and performed an upgrade to 2025.4.0.0, and verified VDBs are quiesced when this change is applied.

</details>
