### PR TITLE
DLPX-94736 upgrade to develop fails with rsync: [generator] failed to set permissions on multiple directories inside log

### DIFF
--- a/upgrade/upgrade-scripts/execute
+++ b/upgrade/upgrade-scripts/execute
@@ -445,6 +445,18 @@ apt_get purge -y $(dpkg -l | grep ^rc | awk '{print $2}') ||
 	die "failed to remove 'rc' packages"
 
 #
+# After removing the td-agent package above, the td-agent user will be deleted,
+# but we've seen this user still referenced via dpkg-statoverride, which causes
+# future package commands to fail (e.g. dpkg, apt-get). As a workaround, we're
+# explicitly removing these references here. Ideally, this would be handled by
+# the td-agent package itself, on removal.
+#
+grep ^td-agent /var/lib/dpkg/statoverride | \
+	awk '{ print $4 }' | \
+	xargs -n1 dpkg-statoverride --remove ||
+	die "failed to remove td-agent from dpkg-statoverride"
+
+#
 # Package configuration files are only automatically removed by the
 # package manager when the package that "owns" the file is "purged".
 # Thus, when upgrading a package to a new version that no longer


### PR DESCRIPTION
<details open>
<summary><h2> Problem </h2></summary>
Upgrades are failing with the following error:

```
2025-07-10T09:38:05.675553+00:00 ip-10-110-222-162 upgrade-scripts:execute[1099]: /var/dlpx-update/2025.5.0.0-snapshot.20250710002438199+jenkins-ops-appliance-build-develop-post-push-3025/common.sh:apt_get:352 apt-get -o Dpkg::Options::=--force-confdef -o Dpkg::Options::=--force-confold install -y --reinstall fontconfig-config
2025-07-10T09:38:05.686360+00:00 ip-10-110-222-162 upgrade-scripts:execute[1099]: Reading package lists...
2025-07-10T09:38:05.688786+00:00 ip-10-110-222-162 upgrade-scripts:execute[1099]: Building dependency tree...
2025-07-10T09:38:05.688837+00:00 ip-10-110-222-162 upgrade-scripts:execute[1099]: Reading state information...
2025-07-10T09:38:05.717440+00:00 ip-10-110-222-162 upgrade-scripts:execute[1099]: 0 upgraded, 0 newly installed, 1 reinstalled, 0 to remove and 1 not upgraded.
2025-07-10T09:38:05.717529+00:00 ip-10-110-222-162 upgrade-scripts:execute[1099]: Need to get 0 B/37.3 kB of archives.
2025-07-10T09:38:05.717561+00:00 ip-10-110-222-162 upgrade-scripts:execute[1099]: After this operation, 0 B of additional disk space will be used.
2025-07-10T09:38:05.717587+00:00 ip-10-110-222-162 upgrade-scripts:execute[1099]: Get:1 file:/var/dlpx-update/2025.5.0.0-snapshot.20250710002438199+jenkins-ops-appliance-build-develop-post-push-3025 noble/delphix amd64 fontconfig-config amd64 2.15.0-1.1ubuntu2 [37.3 kB]
2025-07-10T09:38:05.878774+00:00 ip-10-110-222-162 upgrade-scripts:execute[1099]: debconf: delaying package configuration, since apt-utils is not installed
2025-07-10T09:38:05.896438+00:00 ip-10-110-222-162 upgrade-scripts:execute[1099]: dpkg: unrecoverable fatal error, aborting:#015
2025-07-10T09:38:05.897664+00:00 ip-10-110-222-162 upgrade-scripts:execute[1099]:  unknown system user 'td-agent' in statoverride file; the system user got removed#015
2025-07-10T09:38:05.897726+00:00 ip-10-110-222-162 upgrade-scripts:execute[1099]: before the override, which is most probably a packaging bug, to recover you#015
2025-07-10T09:38:05.897777+00:00 ip-10-110-222-162 upgrade-scripts:execute[1099]: can remove the override manually with dpkg-statoverride#015
2025-07-10T09:38:05.910186+00:00 ip-10-110-222-162 upgrade-scripts:execute[1099]: E: Sub-process /usr/bin/dpkg returned an error code (2)
2025-07-10T09:38:05.911242+00:00 ip-10-110-222-162 upgrade-scripts:execute[1099]: /var/dlpx-update/2025.5.0.0-snapshot.20250710002438199+jenkins-ops-appliance-build-develop-post-push-3025/execute::505 die 'failed to reinstall package '\''fontconfig-config'\'''
```

</details>

<details open>
<summary><h2> Solution </h2></summary>
To workaround this issue, this PR adds logic to explicitly remove paths from dpkg-statoverride, which reference the removed td-agent user.
</details>


<details open>
<summary><h2> Testing Done </h2></summary>

- `git-ab-pre-push` is [here](https://selfservice-jenkins.eng-tools-prd.aws.delphixcloud.com/job/appliance-build-orchestrator-pre-push/11599/)
- Deployed this change, and performed a 2025.3.0.0 to 2025.5.0.0 upgrade, which failed before.

</details>
