### PR TITLE
DLPX-94757 [Backport of DLPX-94736] upgrade to develop fails with rsync: [generator] failed to set permissions on multiple directories inside log

### DIFF
--- a/upgrade/upgrade-scripts/execute
+++ b/upgrade/upgrade-scripts/execute
@@ -79,6 +79,34 @@ function generate_interface_to_mac_address_map() {
 }
 
 #
+# The purpose of this function is to remove entries from dpkg-statoverride that
+# reference a user that doesn't exist. It's not uncommon for a package to
+# remove a user upon removal of the package, but forget to remove the
+# corresponding entry in dpkg-statoverride for that user. When this occurs, it
+# causes future package operations (e.g. dpkg, apt-get) to fail.
+#
+function prune_dpkg_statoverride() {
+	for user in $(awk '{ print $1 }' /var/lib/dpkg/statoverride | sort | uniq); do
+		#
+		# We're only interested in removing entries for users that no
+		# longer exist on the system, so if this user does exist, we
+		# can move on to the next user in the list.
+		#
+		grep -q "^${user}" /etc/passwd && continue
+
+		#
+		# At this point, we know this user does exist in statoverride,
+		# but is not a valid user on the system, so we need to remove
+		# all entries from dpkg-statoverride that reference this user.
+		#
+		grep "^${user}" /var/lib/dpkg/statoverride | \
+			awk '{ print $4 }' | \
+			xargs -n1 dpkg-statoverride --remove ||
+			die "failed to remove '$user' from dpkg-statoverride"
+	done
+}
+
+#
 # Specifies the platform to upgrade to; by default choose the same
 # platform the script is running on.
 #
@@ -443,6 +471,15 @@ apt_get purge -y $(apt-mark showauto | grep -v "$(uname -r)") ||
 # shellcheck disable=SC2046
 apt_get purge -y $(dpkg -l | grep ^rc | awk '{print $2}') ||
 	die "failed to remove 'rc' packages"
+
+#
+# After removing the td-agent package above, the td-agent user will be deleted,
+# but we've seen this user still referenced via dpkg-statoverride, which causes
+# future package commands to fail (e.g. dpkg, apt-get). As a workaround, we're
+# explicitly removing these references here. Ideally, this would be handled by
+# the td-agent package itself, on removal.
+#
+prune_dpkg_statoverride
 
 #
 # Package configuration files are only automatically removed by the


### PR DESCRIPTION
Clean cherry-pick of https://github.com/delphix/appliance-build/pull/831 and https://github.com/delphix/appliance-build/pull/834
