### PR TITLE
DLPX-94736 upgrade to develop fails with rsync: [generator] failed to set permissions on multiple directories inside log

### DIFF
--- a/upgrade/upgrade-scripts/execute
+++ b/upgrade/upgrade-scripts/execute
@@ -451,10 +451,12 @@ apt_get purge -y $(dpkg -l | grep ^rc | awk '{print $2}') ||
 # explicitly removing these references here. Ideally, this would be handled by
 # the td-agent package itself, on removal.
 #
-grep ^td-agent /var/lib/dpkg/statoverride | \
-	awk '{ print $4 }' | \
-	xargs -n1 dpkg-statoverride --remove ||
-	die "failed to remove td-agent from dpkg-statoverride"
+if grep -q ^td-agent /var/lib/dpkg/statoverride; then
+	grep ^td-agent /var/lib/dpkg/statoverride | \
+		awk '{ print $4 }' | \
+		xargs -n1 dpkg-statoverride --remove ||
+		die "failed to remove td-agent from dpkg-statoverride"
+fi
 
 #
 # Package configuration files are only automatically removed by the


### PR DESCRIPTION
<details open>
<summary><h2> Problem </h2></summary>

If dpkg-statoverride doesn't have entries with "td-agent" in it, the logic from 26337c414dc2d75f5e08398f6a6f44c708390075 will cause a failure. For example, if we removed the lines in one upgrade, the subsequent upgrade will throw an error due to the missing lines. E.g.

```
$ grep ^td-agent /var/lib/dpkg/statoverride
$ grep ^td-agent /var/lib/dpkg/statoverride | awk '{ print $4 }' | xargs -n1 dpkg-statoverride --remove
dpkg-statoverride: error: --remove needs a single argument

Use --help for help about overriding file stat information.
```

</details>

<details open>
<summary><h2> Solution </h2></summary>
The solution is to first check if the lines exist, before attempting to remove them.
</details>
