### PR TITLE
DLPX-94736 upgrade to develop fails with rsync: [generator] failed to set permissions on multiple directories inside log

### DIFF
--- a/upgrade/upgrade-scripts/execute
+++ b/upgrade/upgrade-scripts/execute
@@ -79,6 +79,34 @@ function generate_interface_to_mac_address_map() {
 }
 
 #
+# The purpose of this function is to remove entries from dpkg-statoverride that
+# reference a user that doesn't exist. It's not uncommon for a package to
+# remove a user upon removal of the package, but forget to remove the
+# corresponding entry in dpkg-statoverride for that user. When this occurs, it
+# causes future package operations (e.g. dpkg, apt-get) to fail.
+#
+function prune_dpkg_statoverride() {
+	for user in $(awk '{ print $1 }' /var/lib/dpkg/statoverride | sort | uniq); do
+		#
+		# We're only interested in removing entries for users that no
+		# longer exist on the system, so if this user does exist, we
+		# can move on to the next user in the list.
+		#
+		grep -q "^${user}" /etc/passwd && continue
+
+		#
+		# At this point, we know this user does exist in statoverride,
+		# but is not a valid user on the system, so we need to remove
+		# all entries from dpkg-statoverride that reference this user.
+		#
+		grep "^${user}" /var/lib/dpkg/statoverride | \
+			awk '{ print $4 }' | \
+			xargs -n1 dpkg-statoverride --remove ||
+			die "failed to remove '$user' from dpkg-statoverride"
+	done
+}
+
+#
 # Specifies the platform to upgrade to; by default choose the same
 # platform the script is running on.
 #
@@ -451,10 +479,7 @@ apt_get purge -y $(dpkg -l | grep ^rc | awk '{print $2}') ||
 # explicitly removing these references here. Ideally, this would be handled by
 # the td-agent package itself, on removal.
 #
-grep ^td-agent /var/lib/dpkg/statoverride | \
-	awk '{ print $4 }' | \
-	xargs -n1 dpkg-statoverride --remove ||
-	die "failed to remove td-agent from dpkg-statoverride"
+prune_dpkg_statoverride
 
 #
 # Package configuration files are only automatically removed by the


### PR DESCRIPTION
<details open>
<summary><h2> Problem </h2></summary>
The logic in 26337c414dc2d75f5e08398f6a6f44c708390075 is specific to the td-agent user, but the problem is possible for any user listed in dpkg-statoverride. To get ahead of future issues like this with other users, we should make the solution more generic, and not specific to the td-agent user.
</details>

<details open>
<summary><h2> Solution </h2></summary>
Extend the solution to work for any non-existent user found in dpkg-statoverride.
</details>
