### PR TITLE
DLPX-94796 test_post_verify_time_config failed because NTP configuration got reset from enable to disable

### DIFF
--- a/upgrade/upgrade-scripts/execute
+++ b/upgrade/upgrade-scripts/execute
@@ -442,6 +442,22 @@ if [[ -f "/etc/ntp.conf" ]]; then
 		cp /etc/ntp.conf /etc/ntpsec/ntp.conf ||
 			die "failed to copy /etc/ntp.conf to /etc/ntpsec/ntp.conf"
 
+		#
+		# On removal, the "ntp" package will mask the "ntp" service. As
+		# a result, enable of the "ntpsec" service will fail, due to it
+		# having an alias to the "ntp" service name, and that service
+		# being masked.
+		#
+		# As a workaround, we explicitly "purge" the "ntp" package,
+		# which will remove the masked "ntp" service, so that it
+		# doesn't impact the enable of "netpsec".
+		#
+		# This doesn't impact the end state of the system, as the ntp
+		# package would have been purged later in this script; but we
+		# need to do it here, prior to attempting to enable "ntpsec".
+		#
+		apt_get purge -y ntp || die "failed to purge ntp package"
+
 		systemctl unmask ntpsec.service || die "failed to unmask ntpsec.service"
 		systemctl enable ntpsec.service || die "failed to enable ntpsec.service"
 	fi

--- a/upgrade/upgrade-scripts/execute
+++ b/upgrade/upgrade-scripts/execute
@@ -424,18 +424,26 @@ zcat "/usr/share/doc/delphix-entire-$opt_p/packages.list.gz" |
 	cut -d= -f1 | xargs apt-mark manual ||
 	die "failed to mark as manual packages listed in packages.list.gz file"
 
-#
-# As part of the LTS upgrade project to 24.04, `ntp` was replaced by `ntpsec`.
-# To preserve and migrate the NTP configuration, we need to copy the
-# NTP configuration file to the new location after packages are upgraded,
-# but before they are removed so that NTP continues to function as expected.
-#
-if [[ -f "/etc/ntp/ntp.conf" ]]; then
-	cp /etc/ntp/ntp.conf /etc/ntpsec/ntp.conf ||
-		die "failed to copy /etc/ntp/ntp.conf to /etc/ntpsec/ntp.conf"
-	if [[ "$(systemctl is-enabled ntp.service)" == enabled ]]; then
-		systemctl disable --now ntp.service
-		systemctl enable ntpsec.service
+if [[ -f "/etc/ntp.conf" ]]; then
+	NTP_CONF_MD5SUM_ORIGINAL=$(dpkg --status ntp | grep /etc/ntp.conf | awk '{ print $2 }')
+	NTP_CONF_MD5SUM_ACTUAL=$(md5sum /etc/ntp.conf | awk '{ print $1 }')
+
+	#
+	# As part of the LTS upgrade project to 24.04, `ntp` was replaced by `ntpsec`.
+	#
+	# To preserve and migrate the NTP configuration, we need to copy the
+	# NTP configuration file to the new location after packages are upgraded,
+	# but before they are removed so that NTP continues to function as expected.
+	#
+	# We only do this if the configuration no longer matches what's installed by
+	# default, as that indicates NTP was configured and enabled on the appliance.
+	#
+	if [[ "$NTP_CONF_MD5SUM_ORIGINAL" != "$NTP_CONF_MD5SUM_ACTUAL" ]]; then
+		cp /etc/ntp.conf /etc/ntpsec/ntp.conf ||
+			die "failed to copy /etc/ntp.conf to /etc/ntpsec/ntp.conf"
+
+		systemctl unmask ntpsec.service || die "failed to unmask ntpsec.service"
+		systemctl enable ntpsec.service || die "failed to enable ntpsec.service"
 	fi
 fi
 


### PR DESCRIPTION
<details open>
<summary><h2> Problem </h2></summary>
The logic we added to migrate the configuration of the "ntp" service to the new "ntpsec" service is incorrect, causing it not to run. As a result, upgrading from .3 and earlier, to .4 and later, may result in a disabled NTP service, even if it was enabled prior to the upgrade.
</details>

<details open>
<summary><h2> Solution </h2></summary>
It looks like the logic is using an incorrect path to the NTP configuration file; e.g.

```
$ ls -l /etc/ntp/ntp.conf
ls: cannot access '/etc/ntp/ntp.conf': No such file or directory

$ ls -l /etc/ntp.conf
-rw-r----- 1 root root 323 Jul 15 17:21 /etc/ntp.conf

$ systemctl status ntp.service
● ntp.service - Network Time Service
     Loaded: loaded (/lib/systemd/system/ntp.service; enabled; vendor preset: enabled)
    Drop-In: /usr/lib/systemd/system/ntp.service.d
             └─override.conf
     Active: active (running) since Tue 2025-07-15 17:21:34 UTC; 1h 26min ago
       Docs: man:ntpd(8)
   Main PID: 11045 (ntpd)
      Tasks: 2 (limit: 8733)
     Memory: 1.3M
     CGroup: /system.slice/ntp.service
             └─11045 /usr/sbin/ntpd -p /var/run/ntpd.pid -g -u 101:101
```

Thus, the solution is to modify the logic to use the correct path to the NTP configuration file.
</details>


<details open>
<summary><h2> Testing Done </h2></summary>

- `git-ab-pre-push` is [here](https://selfservice-jenkins.eng-tools-prd.aws.delphixcloud.com/job/appliance-build-orchestrator-pre-push/11656/)

- Before:
```
$ sudo /var/dlpx-update/latest/upgrade-container create not-in-place
Created symlink /etc/systemd/system/fluentd.service → /dev/null.
Created symlink /etc/systemd/system/ntpsec.service → /dev/null.
Created symlink /etc/systemd/system/ntpsec-rotate-stats.timer → /dev/null.
Created symlink /etc/systemd/system/systemd-timesyncd.service → /dev/null.
delphix.rKeslf3

$ sudo /var/dlpx-update/latest/upgrade-container start delphix.rKeslf3
$ sudo /var/dlpx-update/latest/upgrade-container upgrade delphix.rKeslf3
tr: write error: Broken pipe
tr: write error
cat: write error: Broken pipe

$ sudo /var/dlpx-update/latest/upgrade-container shell delphix.rKeslf3
Connected to machine delphix.rKeslf3. Press ^] three times within 1s to exit session.

root@ip-10-110-202-48:~# sudo systemctl status ntp.service
Unit ntp.service could not be found.
root@ip-10-110-202-48:~# sudo systemctl status ntpsec.service
○ ntpsec.service
     Loaded: masked (Reason: Unit ntpsec.service is masked.)
     Active: inactive (dead)
```

- After:
```
$ sudo /var/dlpx-update/latest/upgrade-container create not-in-place
Created symlink /etc/systemd/system/fluentd.service → /dev/null.
Created symlink /etc/systemd/system/ntpsec.service → /dev/null.
Created symlink /etc/systemd/system/ntpsec-rotate-stats.timer → /dev/null.
Created symlink /etc/systemd/system/systemd-timesyncd.service → /dev/null.
delphix.gReDkkQ

$ sudo /var/dlpx-update/latest/upgrade-container start delphix.gReDkkQ
$ sudo /var/dlpx-update/latest/upgrade-container upgrade delphix.gReDkkQ
tr: write error: Broken pipe
tr: write error
cat: write error: Broken pipe
```

</details>
