### PR TITLE
DLPX-94817 [Backport of DLPX-94809] 25.0 to 2025.4 upgrade verify thrown DelphixFatalException, failed to enable ntpsec.service

### DIFF
--- a/upgrade/upgrade-scripts/execute
+++ b/upgrade/upgrade-scripts/execute
@@ -442,6 +442,22 @@ if [[ -f "/etc/ntp.conf" ]]; then
 		cp /etc/ntp.conf /etc/ntpsec/ntp.conf ||
 			die "failed to copy /etc/ntp.conf to /etc/ntpsec/ntp.conf"
 
+		#
+		# On removal, the "ntp" package will mask the "ntp" service. As
+		# a result, enable of the "ntpsec" service will fail, due to it
+		# having an alias to the "ntp" service name, and that service
+		# being masked.
+		#
+		# As a workaround, we explicitly "purge" the "ntp" package,
+		# which will remove the masked "ntp" service, so that it
+		# doesn't impact the enable of "netpsec".
+		#
+		# This doesn't impact the end state of the system, as the ntp
+		# package would have been purged later in this script; but we
+		# need to do it here, prior to attempting to enable "ntpsec".
+		#
+		apt_get purge -y ntp || die "failed to purge ntp package"
+
 		systemctl unmask ntpsec.service || die "failed to unmask ntpsec.service"
 		systemctl enable ntpsec.service || die "failed to enable ntpsec.service"
 	fi


### PR DESCRIPTION
<details open>
<summary><h2> Problem </h2></summary>
The "ntpsec" service has an alias to the "ntp" service name. Upon removing the "ntp" package, the "ntp" service is masked, and that causes enable of "netpsec" to fail (due to the alias being in a masked state).
</details>

<details open>
<summary><h2> Solution </h2></summary>
The solution is to purge the "ntp" package, prior to attempting to enable the "ntpsec" package. Purging the "ntp" package removes the "ntp" service entirely, so that's it's no longer in a masked state. Thus, allowing the enable of "ntpsec" to proceed and work normally.
</details>


<details open>
<summary><h2> Testing Done </h2></summary>

- `git-ab-pre-push` is [here](https://selfservice-jenkins.eng-tools-prd.aws.delphixcloud.com/job/appliance-build-orchestrator-pre-push/11683/)
- Applied this change manually, and performed an upgrade using a manual upgrade container.

- Before:
```
$ sudo /var/dlpx-update/latest/upgrade-container upgrade delphix.gPAYRxD
tr: write error: Broken pipe
tr: write error
cat: write error: Broken pipe
execute: failed to enable ntpsec.service
upgrade-container: '/var/dlpx-update/2025.4.0.0/execute' failed in 'delphix.gPAYRxD'
```

- After:
```
$ sudo /var/dlpx-update/latest/upgrade-container upgrade delphix.MZbGREY
tr: write error: Broken pipe
tr: write error
cat: write error: Broken pipe

$ sudo /var/dlpx-update/latest/upgrade-container shell delphix.MZbGREY
Connected to machine delphix.MZbGREY. Press ^] three times within 1s to exit session.
root@localhost:~# systemctl status ntpsec
○ ntpsec.service - Network Time Service
     Loaded: loaded (/usr/lib/systemd/system/ntpsec.service; enabled; preset: enabled)
    Drop-In: /usr/lib/systemd/system/ntp.service.d
             └─override.conf
     Active: inactive (dead)
       Docs: man:ntpd(8)
```

</details>
