### PR TITLE
CP-12696 Update appliance build to enable SB (no shim)

### DIFF
--- a/live-build/config/hooks/vm-artifacts/90-raw-disk-image.binary
+++ b/live-build/config/hooks/vm-artifacts/90-raw-disk-image.binary
@@ -345,7 +345,35 @@ for dir in /dev /proc /sys; do
 done
 
 #
-# Mount /boot/efi and do grub and bootctl install
+# Kernel modules, ZFS modules, and vmlinuz are signed. So sign only
+# systemd-bootx64.efi and copy certs onto image
+#
+SB_KEYS_DIR="/var/tmp/delphix-sb-keys"
+S3_KEYS_URL="s3://secure-boot-keys-prod/release"
+aws s3 cp --recursive "$S3_KEYS_URL/db/" $SB_KEYS_DIR
+
+#
+# debsums -c during sync-* jobs would fail if original file is replaced.
+# Keep both original .efi and new .signed versions, bootctl install will use
+# the .signed file.
+#
+# Alternatively, build our own systemd-boot-efi package and sign
+# systemd-bootx64.efi there.
+#
+SYSTEMD_BOOT_PATH="${DIRECTORY}/usr/lib/systemd/boot/efi/systemd-bootx64.efi"
+sbsign --key ${SB_KEYS_DIR}/db.key --cert ${SB_KEYS_DIR}/db.crt --output "${SYSTEMD_BOOT_PATH}.signed" "${SYSTEMD_BOOT_PATH}"
+sbverify --list "${SYSTEMD_BOOT_PATH}.signed"
+
+# Copy Secure Boot certs onto image then delete keys/certs from build server
+DLPX_KEYS_DIR="${DIRECTORY}/var/delphix/server/sb_certs"
+mkdir -p $DLPX_KEYS_DIR
+
+aws s3 cp --recursive "$S3_KEYS_URL/pub/" $SB_KEYS_DIR
+cp ${SB_KEYS_DIR}/*.auth "${DLPX_KEYS_DIR}"
+rm -r "${SB_KEYS_DIR}"
+
+#
+# Mount /boot/efi and do bootctl install
 #
 EFI_DIR="/mnt/boot/efi"
 chroot "$DIRECTORY" mkdir -p $EFI_DIR

--- a/upgrade/upgrade-scripts/common.sh
+++ b/upgrade/upgrade-scripts/common.sh
@@ -19,7 +19,7 @@
 UPDATE_DIR="/var/dlpx-update"
 LOG_DIRECTORY="/var/tmp/delphix-upgrade"
 HOTFIX_PATH="/etc/hotfix"
-EFI_DIR="/boot/efi"
+EFI_DIR="/mnt/boot/efi"
 EFI_PART_UUID="c12a7328-f81f-11d2-ba4b-00a0c93ec93b"
 
 #

--- a/upgrade/upgrade-scripts/rootfs-container
+++ b/upgrade/upgrade-scripts/rootfs-container
@@ -110,6 +110,7 @@ function mount_efi() {
 	#
 	# Find and mount the device and partition with EFI UUID
 	#
+	mkdir -p "$EFI_DIR"
 	for dev in $(get_bootloader_devices); do
 		for part in $(lsblk -ln -o NAME,FSTYPE,PARTTYPE "/dev/$dev" | grep "$EFI_PART_UUID" | awk '{print $1}'); do
 			part_path="/dev/$part"
@@ -192,7 +193,7 @@ function set_bootfs_not_mounted() {
 		update_systemd_boot_entries
 		cp "/var/lib/machines/${CONTAINER}/boot/initrd.img" "$EFI_DIR"
 		cp "/var/lib/machines/${CONTAINER}/boot/vmlinuz" "$EFI_DIR"
-		chroot "/var/lib/machines/$CONTAINER" bootctl update
+		chroot "/var/lib/machines/$CONTAINER" bootctl --esp-path="$EFI_DIR" update
 		umount "$EFI_DIR"
 	else
 		for dev in $(get_bootloader_devices); do
@@ -259,7 +260,7 @@ function set_bootfs_mounted() {
 		update_systemd_boot_entries
 		cp /boot/initrd.img "$EFI_DIR"
 		cp /boot/vmlinuz "$EFI_DIR"
-		bootctl update
+		bootctl --esp-path="$EFI_DIR" update
 		umount "$EFI_DIR"
 	else
 		for dev in $(get_bootloader_devices); do


### PR DESCRIPTION
<details open>
<summary><h2> Background </h2></summary>
Builds appliance image with secure-boot support.
</details>

<!--
<details open>
<summary><h2> Problem </h2></summary>

Provide a clear description of the high-level problem you are trying to
solve. The problem statement should be written in terms of a specific
symptom that affects users or the business. The problem statement should
not be written in terms of the solution. If possible, include a minimal
reproducible example (MRE) with steps to reproduce, expected results,
and actual results.
</details>
-->

<!--
<details>
<summary><h2> Evaluation </h2></summary>

If the cause of the problem is not obvious, provide a root-cause
analysis (RCA), ideally using the Five Whys iterative interrogative
technique or some other form of analytical reasoning.
</details>
-->

<details open>
<summary><h2> Solution </h2></summary>
This change depends on ZFS, connstat, and kernel builds changes in https://github.com/delphix/linux-pkg/pull/371 which signs modules and kernel images for secure-boot. </p>

The kernel image and modules are signed in the above PR. Appliance image creation needs to sign only the systemd-boot binary which is done in this PR. `bootctl install` uses the .signed file by default.
</details>


<details open>
<summary><h2> Testing Done </h2></summary>

- Successful appliance builds for ESX, AWS, GCP, and Azure which imported created images and successfully booted VMs on those cloud platforms.
- On AWS, upgrade blackbox test also ran successfully.
- Manually tested 2025.5 secure boot to 2025.5
- Manually tested 2024.4 BIOS to 2025.5 (similar to upgrade blackbox test)

Last successful build (08/23) - https://selfservice-jenkins.eng-tools-prd.aws.delphixcloud.com/job/appliance-build-orchestrator-pre-push/11986/console </p>

Current build (08/25) - https://selfservice-jenkins.eng-tools-prd.aws.delphixcloud.com/job/appliance-build-orchestrator-pre-push/11996/console
</details>

<!--
<details>
<summary><h2> Implementation </h2></summary>

Describe the implementation details of the solution. Generally the
reasoning behind any non-obvious code should be recorded in code
comments. However, code comments should always describe the current
state of the code; in contrast, this section may be useful to describe
the relationship between the original code and the code being proposed
in this pull request.
</details>
-->

<!--
<details>
<summary><h2> Notes to Reviewers </h2></summary>

Provide any extra information a reviewer may need to know before
evaluating your pull request. For example, you may wish to describe
which files should be reviewed first or which files are auto-generated.
If the review tool cannot detect a file move, you may wish to link to a
patch comparing the old file and the new file.
</details>
-->

<!--
<details>
<summary><h2> Deployment Plan </h2></summary>

Describe how the code in this pull request will be deployed. Some
deployments are complicated and may require flag days between multiple
repositories or the provisioning of new infrastructure. Describing your
deployment plan allows reviewers to ensure that your work will not cause
any unnecessary interruption to end users.
</details>
-->

<!--
<details>
<summary><h2> Future Work </h2></summary>

Provide a description of any possible follow-up work that is explicitly
not being done in this pull request.
</details>
-->

<!--
<details>
<summary><h2> Bonus </h2></summary>

Provide a description of any extra problems you have solved in this pull
request.
</details>
-->
