### PR TITLE
HM-4892 [appliance-build] Run the hyperscale-common task after masking-common task in the internal-hyperscale playbook

### DIFF
--- a/live-build/variants/internal-hyperscale/ansible/playbook.yml
+++ b/live-build/variants/internal-hyperscale/ansible/playbook.yml
@@ -24,9 +24,16 @@
     - appliance-build.minimal-common
     - appliance-build.minimal-internal
     - appliance-build.minimal-development
-    - appliance-build.hyperscale-common
     - appliance-build.masking-common
     - appliance-build.masking-development
     - appliance-build.virtualization-common
     - appliance-build.virtualization-development
+    #
+    # The hyperscale-common role requires the appliance configuration,
+    # essentially the 'masking' user creation, done by the masking-common
+    # role to be in place before the hyperscale-common role is applied.
+    # Thus, we need to ensure the hyperscale-common role is applied after
+    # the masking-common role.
+    #
+    - appliance-build.hyperscale-common
     - appliance-build.qa-internal


### PR DESCRIPTION

<details open>
<summary><h2> Background </h2></summary>

A developer is working on a change for the hyperscale closed appliance project which requires the appliance configuration(essentially the `masking` user creation) done by the masking debian package to be in place before the hyperscale debian package is installed as part of the `internal-hyperscale` playbook.
</details>


<details open>
<summary><h2> Problem </h2></summary>

The developer working on that [change](https://github.com/delphix/hyperscale-masking/pull/1874) ran into a failure as we currently install the hyperscale package first before installing the masking package as part of `internal-hyperscale` playbook:
https://masking-jenkins.eng-tools-prd.aws.delphixcloud.com/job/appliance-build-stage1/job/pre-push/2/console
```
Unpacking delphix-hyperscale (2025.08.20.12) ...\r\nSetting up docker-compose-plugin (2.39.1-1~ubuntu.24.04~noble) ...\r\nSetting up delphix-hyperscale (2025.08.20.12) ...\r\n+ case $1 in\r\n+ docker info\r\n+ usermod -aG docker masking\r\nusermod: user 'masking' does not exist\r\ndpkg: error processing package delphix-hyperscale
```

<!--
<details>
<summary><h2> Evaluation </h2></summary>

If the cause of the problem is not obvious, provide a root-cause
analysis (RCA), ideally using the Five Whys iterative interrogative
technique or some other form of analytical reasoning.
</details>
-->

<details open>
<summary><h2> Solution </h2></summary>

Run the hyperscale-common task after masking-common task in hyperscale playbook.
</details>


<details>
<summary><h2> Testing Done </h2></summary>

Ran the hyperscale appliance build job with this `appliance-build` repo change along with the developer's `hyperscale-masking` repo change and it ran with success(barring an error while attempting to post results on a slack channel in  another downstream job):
https://masking-jenkins.eng-tools-prd.aws.delphixcloud.com/job/github/job/delphix/job/hyperscale-masking/job/build/job/appliance-build/job/pre-push/7/
Verified that the `hyperscale-common` task passed:
https://masking-jenkins.eng-tools-prd.aws.delphixcloud.com/job/appliance-build-stage1/job/pre-push/6/consoleFull
</details>

<!--
<details>
<summary><h2> Implementation </h2></summary>

Describe the implementation details of the solution. Generally the
reasoning behind any non-obvious code should be recorded in code
comments. However, code comments should always describe the current
state of the code; in contrast, this section may be useful to describe
the relationship between the original code and the code being proposed
in this pull request.
</details>
-->

<!--
<details>
<summary><h2> Notes to Reviewers </h2></summary>

Provide any extra information a reviewer may need to know before
evaluating your pull request. For example, you may wish to describe
which files should be reviewed first or which files are auto-generated.
If the review tool cannot detect a file move, you may wish to link to a
patch comparing the old file and the new file.
</details>
-->

<!--
<details>
<summary><h2> Deployment Plan </h2></summary>

Describe how the code in this pull request will be deployed. Some
deployments are complicated and may require flag days between multiple
repositories or the provisioning of new infrastructure. Describing your
deployment plan allows reviewers to ensure that your work will not cause
any unnecessary interruption to end users.
</details>
-->

<!--
<details>
<summary><h2> Future Work </h2></summary>

Provide a description of any possible follow-up work that is explicitly
not being done in this pull request.
</details>
-->

<!--
<details>
<summary><h2> Bonus </h2></summary>

Provide a description of any extra problems you have solved in this pull
request.
</details>
-->