### PR TITLE
DLPX-95320 restarting docker service doesn't need to restart mgmt service

### DIFF
--- a/upgrade/upgrade-scripts/execute
+++ b/upgrade/upgrade-scripts/execute
@@ -238,6 +238,20 @@ start_stderr_redirect_to_system_log
 fix_and_migrate_services
 
 #
+# Due to DLPX-77949, docker needs to be masked for the duration
+# of the upgrade so that it does not get restarted automatically on
+# upgrade, which would also force a restart of the delphix-mgmt
+# service (since the latter has a dependency on docker.service), and
+# thus interrupt the upgrade.
+#
+# Once the upgrade is done we restart delphix.target, which will
+# attempt to restart both delphix-mgmt and docker, so docker
+# needs to be unmasked before that point. As such, docker is
+# unmasked at the end of this script.
+#
+systemctl mask docker.service
+
+#
 # When an upgrade gets interrupted while it’s in the middle of upgrading
 # packages, the package manager can get into a state where “dpkg --configure -a”
 # needs to be manually run to enable the upgrade to be restarted.
@@ -579,6 +593,12 @@ fi
 if [[ "$(systemctl is-enabled ntpsec-rotate-stats.timer)" == enabled ]]; then
 	systemctl mask --now ntpsec-rotate-stats.timer
 fi
+
+#
+# Unmask docker, which was masked at the beginning of the upgrade due
+# to DLPX-77949.
+#
+systemctl unmask docker.service
 
 stop_stdout_redirect_to_system_log
 stop_stderr_redirect_to_system_log

--- a/upgrade/upgrade-scripts/execute
+++ b/upgrade/upgrade-scripts/execute
@@ -249,7 +249,12 @@ fix_and_migrate_services
 # needs to be unmasked before that point. As such, docker is
 # unmasked at the end of this script.
 #
-systemctl mask docker.service
+# We've removed the need to mask the docker service in 2025.6.0.0.
+#
+if [[ -n "$CURRENT_VERSION" ]] &&
+	compare_versions "$CURRENT_VERSION" "lt" "2025.6.0.0-0"; then
+	systemctl mask docker.service
+fi
 
 #
 # When an upgrade gets interrupted while it’s in the middle of upgrading
@@ -598,7 +603,12 @@ fi
 # Unmask docker, which was masked at the beginning of the upgrade due
 # to DLPX-77949.
 #
-systemctl unmask docker.service
+# We've removed the need to mask the docker service in 2025.6.0.0.
+#
+if [[ -n "$CURRENT_VERSION" ]] &&
+	compare_versions "$CURRENT_VERSION" "lt" "2025.6.0.0-0"; then
+	systemctl unmask docker.service
+fi
 
 stop_stdout_redirect_to_system_log
 stop_stderr_redirect_to_system_log

--- a/upgrade/upgrade-scripts/execute
+++ b/upgrade/upgrade-scripts/execute
@@ -238,20 +238,6 @@ start_stderr_redirect_to_system_log
 fix_and_migrate_services
 
 #
-# Due to DLPX-77949, docker needs to be masked for the duration
-# of the upgrade so that it does not get restarted automatically on
-# upgrade, which would also force a restart of the delphix-mgmt
-# service (since the latter has a dependency on docker.service), and
-# thus interrupt the upgrade.
-#
-# Once the upgrade is done we restart delphix.target, which will
-# attempt to restart both delphix-mgmt and docker, so docker
-# needs to be unmasked before that point. As such, docker is
-# unmasked at the end of this script.
-#
-systemctl mask docker.service
-
-#
 # When an upgrade gets interrupted while it’s in the middle of upgrading
 # packages, the package manager can get into a state where “dpkg --configure -a”
 # needs to be manually run to enable the upgrade to be restarted.
@@ -593,12 +579,6 @@ fi
 if [[ "$(systemctl is-enabled ntpsec-rotate-stats.timer)" == enabled ]]; then
 	systemctl mask --now ntpsec-rotate-stats.timer
 fi
-
-#
-# Unmask docker, which was masked at the beginning of the upgrade due
-# to DLPX-77949.
-#
-systemctl unmask docker.service
 
 stop_stdout_redirect_to_system_log
 stop_stderr_redirect_to_system_log


### PR DESCRIPTION
Depends on https://github.com/delphix/dlpx-app-gate/pull/3541