### PR TITLE
DLPX-95341 Can't boot OCI images if CPU count is 8+

### DIFF
--- a/live-build/config/hooks/vm-artifacts/90-raw-disk-image.binary
+++ b/live-build/config/hooks/vm-artifacts/90-raw-disk-image.binary
@@ -373,9 +373,9 @@ cp ${SB_KEYS_DIR}/*.auth "${DLPX_KEYS_DIR}"
 rm -r "${SB_KEYS_DIR}"
 
 #
-# Mount /boot/efi and do bootctl install
+# Mount /mnt/boot/efi and do bootctl install
 #
-EFI_DIR="/mnt/boot/efi"
+EFI_DIR="/boot/efi"
 chroot "$DIRECTORY" mkdir -p $EFI_DIR
 chroot "$DIRECTORY" mount /dev/mapper/${LOOPNAME}p2 $EFI_DIR
 
@@ -383,6 +383,18 @@ chroot "$DIRECTORY" mount /dev/mapper/${LOOPNAME}p2 $EFI_DIR
 chroot "$DIRECTORY" cp /boot/initrd.img $EFI_DIR
 chroot "$DIRECTORY" cp /boot/vmlinuz $EFI_DIR
 chroot "$DIRECTORY" bootctl --esp-path=$EFI_DIR install --no-variables
+
+#
+# For OCI, use GRUB as the primary boot loader. OCI has issue booting
+# with systemd-boot when VM is created with >=8 vCPUs.
+#
+if [[ "$APPLIANCE_PLATFORM" == "oci" ]]; then
+  chroot "$DIRECTORY" mount -t zfs "$FSNAME/grub" /mnt
+  chroot "$DIRECTORY" grub-install --target=x86_64-efi --efi-directory="$EFI_DIR" \
+    --root-directory=/mnt --bootloader-id=GRUB --no-nvram
+  chroot "$DIRECTORY" grub-mkconfig -o /mnt/boot/grub/grub.cfg
+  chroot "$DIRECTORY" umount /mnt
+fi
 
 # Use GRUB_CMDLINE_LINUX_DEFAULT boot options
 source $DIRECTORY/etc/default/grub.d/override.cfg

--- a/upgrade/upgrade-scripts/rootfs-container
+++ b/upgrade/upgrade-scripts/rootfs-container
@@ -133,12 +133,20 @@ function update_systemd_boot_entries() {
 	options root=ZFS=rpool/ROOT/${CONTAINER}/root ro $GRUB_CMDLINE_LINUX_DEFAULT
 	EOF
 
-	# Single user entry
+  #
+  # Single user entry
+  # Set console option, ESX and HyperV use VGA (tty0) and cloud platforms use serial (ttyS0).
+  #
+  if [[ "$APPLIANCE_PLATFORM" == "esx" || "$APPLIANCE_PLATFORM" == "hyperv" ]]; then
+    console_options="console=tty0"
+  else
+    console_options="console=ttyS0"
+  fi
 	cat <<-EOF >"${EFI_DIR}/loader/entries/delphix-single.conf"
 	title   Delphix Engine Single User mode
 	linux   /vmlinuz
 	initrd  /initrd.img
-	options root=ZFS=rpool/ROOT/${CONTAINER}/root ro single nomodeset dis_ucode_ldr
+	options root=ZFS=rpool/ROOT/${CONTAINER}/root ro single ${console_options} nomodeset dis_ucode_ldr
 	EOF
 }
 
@@ -194,14 +202,29 @@ function set_bootfs_not_mounted() {
 		cp "/var/lib/machines/${CONTAINER}/boot/initrd.img" "$EFI_DIR"
 		cp "/var/lib/machines/${CONTAINER}/boot/vmlinuz" "$EFI_DIR"
 		chroot "/var/lib/machines/$CONTAINER" bootctl --esp-path="$EFI_DIR" update
+
+    # Update GRUB boot loader and config
+    if [[ -f "$EFI_DIR/EFI/GRUB/grubx64.efi" ]]; then
+      opts="--root-directory=/mnt --bootloader-id=GRUB --no-nvram"
+      if [[ "$PLATFORM" == "oci" ]]; then
+        opts+=" --debug-image=all -v"
+      fi
+      # shellcheck disable=SC2086
+      chroot "/var/lib/machines/$CONTAINER" \
+        grub-install --target=x86_64-efi --efi-directory="$EFI_DIR" $opts ||
+        die "'grub-install' for '$EFI_DIR' failed in '$CONTAINER'"
+
+      chroot "/var/lib/machines/$CONTAINER" \
+        grub-mkconfig -o /mnt/boot/grub/grub.cfg ||
+        die "'grub-mkconfig' failed in '$CONTAINER'"
+    fi
 		umount "$EFI_DIR"
 	else
 		for dev in $(get_bootloader_devices); do
 			opts="--root-directory=/mnt"
 
 			if [[ "$PLATFORM" == "esx" ]] || [[ "$PLATFORM" == "oci" ]]; then
-				opts+=" --debug-image=all"
-				opts+=" -v"
+				opts+=" --debug-image=all -v"
 			fi
 
 			# shellcheck disable=SC2086
@@ -261,6 +284,20 @@ function set_bootfs_mounted() {
 		cp /boot/initrd.img "$EFI_DIR"
 		cp /boot/vmlinuz "$EFI_DIR"
 		bootctl --esp-path="$EFI_DIR" update
+
+    # Update GRUB boot loader and config
+    if [[ -f "$EFI_DIR/EFI/GRUB/grubx64.efi" ]]; then
+      opts="--root-directory=/mnt --bootloader-id=GRUB --no-nvram"
+      if [[ "$PLATFORM" == "oci" ]]; then
+        opts+=" --debug-image=all -v"
+      fi
+      # shellcheck disable=SC2086
+      grub-install --target=x86_64-efi --efi-directory="$EFI_DIR" $opts ||
+        die "'grub-install' for '$EFI_DIR' failed in '$CONTAINER'"
+
+      grub-mkconfig -o /mnt/boot/grub/grub.cfg ||
+      die "'grub-mkconfig' failed in '$CONTAINER'"
+    fi
 		umount "$EFI_DIR"
 	else
 		for dev in $(get_bootloader_devices); do


### PR DESCRIPTION
<!--
<details open>
<summary><h2> Background </h2></summary>

Provide a clear description of the high-level effort with which this
pull request is associated. Recall that while anyone in the organization
can see this pull request, not everyone necessarily has the same context
as you. If applicable, link to design documents or high-level tracking
epics here.
</details>
-->

<details open>
<summary><h2> Problem </h2></summary>

On OCI, VM images with `systemd-boot` can't boot properly when a VM is created with 8 or more OCPUs. The reported error is "?Error loading \vmlinuz: Not found" which is weird because the file is present in the EFI partition.

</details>

<!--
<details>
<summary><h2> Evaluation </h2></summary>

If the cause of the problem is not obvious, provide a root-cause
analysis (RCA), ideally using the Five Whys iterative interrogative
technique or some other form of analytical reasoning.
</details>
-->

<details open>
<summary><h2> Solution </h2></summary>

I noticed OCI Ubuntu images use GRUB and don't have this issue.

So the approach here is to install `GRUB` as the primary boot loader for OCI images so our OCI images can function properly for all machine sizes. `systemd-boot` is still on the image but will not be active.

In the future, we can remove GRUB if/when systemd-boot works correctly with higher CPU count. Another solution could be to unify and use only GRUB if we don't see the GRUB corruption issue with EFI GRUB. 
</details>


<details open>
<summary><h2> Testing Done </h2></summary>

Confirmed
1) OCI VM with 9 CPUs boot successfully and
2) upgrading 2025.6 AWS VM (systemd-boot) to new code works as expected.

</details>

<!--
<details>
<summary><h2> Implementation </h2></summary>

Describe the implementation details of the solution. Generally the
reasoning behind any non-obvious code should be recorded in code
comments. However, code comments should always describe the current
state of the code; in contrast, this section may be useful to describe
the relationship between the original code and the code being proposed
in this pull request.
</details>
-->

<!--
<details>
<summary><h2> Notes to Reviewers </h2></summary>

Provide any extra information a reviewer may need to know before
evaluating your pull request. For example, you may wish to describe
which files should be reviewed first or which files are auto-generated.
If the review tool cannot detect a file move, you may wish to link to a
patch comparing the old file and the new file.
</details>
-->

<!--
<details>
<summary><h2> Deployment Plan </h2></summary>

Describe how the code in this pull request will be deployed. Some
deployments are complicated and may require flag days between multiple
repositories or the provisioning of new infrastructure. Describing your
deployment plan allows reviewers to ensure that your work will not cause
any unnecessary interruption to end users.
</details>
-->

<!--
<details>
<summary><h2> Future Work </h2></summary>

Provide a description of any possible follow-up work that is explicitly
not being done in this pull request.
</details>
-->

<!--
<details>
<summary><h2> Bonus </h2></summary>

Provide a description of any extra problems you have solved in this pull
request.
</details>
-->
