### PR TITLE
DLPX-95321 Last pkg version of python3-rtslib-fb breaks upgrade due to failing to restart rtslib-fb-targetctl.service

### DIFF
--- a/upgrade/upgrade-scripts/execute
+++ b/upgrade/upgrade-scripts/execute
@@ -238,6 +238,20 @@ start_stderr_redirect_to_system_log
 fix_and_migrate_services
 
 #
+# Due to DLPX-77949, docker needs to be masked for the duration
+# of the upgrade so that it does not get restarted automatically on
+# upgrade, which would also force a restart of the delphix-mgmt
+# service (since the latter has a dependency on docker.service), and
+# thus interrupt the upgrade.
+#
+# Once the upgrade is done we restart delphix.target, which will
+# attempt to restart both delphix-mgmt and docker, so docker
+# needs to be unmasked before that point. As such, docker is
+# unmasked at the end of this script.
+#
+systemctl mask docker.service
+
+#
 # When an upgrade gets interrupted while it’s in the middle of upgrading
 # packages, the package manager can get into a state where “dpkg --configure -a”
 # needs to be manually run to enable the upgrade to be restarted.
@@ -579,6 +593,12 @@ fi
 if [[ "$(systemctl is-enabled ntpsec-rotate-stats.timer)" == enabled ]]; then
 	systemctl mask --now ntpsec-rotate-stats.timer
 fi
+
+#
+# Unmask docker, which was masked at the beginning of the upgrade due
+# to DLPX-77949.
+#
+systemctl unmask docker.service
 
 stop_stdout_redirect_to_system_log
 stop_stderr_redirect_to_system_log

--- a/upgrade/upgrade-scripts/execute
+++ b/upgrade/upgrade-scripts/execute
@@ -238,18 +238,24 @@ start_stderr_redirect_to_system_log
 fix_and_migrate_services
 
 #
-# Due to DLPX-77949, docker needs to be masked for the duration
-# of the upgrade so that it does not get restarted automatically on
-# upgrade, which would also force a restart of the delphix-mgmt
-# service (since the latter has a dependency on docker.service), and
-# thus interrupt the upgrade.
+# Starting in 2025.6.0.0, the virtualization service no longer "requires" the
+# docker service, so we no longer need to mask the docker service.
 #
-# Once the upgrade is done we restart delphix.target, which will
-# attempt to restart both delphix-mgmt and docker, so docker
-# needs to be unmasked before that point. As such, docker is
-# unmasked at the end of this script.
-#
-systemctl mask docker.service
+if compare_versions "$CURRENT_VERSION" lt "2025.6.0.0-0"; then
+	#
+	# Due to DLPX-77949, docker needs to be masked for the duration
+	# of the upgrade so that it does not get restarted automatically on
+	# upgrade, which would also force a restart of the delphix-mgmt
+	# service (since the latter has a dependency on docker.service), and
+	# thus interrupt the upgrade.
+	#
+	# Once the upgrade is done we restart delphix.target, which will
+	# attempt to restart both delphix-mgmt and docker, so docker
+	# needs to be unmasked before that point. As such, docker is
+	# unmasked at the end of this script.
+	#
+	systemctl mask docker.service
+fi
 
 #
 # When an upgrade gets interrupted while it’s in the middle of upgrading
@@ -594,11 +600,13 @@ if [[ "$(systemctl is-enabled ntpsec-rotate-stats.timer)" == enabled ]]; then
 	systemctl mask --now ntpsec-rotate-stats.timer
 fi
 
-#
-# Unmask docker, which was masked at the beginning of the upgrade due
-# to DLPX-77949.
-#
-systemctl unmask docker.service
+if compare_versions "$CURRENT_VERSION" lt "2025.6.0.0-0"; then
+	#
+	# Unmask docker, which was masked at the beginning of the upgrade due
+	# to DLPX-77949.
+	#
+	systemctl unmask docker.service
+fi
 
 stop_stdout_redirect_to_system_log
 stop_stderr_redirect_to_system_log

--- a/upgrade/upgrade-scripts/execute
+++ b/upgrade/upgrade-scripts/execute
@@ -238,20 +238,6 @@ start_stderr_redirect_to_system_log
 fix_and_migrate_services
 
 #
-# Due to DLPX-77949, docker needs to be masked for the duration
-# of the upgrade so that it does not get restarted automatically on
-# upgrade, which would also force a restart of the delphix-mgmt
-# service (since the latter has a dependency on docker.service), and
-# thus interrupt the upgrade.
-#
-# Once the upgrade is done we restart delphix.target, which will
-# attempt to restart both delphix-mgmt and docker, so docker
-# needs to be unmasked before that point. As such, docker is
-# unmasked at the end of this script.
-#
-systemctl mask docker.service
-
-#
 # When an upgrade gets interrupted while it’s in the middle of upgrading
 # packages, the package manager can get into a state where “dpkg --configure -a”
 # needs to be manually run to enable the upgrade to be restarted.
@@ -593,12 +579,6 @@ fi
 if [[ "$(systemctl is-enabled ntpsec-rotate-stats.timer)" == enabled ]]; then
 	systemctl mask --now ntpsec-rotate-stats.timer
 fi
-
-#
-# Unmask docker, which was masked at the beginning of the upgrade due
-# to DLPX-77949.
-#
-systemctl unmask docker.service
 
 stop_stdout_redirect_to_system_log
 stop_stderr_redirect_to_system_log


### PR DESCRIPTION
<details open>
<summary><h2> Problem </h2></summary>
Since landing the fix for DLPX-95320 via https://www.github.com/delphix/dlpx-app-gate/pull/3541, we no longer need to mask the docker service during upgrade.
</details>

<details open>
<summary><h2> Solution </h2></summary>
This PR removes the logic that would mask/unmask the docker service, on versions that include the fix referenced above.
</details>

<details open>
<summary><h2> Testing </h2></summary>

I've done the following upgrades:

- develop to this change; verified upgrade completed successfully and no mask of the docker service occured.
- 2025.1 to this change; verified upgrade completed successfully, and the docker service was still masked/unmasked.

I didn't verify the docker service was restarted during the package upgrades, which is why the mask/unmask was added to begin with.. but I did verify restarting the docker service outside of the upgrade context (on a develop system running with https://github.com/delphix/dlpx-app-gate/pull/3541), does not restart the virtualization service (implying it should work the same during upgrade context, and we don't need to mask/unmask anymore).

</details>