### PR TITLE
HM-4133 [appliance-build] Add initial external-hyperscale variant

### DIFF
--- a/live-build/variants/external-hyperscale/ansible/playbook.yml
+++ b/live-build/variants/external-hyperscale/ansible/playbook.yml
@@ -1,0 +1,34 @@
+#
+# Copyright 2025 Delphix
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+---
+- name: Configure Appliance for Hyperscale Compliance
+  hosts: all
+  gather_facts: false
+  vars:
+    ansible_python_interpreter: /usr/bin/python3
+  roles:
+    - appliance-build.minimal-common
+    - appliance-build.masking-common
+    - appliance-build.virtualization-common
+    #
+    # The hyperscale-common role requires the appliance configuration,
+    # essentially the 'masking' user creation, done by the masking-common
+    # role to be in place before the hyperscale-common role is applied.
+    # Thus, we need to ensure the hyperscale-common role is applied after
+    # the masking-common role.
+    #
+    - appliance-build.hyperscale-common

--- a/live-build/variants/external-hyperscale/ansible/roles
+++ b/live-build/variants/external-hyperscale/ansible/roles
@@ -1,0 +1,1 @@
+../../../misc/ansible-roles


### PR DESCRIPTION
<!--
<details open>
<summary><h2> Background </h2></summary>

Provide a clear description of the high-level effort with which this
pull request is associated. Recall that while anyone in the organization
can see this pull request, not everyone necessarily has the same context
as you. If applicable, link to design documents or high-level tracking
epics here.
</details>
-->

<details open>
<summary><h2> Problem </h2></summary>

We need to create the 'external' variants of the hyperscale compliance appliance image in the dcenters. Currently, we do not have the ansible playbook defined to create the external variant.
</details>

<!--
<details>
<summary><h2> Evaluation </h2></summary>

If the cause of the problem is not obvious, provide a root-cause
analysis (RCA), ideally using the Five Whys iterative interrogative
technique or some other form of analytical reasoning.
</details>
-->

<details open>
<summary><h2> Solution </h2></summary>

Add an ansible playbook, similar to the [`external-dct`](https://github.com/delphix/appliance-build/blob/develop/live-build/variants/external-dct/ansible/playbook.yml) and [`external-standard`](https://github.com/delphix/appliance-build/blob/develop/live-build/variants/external-standard/ansible/playbook.yml) ones, to be able to create the 'external' variants for the hyperscale compliance appliance image. 
</details>


<details>
<summary><h2> Testing Done </h2></summary>

Ran the hyperscale pre-push appliance build using the appliance-build branch from this PR and verified that the external variant was built successfully:
https://masking-jenkins.eng-tools-prd.aws.delphixcloud.com/job/appliance-build-stage1/job/pre-push/64/consoleFull
```
13:46:51  + sudo -E ./gradlew buildExternalHyperscaleAws
13:46:54  Downloading https://artifactory.delphix.com/artifactory/gradle-distributions/gradle-5.1-bin.zip
13:47:09  .................................................................................
13:47:11  
13:47:11  Welcome to Gradle 5.1!
13:47:11  
13:47:11  Here are the highlights of this release:
13:47:11   - Control which dependencies can be retrieved from which repositories
13:47:11   - Production-ready configuration avoidance APIs
13:47:11  
13:47:11  For more details see https://docs.gradle.org/5.1/release-notes.html
13:47:11  
13:47:11  To honour the JVM settings for this build a new JVM will be forked. Please consider using the daemon: https://docs.gradle.org/5.1/userguide/gradle_daemon.html.
13:47:12  Daemon will be stopped at the end of the build stopping after processing
13:47:19  
13:47:19  > Task :live-build:ancillaryRepository
13:47:19  + set -o errexit
13:47:19  + set -o pipefail
....
....
14:46:09  
14:46:09  BUILD SUCCESSFUL in 59m 11s
14:46:09  3 actionable tasks: 3 executed
14:46:09  [Pipeline] }
14:46:09  [Pipeline] // dir
14:46:09  [Pipeline] }
14:46:09  [Pipeline] // withCredentials
14:46:09  [Pipeline] }
14:46:10  [Pipeline] // stage
14:46:10  [Pipeline] stage
14:46:10  [Pipeline] { (Publish)
14:46:10  [Pipeline] pwd
14:46:10  [Pipeline] sh
14:46:11  + mktemp /export/home/delphix/jenkins/workspace/appliance-build-stage1/pre-push@tmp/SHA256SUMS.XXXXXXXXXX
14:46:12  [Pipeline] sh
14:46:12  + mktemp /export/home/delphix/jenkins/workspace/appliance-build-stage1/pre-push@tmp/MD5SUMS.XXXXXXXXXX
14:46:13  [Pipeline] dir
14:46:13  Running in /export/home/delphix/jenkins/workspace/appliance-build-stage1/pre-push/appliance-build/live-build/build/artifacts
14:46:13  [Pipeline] {
14:46:13  [Pipeline] withCredentials
14:46:13  Masking supported pattern matches of $AWS_ACCESS_KEY_ID or $AWS_SECRET_ACCESS_KEY
14:46:13  [Pipeline] {
14:46:13  [Pipeline] sh
14:46:14  + xargs -0 sha256sum
14:46:14  + find external-hyperscale-aws.debs.tar.gz external-hyperscale-aws.packages.list external-hyperscale-aws.vmdk -type f -print0
14:48:35  [Pipeline] sh
14:48:36  + xargs -0 md5sum
14:48:36  + find external-hyperscale-aws.debs.tar.gz external-hyperscale-aws.packages.list external-hyperscale-aws.vmdk -type f -print0
14:50:58  [Pipeline] sh
14:50:59  + mv /export/home/delphix/jenkins/workspace/appliance-build-stage1/pre-push@tmp/SHA256SUMS.dxWybn7zfg SHA256SUMS
14:50:59  [Pipeline] sh
14:51:00  + mv /export/home/delphix/jenkins/workspace/appliance-build-stage1/pre-push@tmp/MD5SUMS.3Wyg32dlPb MD5SUMS
14:51:00  [Pipeline] archiveArtifacts
14:51:00  Archiving artifacts
14:51:03  [Pipeline] archiveArtifacts
14:51:04  Archiving artifacts
14:51:04  [Pipeline] sh
14:51:05  + aws s3 sync --delete --only-show-errors --exclude '*.tar.gz' . s3://dev-de-images/builds/jenkins-masking/appliance-build/develop/pre-push/66/external-hyperscale-aws/
14:52:27  [Pipeline] sh
14:52:27  + aws s3 sync --delete --only-show-errors --exclude '*' --include '*.tar.gz' --content-type application/x-gzip . s3://dev-de-images/builds/jenkins-masking/appliance-build/develop/pre-push/66/external-hyperscale-aws/
``` 
However, the appliance snapshot failed because currently the pre-push job only looks to import internal variants and not external ones:
https://masking-jenkins.eng-tools-prd.aws.delphixcloud.com/job/delphix-build-and-snapshots/job/ami-snapshots/227/console
```
15:30:29  + aws s3 cp --only-show-errors s3://dev-de-images/builds/jenkins-masking/appliance-build/develop/pre-push/66/internal-hyperscale-aws/internal-hyperscale-aws.vmdk /scratch/image--227.img
15:30:30  fatal error: An error occurred (404) when calling the HeadObject operation: Key "builds/jenkins-masking/appliance-build/develop/pre-push/66/internal-hyperscale-aws/internal-hyperscale-aws.vmdk" does not exist
15:30:31  [Pipeline] sh
15:30:32  + rm -f /scratch/image--227.img

```
We'll be adding nightly jobs to build internal and external images as part of https://perforce.atlassian.net/browse/HM-4555.
</details>

<!--
<details>
<summary><h2> Implementation </h2></summary>

Describe the implementation details of the solution. Generally the
reasoning behind any non-obvious code should be recorded in code
comments. However, code comments should always describe the current
state of the code; in contrast, this section may be useful to describe
the relationship between the original code and the code being proposed
in this pull request.
</details>
-->

<!--
<details>
<summary><h2> Notes to Reviewers </h2></summary>

Provide any extra information a reviewer may need to know before
evaluating your pull request. For example, you may wish to describe
which files should be reviewed first or which files are auto-generated.
If the review tool cannot detect a file move, you may wish to link to a
patch comparing the old file and the new file.
</details>
-->

<!--
<details>
<summary><h2> Deployment Plan </h2></summary>

Describe how the code in this pull request will be deployed. Some
deployments are complicated and may require flag days between multiple
repositories or the provisioning of new infrastructure. Describing your
deployment plan allows reviewers to ensure that your work will not cause
any unnecessary interruption to end users.
</details>
-->

<!--
<details>
<summary><h2> Future Work </h2></summary>

Provide a description of any possible follow-up work that is explicitly
not being done in this pull request.
</details>
-->

<!--
<details>
<summary><h2> Bonus </h2></summary>

Provide a description of any extra problems you have solved in this pull
request.
</details>
-->