### PR TITLE
DLPX-95854 Single-user mode has incorrect console setting for ESX and HyperV

### DIFF
--- a/live-build/config/hooks/vm-artifacts/90-raw-disk-image.binary
+++ b/live-build/config/hooks/vm-artifacts/90-raw-disk-image.binary
@@ -393,8 +393,16 @@ initrd  /initrd.img
 options root=ZFS=rpool/ROOT/${FSNAME}/root ro $GRUB_CMDLINE_LINUX_DEFAULT
 EOF
 
-# Single user mode. Need the console options from GRUB
-console_options=$(awk -F'"' '/console=tty/ {print $2}' $DIRECTORY/etc/default/grub.d/override.cfg)
+#
+# Single user boot entry.
+#
+# ESX and HyperV use VGA (tty0) and cloud platforms use serial (ttyS0).
+#
+if [[ "$APPLIANCE_PLATFORM" == "esx" || "$APPLIANCE_PLATFORM" == "hyperv" ]]; then
+	console_options="console=tty0"
+else
+	console_options="console=ttyS0"
+fi
 cat <<-EOF >"${DIRECTORY}/${EFI_DIR}/loader/entries/delphix-single.conf"
 title   Delphix Engine Single User mode
 linux   /vmlinuz


### PR DESCRIPTION
<!--
<details open>
<summary><h2> Background </h2></summary>

Provide a clear description of the high-level effort with which this
pull request is associated. Recall that while anyone in the organization
can see this pull request, not everyone necessarily has the same context
as you. If applicable, link to design documents or high-level tracking
epics here.
</details>
-->

<details open>
<summary><h2> Problem </h2></summary>

On ESX and HyperV, booting into single-user doesn't seem to work, there's nothing on the graphical console (tty0). This is due to the console options ins the boot option line:
```
options root=ZFS=rpool/ROOT/delphix.Lrzt8cw/root ro single console=tty0 console=ttyS0 nomodeset dis_ucode_ldr
```

In single user mode (rescue.target), `systemd` does not start multiple getty services — only one root shell attached to `/dev/console` which points to the last console option which is `ttyS0`. Thus the graphical console appears stuck (blank) even though the shell is running fine on the serial port. Note that clouds like AWS/OCI VMs don't have this problem since their console is the serial console.

The console options order is not an issue with normal multi-user boot, initramfs and systemd duplicate logs to both `/dev/console` and `/dev/tty0`.

</details>

<!--
<details>
<summary><h2> Evaluation </h2></summary>

If the cause of the problem is not obvious, provide a root-cause
analysis (RCA), ideally using the Five Whys iterative interrogative
technique or some other form of analytical reasoning.
</details>
-->

<details open>
<summary><h2> Solution </h2></summary>

Update the boot options to use VGA (tty0) for ESX and HyperV and serial (ttyS0) for other platforms.

</details>


<details open>
<summary><h2> Testing Done </h2></summary>

Built new appliances and tested that single-user booting works as expected.

ESX - Done
AWS - Done
OCI - Done
GCP - Done
HyperV - Done
On-prem KVM - Serial port console works.

</details>

<!--
<details>
<summary><h2> Implementation </h2></summary>

Describe the implementation details of the solution. Generally the
reasoning behind any non-obvious code should be recorded in code
comments. However, code comments should always describe the current
state of the code; in contrast, this section may be useful to describe
the relationship between the original code and the code being proposed
in this pull request.
</details>
-->

<!--
<details>
<summary><h2> Notes to Reviewers </h2></summary>

Provide any extra information a reviewer may need to know before
evaluating your pull request. For example, you may wish to describe
which files should be reviewed first or which files are auto-generated.
If the review tool cannot detect a file move, you may wish to link to a
patch comparing the old file and the new file.
</details>
-->

<!--
<details>
<summary><h2> Deployment Plan </h2></summary>

Describe how the code in this pull request will be deployed. Some
deployments are complicated and may require flag days between multiple
repositories or the provisioning of new infrastructure. Describing your
deployment plan allows reviewers to ensure that your work will not cause
any unnecessary interruption to end users.
</details>
-->

<!--
<details>
<summary><h2> Future Work </h2></summary>

Provide a description of any possible follow-up work that is explicitly
not being done in this pull request.
</details>
-->

<!--
<details>
<summary><h2> Bonus </h2></summary>

Provide a description of any extra problems you have solved in this pull
request.
</details>
-->
