### PR TITLE
APIGW-15589 Upgrade verify severes DCT containers external network connectivity

### DIFF
--- a/upgrade/upgrade-scripts/upgrade-container
+++ b/upgrade/upgrade-scripts/upgrade-container
@@ -483,7 +483,7 @@ function stop() {
 	#
 	# Starting the upgrade container would have enabled ip forwarding
 	# on the host (and in turn disabled LRO). Reset these settings
-	# on a best effor basis, unless this is a DCT or hyperscale
+	# on a best effort basis, unless this is a DCT or hyperscale
 	# appliance which require net.ipv4.ip_forward to be enabled
 	# so that docker containers can have network access.
 	#

--- a/upgrade/upgrade-scripts/upgrade-container
+++ b/upgrade/upgrade-scripts/upgrade-container
@@ -489,7 +489,7 @@ function stop() {
 	#
 	if ! needs_ip_forwarding; then
 		sysctl -w net.ipv4.ip_forward=0 ||
-		    warn "failed to disable ip port forwarding"
+		    warn "failed to disable ip forwarding"
 	fi
 
 	#

--- a/upgrade/upgrade-scripts/upgrade-container
+++ b/upgrade/upgrade-scripts/upgrade-container
@@ -484,7 +484,7 @@ function stop() {
 	# Starting the upgrade container would have enabled ip forwarding
 	# on the host (and in turn disabled LRO). Reset these settings
 	# on a best effor basis, unless this is a DCT or hyperscale
-	# appliance which required net.ipv4.ip_forward to be enabled
+	# appliance which require net.ipv4.ip_forward to be enabled
 	# so that docker containers can have network access.
 	#
 	if ! needs_ip_forwarding; then

--- a/upgrade/upgrade-scripts/upgrade-container
+++ b/upgrade/upgrade-scripts/upgrade-container
@@ -453,6 +453,13 @@ function start() {
 		die "'default.target' inactive in container '$CONTAINER'"
 }
 
+function needs_ip_forwarding() {
+	platform=$(get-appliance-variant)
+	[[ "$platform" =~ "dct" ]] && return 0
+	[[ "$platform" =~ "hyperscale" ]] && return 0
+	return 1
+}
+
 function stop() {
 	systemctl restart systemd-reexec.service 2>/dev/null
 	machinectl terminate "$CONTAINER" ||
@@ -476,9 +483,14 @@ function stop() {
 	#
 	# Starting the upgrade container would have enabled ip forwarding
 	# on the host (and in turn disabled LRO). Reset these settings
-	# on a best effor basis.
+	# on a best effor basis, unless this is a DCT or hyperscale
+	# appliance which required net.ipv4.ip_forward to be enabled
+	# so that docker containers can have network access.
 	#
-	sysctl -w net.ipv4.ip_forward=0 || warn "failed to disable ip port forwarding"
+	if ! needs_ip_forwarding; then
+		sysctl -w net.ipv4.ip_forward=0 ||
+		    warn "failed to disable ip port forwarding"
+	fi
 
 	#
 	# Find all the interfaces configured on the host and set


### PR DESCRIPTION
<!--
<details open>
<summary><h2> Background </h2></summary>

Provide a clear description of the high-level effort with which this
pull request is associated. Recall that while anyone in the organization
can see this pull request, not everyone necessarily has the same context
as you. If applicable, link to design documents or high-level tracking
epics here.
</details>
-->

<details open>
<summary><h2> Problem </h2></summary>

Upgrade verify unconditionally executes `sysctl -w net.ipv4.ip_forward=0` when terminating the upgrade container. While this is desired for Delphix engines has IP forwarding has a negative performance impact, DCT and hyperscale appliances require IP forwarding so that their docker containers have access to the external network.

</details>

<details open>
<summary><h2> Solution </h2></summary>

While a more advanced solution might be to remember the value of the setting earlier in the upgrade process, eliminating the need to hard coded specific variants in the upgrade script, we are implementing a simpler solution which checks the appliance variant and does not touch the IP forwarding setting for DCT and hyperscale appliances.
</details>


<details>
<summary><h2> Testing Done </h2></summary>
Built an upgrade image with https://regression-jenkins.eng-tools-prd.aws.delphixcloud.com/job/appliance-build/job/develop/job/pre-push/3576/console,

Ran upgrade verify with that upgrade image on a DCT appliance
```
ip-10-110-223-73 job 'JOB-2'> get
    type: Job
    name: (unset)
    actionType: UPGRADE_VERIFY
    cancelable: true
    emailAddresses: (unset)
    events: [ ... ]
    jobState: COMPLETED
    parentAction: ACTION-15
    parentActionState: COMPLETED
    percentComplete: 100%
    queued: false
    reference: JOB-2
    startTime: 2026-02-06T14:05:11.619Z
    suspendable: false
    target: 2026.2.0.0-snapshot.20260206095206493+jenkins-regression-appliance-build-develop-pre-push-3576
    targetName: 2026.2.0.0-snapshot.20260206095206493+jenkins-regression-appliance-build-develop-pre-push-3576
    targetObjectType: SystemVersion
    title: Verify version "2026.2.0.0-snapshot.20260206095206493+jenkins-regression-appliance-build-develop-pre-push-3576" without upgrading.
    updateTime: 2026-02-06T14:17:48.271Z
    user: sysadmin
```
and verified `net.ipv4.ip_forward` is still enabled
```
delphix@ip-10-110-223-73:~$ sysctl  net.ipv4.ip_forward
net.ipv4.ip_forward = 1
```

Then repeated on a standard Delphix engine (Note that I have not seen the ip_forward value be set, so can't tell for sure it was unset when the uprade verify container was stopped)
```
ip-10-110-249-40 job 'JOB-2'> get
    type: Job
    name: (unset)
    actionType: UPGRADE_VERIFY
    cancelable: true
    emailAddresses: (unset)
    events: [ ... ]
    jobState: COMPLETED
    parentAction: ACTION-16
    parentActionState: COMPLETED
    percentComplete: 100%
    queued: false
    reference: JOB-2
    startTime: 2026-02-06T15:29:46.366Z
    suspendable: false
    target: 2026.2.0.0-snapshot.20260206095729316+jenkins-selfservice-appliance-build-develop-pre-push-5906
    targetName: 2026.2.0.0-snapshot.20260206095729316+jenkins-selfservice-appliance-build-develop-pre-push-5906
    targetObjectType: SystemVersion
    title: Verify version "2026.2.0.0-snapshot.20260206095729316+jenkins-selfservice-appliance-build-develop-pre-push-5906" without upgrading.
    updateTime: 2026-02-06T15:34:03.104Z
    user: sysadmin
ip-10-110-249-40 job 'JOB-2'> exit
delphix@ip-10-110-249-40:/tmp$ sysctl  net.ipv4.ip_forward
net.ipv4.ip_forward = 0
```
</details>

<!--
<details>
<summary><h2> Implementation </h2></summary>

Describe the implementation details of the solution. Generally the
reasoning behind any non-obvious code should be recorded in code
comments. However, code comments should always describe the current
state of the code; in contrast, this section may be useful to describe
the relationship between the original code and the code being proposed
in this pull request.
</details>
-->

<!--
<details>
<summary><h2> Notes to Reviewers </h2></summary>

Provide any extra information a reviewer may need to know before
evaluating your pull request. For example, you may wish to describe
which files should be reviewed first or which files are auto-generated.
If the review tool cannot detect a file move, you may wish to link to a
patch comparing the old file and the new file.
</details>
-->

<!--
<details>
<summary><h2> Deployment Plan </h2></summary>

Describe how the code in this pull request will be deployed. Some
deployments are complicated and may require flag days between multiple
repositories or the provisioning of new infrastructure. Describing your
deployment plan allows reviewers to ensure that your work will not cause
any unnecessary interruption to end users.
</details>
-->

<!--
<details>
<summary><h2> Future Work </h2></summary>

Provide a description of any possible follow-up work that is explicitly
not being done in this pull request.
</details>
-->

<!--
<details>
<summary><h2> Bonus </h2></summary>

Provide a description of any extra problems you have solved in this pull
request.
</details>
-->
