### PR TITLE
DLPX-96942 Replace ntpsec with chrony (appliance-build changes)

### DIFF
--- a/live-build/misc/ansible-roles/appliance-build.dcenter/tasks/main.yml
+++ b/live-build/misc/ansible-roles/appliance-build.dcenter/tasks/main.yml
@@ -86,5 +86,5 @@
 #
 - name: Enable NTP systemd service
   ansible.builtin.systemd_service:
-    name: ntpsec.service
+    name: chrony.service
     enabled: true

--- a/live-build/misc/ansible-roles/appliance-build.virtualization-common/tasks/main.yml
+++ b/live-build/misc/ansible-roles/appliance-build.virtualization-common/tasks/main.yml
@@ -80,8 +80,7 @@
   with_items:
     - delphix-fluentd.service
     - delphix-masking.service
-    - ntpsec.service
-    - ntpsec-rotate-stats.timer
+    - chrony.service
     - snmpd.service
 
 #

--- a/upgrade/upgrade-scripts/common.sh
+++ b/upgrade/upgrade-scripts/common.sh
@@ -514,13 +514,12 @@ function fix_and_migrate_services() {
 		should_mask_service "$svc" &&
 			mask_service "$svc" "$container"
 	done <<-EOF
+		chrony.service
 		delphix-fluentd.service
 		delphix-masking.service
 		fluentd.service
 		nfs-mountd.service
 		nginx.service
-		ntpsec.service
-		ntpsec-rotate-stats.timer
 		postgresql.service
 		rpc-statd.service
 		rpcbind.service

--- a/upgrade/upgrade-scripts/execute
+++ b/upgrade/upgrade-scripts/execute
@@ -439,43 +439,50 @@ zcat "/usr/share/doc/delphix-entire-$opt_p/packages.list.gz" |
 	cut -d= -f1 | xargs apt-mark manual ||
 	die "failed to mark as manual packages listed in packages.list.gz file"
 
-if [[ -f "/etc/ntp.conf" ]]; then
-	NTP_CONF_MD5SUM_ORIGINAL=$(dpkg --status ntp | grep /etc/ntp.conf | awk '{ print $2 }')
-	NTP_CONF_MD5SUM_ACTUAL=$(md5sum /etc/ntp.conf | awk '{ print $1 }')
+#
+# Migrate any active NTP configuration to chrony. We handle two cases:
+#   1. ntpsec was the active NTP service (most recent prior implementation)
+#   2. The legacy ntp package was the active NTP service (older engines
+#      that never received the ntpsec migration)
+#
+# In both cases, pool entries are preserved as-is and multicastclient
+# entries are converted to their chrony equivalent (server ... iburst).
+# ntpsec-specific restrict directives are dropped since chrony does not
+# use them.
+#
+NTP_CONF_SOURCE=""
 
+if [[ "$(systemctl is-enabled ntpsec.service 2>/dev/null)" == "enabled" ]]; then
+	NTP_CONF_SOURCE="/etc/ntpsec/ntp.conf"
+elif [[ "$(systemctl is-enabled ntp.service 2>/dev/null)" == "enabled" ]]; then
+	NTP_CONF_SOURCE="/etc/ntp.conf"
 	#
-	# As part of the LTS upgrade project to 24.04, `ntp` was replaced by `ntpsec`.
+	# On removal, the ntp package masks ntp.service. Purge it now so
+	# that masked state does not linger for the rest of the upgrade.
 	#
-	# To preserve and migrate the NTP configuration, we need to copy the
-	# NTP configuration file to the new location after packages are upgraded,
-	# but before they are removed so that NTP continues to function as expected.
-	#
-	# We only do this if the configuration no longer matches what's installed by
-	# default, as that indicates NTP was configured and enabled on the appliance.
-	#
-	if [[ "$NTP_CONF_MD5SUM_ORIGINAL" != "$NTP_CONF_MD5SUM_ACTUAL" ]]; then
-		cp /etc/ntp.conf /etc/ntpsec/ntp.conf ||
-			die "failed to copy /etc/ntp.conf to /etc/ntpsec/ntp.conf"
+	apt_get purge -y ntp || die "failed to purge ntp package"
+fi
 
-		#
-		# On removal, the "ntp" package will mask the "ntp" service. As
-		# a result, enable of the "ntpsec" service will fail, due to it
-		# having an alias to the "ntp" service name, and that service
-		# being masked.
-		#
-		# As a workaround, we explicitly "purge" the "ntp" package,
-		# which will remove the masked "ntp" service, so that it
-		# doesn't impact the enable of "netpsec".
-		#
-		# This doesn't impact the end state of the system, as the ntp
-		# package would have been purged later in this script; but we
-		# need to do it here, prior to attempting to enable "ntpsec".
-		#
-		apt_get purge -y ntp || die "failed to purge ntp package"
+if [[ -n "$NTP_CONF_SOURCE" ]]; then
+	CHRONY_CONF="/etc/chrony/chrony.conf"
+	CHRONY_DRIFT_FILE="/var/lib/chrony/chrony.drift"
 
-		systemctl unmask ntpsec.service || die "failed to unmask ntpsec.service"
-		systemctl enable ntpsec.service || die "failed to enable ntpsec.service"
+	if [[ -f "$CHRONY_CONF" ]]; then
+		cp "$CHRONY_CONF" "${CHRONY_CONF}.bak" ||
+			die "failed to back up $CHRONY_CONF"
 	fi
+
+	{
+		grep "^pool " "$NTP_CONF_SOURCE" || true
+		grep "^multicastclient " "$NTP_CONF_SOURCE" |
+			sed 's/^multicastclient \(.*\)/server \1 iburst/' || true
+		echo "driftfile $CHRONY_DRIFT_FILE"
+		echo "makestep 1.0 3"
+		echo "rtcsync"
+	} >"$CHRONY_CONF" || die "failed to write $CHRONY_CONF"
+
+	systemctl unmask chrony.service || die "failed to unmask chrony.service"
+	systemctl enable chrony.service || die "failed to enable chrony.service"
 fi
 
 #
@@ -598,15 +605,6 @@ rm -f /etc/apt/sources.list.d/*
 #
 if [[ "$(systemctl is-enabled telegraf)" == enabled ]]; then
 	systemctl mask --now telegraf.service
-fi
-
-#
-# Upgrading to LTS 24.04 causes the `ntpsec` package to be installed. This package installs the
-# `ntpsec-rotate-stats.timer` timer which is enabled by default. Our product never enables
-# the collection of NTP stats, so we disable the timer to prevent it from running.
-#
-if [[ "$(systemctl is-enabled ntpsec-rotate-stats.timer)" == enabled ]]; then
-	systemctl mask --now ntpsec-rotate-stats.timer
 fi
 
 if compare_versions "$CURRENT_VERSION" lt "2025.6.0.0-0"; then


### PR DESCRIPTION
<details open>
<summary><h2> Background </h2></summary>

The Delphix appliance previously used `ntpsec` as its NTP daemon (and before that, the legacy `ntp` package). Both packages are being replaced with `chrony` ([DLPX-96940](https://perforce.atlassian.net/browse/DLPX-96940)/[96941](https://perforce.atlassian.net/browse/DLPX-96941)/[96942](https://perforce.atlassian.net/browse/DLPX-96942)), motivated by two factors:

1. **Security ([DLPX-86999](https://perforce.atlassian.net/browse/DLPX-86999), Qualys QID 38293):** `ntpsec` and `ntp` respond to NTP mode 6/7 queries, exposing sensitive system information (OS version, kernel, stratum, etc.) that can aid further attacks against the system. `chrony` does not support these query modes by default, eliminating the disclosure.
2. **Ubuntu 25.04 compatibility:** The Delphix Engine is planned to move to Ubuntu 25.04 later this year, where `chrony` is the default NTP daemon. Making this switch now avoids duplicating the migration effort at that time.
</details>

<details open>
<summary><h2> Companion PRs </h2></summary>

This PR is part of a set of four that must merge together:

- [dlpx-app-gate#4244](https://github.com/delphix/dlpx-app-gate/pull/4244) — app-stack changes
- [delphix-platform#556](https://github.com/delphix/delphix-platform/pull/556) — platform changes
- This PR — upgrade/migration scripts
- [dlpx-qa-gate#8297](https://github.com/delphix/dlpx-qa-gate/pull/8297) — QA gate test updates
</details>

<details open>
<summary><h2> Problem </h2></summary>

This PR handles the upgrade path: when an appliance running `ntpsec` (or `ntp`) upgrades to a version with `chrony`, the existing NTP configuration must be migrated so that the user's configured NTP servers are preserved and `chrony` is started in the same enabled/disabled state as the outgoing NTP service.

Without this migration, an appliance that had NTP enabled would silently end up with `chrony` masked and no servers configured after upgrade.
</details>

<details open>
<summary><h2> Solution </h2></summary>

The `upgrade/upgrade-scripts/execute` script now includes an NTP migration block that runs after the new packages are installed. It detects which of the two possible predecessor services was active and reads the corresponding config:

- If `ntpsec.service` was enabled → reads from `/etc/ntpsec/ntp.conf`
- If `ntp.service` was enabled → reads from `/etc/ntp.conf` and purges the `ntp` package (whose removal script would otherwise leave `ntp.service` in a masked state)
- If neither was enabled → no migration; `chrony.service` stays masked (handled by `fix_and_migrate_services`)

When a source config is found, the script writes a new `/etc/chrony/chrony.conf` by extracting the relevant entries and translating them to chrony's format:

- `pool <server> iburst` lines are preserved as-is (chrony supports the same `pool` directive)
- `multicastclient <addr>` entries are converted to `server <addr> iburst` (the chrony equivalent)
- `ntpsec`-specific directives (`restrict`, `driftfile` path) are dropped and replaced with chrony equivalents (`driftfile /var/lib/chrony/chrony.drift`, `makestep 1.0 3`, `rtcsync`)

Finally, `chrony.service` is unmasked and enabled.

`upgrade/upgrade-scripts/common.sh` (`fix_and_migrate_services`) is also updated to mask `chrony.service` (instead of the removed `ntpsec.service` and `ntpsec-rotate-stats.timer`) when those services are not-found or disabled, ensuring the default disabled state is preserved across not-in-place upgrades.

**Note on config format:** The Delphix appliance only ever writes two kinds of entries to the NTP config via `bos_mgmt.sh` in `dlpx-app-gate`: `pool <server> iburst` and `multicastclient <addr>`. This has been true for both the `ntp` and `ntpsec` eras, so the migration covers all configurations that can exist on a Delphix-managed appliance.

The remaining directives present in a typical Ubuntu ntpsec installation are package defaults, not appliance or user configuration. The table below documents each one and how chrony handles it, verified against `man chrony.conf` (chrony 4.5) and the Ubuntu default `chrony.conf` from the package:

| ntpsec directive | Source | Chrony handling |
|---|---|---|
| `driftfile /var/lib/ntpsec/ntp.drift` | Ubuntu default | Replaced with `driftfile /var/lib/chrony/chrony.drift` (written explicitly by the migration script, matching the Ubuntu default chrony path) |
| `leapfile /usr/share/zoneinfo/leap-seconds.list` | Ubuntu default | Chrony uses `leapsectz right/UTC` instead (reads leap seconds from the system timezone database). The migration script does not add this directive; for a pure NTP client, leap seconds are handled automatically via NTP server announcements. |
| `tos maxclock 11` | Ubuntu default | No equivalent; chrony selects the best sources automatically using its own algorithm |
| `tos minclock 4 minsane 3` | Ubuntu default | No equivalent; chrony's source selection handles minimum source requirements natively |
| `server ntp.ubuntu.com` | Ubuntu default fallback | Not added; Ubuntu's default `chrony.conf` uses `pool ntp.ubuntu.com iburst maxsources 4` instead of a bare `server` line. Since the migration writes a new `chrony.conf` from the pool entries in the original ntpsec config (which include the four `N.ubuntu.pool.ntp.org` entries), coverage is equivalent. |
| `restrict default kod nomodify nopeer noquery limited` | Ubuntu default | Not needed; per `man chrony.conf`: "The default is that no clients are allowed access, i.e. chronyd operates purely as an NTP client." |
| `restrict 127.0.0.1` / `restrict ::1` | Ubuntu default | Not needed; chrony binds its command sockets to loopback by default, blocking all access except from localhost |
</details>

<details open>
<summary><h2> Testing Done </h2></summary>

**Migration logic (script-level test):**

The NTP migration block was extracted and tested in isolation against simulated input configs, covering all meaningful scenarios:

- **NTP disabled**: migration block is skipped; no `chrony.conf` changes (chrony stays masked via `fix_and_migrate_services`)
- **ntpsec with pool servers**: `pool` lines preserved verbatim, `restrict` and ntpsec-specific directives dropped, chrony directives (`driftfile`, `makestep`, `rtcsync`) added correctly
- **ntpsec with multicastclient**: `multicastclient <addr>` correctly converted to `server <addr> iburst`
- **Mixed pool + multicast**: both handled correctly in the same config

All 14 test assertions passed.

**CI builds**

| Build | Description | Status |
|---|---|---|
| [#13927](https://selfservice-jenkins.eng-tools-prd.aws.delphixcloud.com/job/appliance-build-orchestrator-pre-push/13927/) | Full build + upgrade from 2025.3.0.1 | UNSTABLE — dx-integration-tests: `NtpServerMonitoringTest` flakiness (fixed; see second set of runs below) |
| [#13928](https://selfservice-jenkins.eng-tools-prd.aws.delphixcloud.com/job/appliance-build-orchestrator-pre-push/13928/) | Full build + upgrade from 2025.6.0.0 | SUCCESS |
| [#13929](https://selfservice-jenkins.eng-tools-prd.aws.delphixcloud.com/job/appliance-build-orchestrator-pre-push/13929/) | Full build + upgrade from 2026.2.0.0 | UNSTABLE — upgrade-testing: pre-existing failure unrelated to this change |
| [#13930](https://selfservice-jenkins.eng-tools-prd.aws.delphixcloud.com/job/appliance-build-orchestrator-pre-push/13930/) | Full build | UNSTABLE — upgrade-testing: pre-existing failure unrelated to this change |
| [#13941](https://selfservice-jenkins.eng-tools-prd.aws.delphixcloud.com/job/appliance-build-orchestrator-pre-push/13941/) | Full build + upgrade from 2025.3.0.1 | UNSTABLE — upgrade-testing: pre-existing failure unrelated to this change |
| [#13938](https://selfservice-jenkins.eng-tools-prd.aws.delphixcloud.com/job/appliance-build-orchestrator-pre-push/13938/) | Full build + upgrade from 2025.6.0.0 | SUCCESS |
| [#13940](https://selfservice-jenkins.eng-tools-prd.aws.delphixcloud.com/job/appliance-build-orchestrator-pre-push/13940/) | Full build + upgrade from 2026.2.0.0 | UNSTABLE — upgrade-testing: pre-existing failure unrelated to this change |
| [#13939](https://selfservice-jenkins.eng-tools-prd.aws.delphixcloud.com/job/appliance-build-orchestrator-pre-push/13939/) | Full build | FAILURE — upgrade-testing: pre-existing failure unrelated to this change |

> **Note:** The git workflow runs with only this repo's changes, without the companion changes in [dlpx-app-gate#4244](https://github.com/delphix/dlpx-app-gate/pull/4244) and [delphix-platform#556](https://github.com/delphix/delphix-platform/pull/556). The `appliance-build-orchestrator-pre-push` runs pull in all three companion PRs together, so their results reflect the full end-to-end change.

**Upgrade testing:**

End-to-end upgrade tests were run against a VM running 2026.4.0.0-snapshot with ntpsec configured, upgrading to the build from [#13897](https://selfservice-jenkins.eng-tools-prd.aws.delphixcloud.com/job/appliance-build-orchestrator-pre-push/13897/). All three migration scenarios passed on blackbox-self-service:

| Scenario | Result |
|---|---|
| ntpsec with pool servers ([#215235](https://selfservice-jenkins.eng-tools-prd.aws.delphixcloud.com/job/blackbox-self-service/215235/)) | SUCCESS |
| ntpsec with multicastclient ([#215236](https://selfservice-jenkins.eng-tools-prd.aws.delphixcloud.com/job/blackbox-self-service/215236/)) | SUCCESS |
| NTP disabled ([#215237](https://selfservice-jenkins.eng-tools-prd.aws.delphixcloud.com/job/blackbox-self-service/215237/)) | SUCCESS |

**Long-path upgrade test ([DLPX-95255](https://perforce.atlassian.net/browse/DLPX-95255)):**

Full upgrade path 21.0.0.0 → 2025.2.0.1 → 2026.4.0.0, exercising migration from the legacy `ntp` package:

| Build | NTP state | Result |
|---|---|---|
| [#9260](https://selfservice-jenkins.eng-tools-prd.aws.delphixcloud.com/job/blackbox-chained/9260/) | enabled (ntp.service) | FAILURE — wrong qa_branch (`dlpx-2025.2.0.1`); fixed in #9262 |
| [#9262](https://selfservice-jenkins.eng-tools-prd.aws.delphixcloud.com/job/blackbox-chained/9262/) | enabled (ntp.service) | SUCCESS |

The NTP-never-enabled path (ntp.service masked from 21.0, `chronyd` should stay masked post-upgrade) was tested manually with AI assist ([DLPX-95255](https://perforce.atlassian.net/browse/DLPX-95255)). Upgrade performed on `mj-ntp-off-21000.dlpxdc.co` (21.0.0.0 → 2025.2.0.1 → 2026.4.0.0 pre-push [#6498](https://selfservice-jenkins.eng-tools-prd.aws.delphixcloud.com/job/appliance-build/6498/)). Post-upgrade state confirmed: `chrony` installed, `chrony.service` masked, `GET /service/time` → `ntpConfig.enabled: false`.
</details>