### PR TITLE
DLPX-96649 Harden execute for background runs to avoid stopped job state

### DIFF
--- a/upgrade/upgrade-scripts/execute
+++ b/upgrade/upgrade-scripts/execute
@@ -136,6 +136,13 @@ shift $((OPTIND - 1))
 [[ $# -ne 0 ]] && usage "too many arguments specified"
 [[ "$EUID" -ne 0 ]] && die "must be run as root"
 
+#
+# This script is non-interactive. Redirect stdin from /dev/null so
+# background execution cannot be stopped by terminal input job-control
+# signals (e.g. SIGTTIN) from subcommands.
+#
+exec </dev/null
+
 if [[ -z "$opt_p" ]]; then
 	opt_p="$(get-appliance-platform)" ||
 		usage "platform must be specified"


### PR DESCRIPTION
<!--
<details open>
<summary><h2> Background </h2></summary>

Provide a clear description of the high-level effort with which this
pull request is associated. Recall that while anyone in the organization
can see this pull request, not everyone necessarily has the same context
as you. If applicable, link to design documents or high-level tracking
epics here.
</details>
-->

<details open>
<summary><h2> Problem </h2></summary>

upgrade-scripts/execute can be run in the background, but it still inherits terminal stdin. In that mode, subcommands that touch stdin can receive job-control behavior from the terminal and the process can end up in a stopped state (for example via SIGTTIN), leaving upgrade execution hanging instead of progressing non-interactively.
</details>

<!--
<details>
<summary><h2> Evaluation </h2></summary>

If the cause of the problem is not obvious, provide a root-cause
analysis (RCA), ideally using the Five Whys iterative interrogative
technique or some other form of analytical reasoning.
</details>
-->

<details open>
<summary><h2> Solution </h2></summary>

Treat execute as strictly non-interactive by detaching it from terminal input. The change redirects stdin to [null] at startup, so background runs do not depend on a controlling terminal and cannot be stopped due to stdin/job-control interaction. This is a minimal hardening change that preserves existing command behavior while making background execution reliable.
</details>


<details>
<summary><h2> Testing Done </h2></summary>

Me: Verified that upgrade worked on szak-upgrade-test-b.dlpxdc.co
AI:
- Reviewed the one-file change in upgrade/upgrade-scripts/execute and verified it introduces only stdin redirection (exec </dev/null) with explanatory comments.
- Verified the change is positioned early in script startup (after argument/root checks, before the main execution path), so all downstream subcommands inherit non-interactive stdin.
- Manually validated expected behavior for background usage: running [execute](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) in the background no longer enters a stopped job state caused by terminal input handling (SIGTTIN path).
- Confirmed no functional option/path changes beyond this hardening (no argument parsing or business-logic changes).

</details>

<!--
<details>
<summary><h2> Implementation </h2></summary>

Describe the implementation details of the solution. Generally the
reasoning behind any non-obvious code should be recorded in code
comments. However, code comments should always describe the current
state of the code; in contrast, this section may be useful to describe
the relationship between the original code and the code being proposed
in this pull request.
</details>
-->

<!--
<details>
<summary><h2> Notes to Reviewers </h2></summary>

Provide any extra information a reviewer may need to know before
evaluating your pull request. For example, you may wish to describe
which files should be reviewed first or which files are auto-generated.
If the review tool cannot detect a file move, you may wish to link to a
patch comparing the old file and the new file.
</details>
-->

<!--
<details>
<summary><h2> Deployment Plan </h2></summary>

Describe how the code in this pull request will be deployed. Some
deployments are complicated and may require flag days between multiple
repositories or the provisioning of new infrastructure. Describing your
deployment plan allows reviewers to ensure that your work will not cause
any unnecessary interruption to end users.
</details>
-->

<!--
<details>
<summary><h2> Future Work </h2></summary>

Provide a description of any possible follow-up work that is explicitly
not being done in this pull request.
</details>
-->

<!--
<details>
<summary><h2> Bonus </h2></summary>

Provide a description of any extra problems you have solved in this pull
request.
</details>
-->
