### PR TITLE
DLPX-96648 Add upgrade container list commands and simplify cleanup to container-id only

### DIFF
--- a/upgrade/upgrade-scripts/tests/README.md
+++ b/upgrade/upgrade-scripts/tests/README.md
@@ -1,0 +1,85 @@
+# upgrade-scripts tests
+
+Run commands in this document from `upgrade/upgrade-scripts/tests`.
+
+## Test flow for recent `upgrade-container` changes
+
+This validates the new commands/features:
+
+- `list-started`
+- `list-all`
+- `cleanup <container>`
+
+### Prerequisites
+
+- Run on a target appliance/test box as `root`
+- `machinectl` is available
+- `upgrade-container` script is present and executable
+
+### Test script
+
+Use:
+
+- `./test-upgrade-container-changes.sh`
+
+Optional flags:
+
+- `--type <in-place|not-in-place|rollback>` (default: `in-place`)
+
+Examples:
+
+- `./test-upgrade-container-changes.sh`
+- `./test-upgrade-container-changes.sh --type not-in-place`
+
+### What the harness verifies
+
+- Created container appears in `list-all`
+- Stopped container does not appear in `list-started`
+- Running container appears in `list-started`
+- `cleanup <container>` stops (if needed) and destroys the container
+
+### Expected output
+
+The script prints status lines like:
+
+- `[INFO] ...`
+- `[PASS] ...`
+- `[FAIL] ...` (and exits non-zero)
+
+A successful run ends with:
+
+- `[PASS] All requested tests completed`
+
+### Quick smoke test (manual)
+
+Use this when you want a minimal, fast validation without running the full harness.
+
+1. Create and start one test container:
+
+	- `c=$(../upgrade-container create in-place)`
+	- `../upgrade-container start "$c"`
+
+2. Verify listing commands:
+
+	- `../upgrade-container list-all | grep -Fx "$c"`
+	- `../upgrade-container list-started | grep -Fx "$c"`
+
+3. Preview and clean up:
+
+	- `../upgrade-container cleanup "$c"`
+	- `../upgrade-container list-all | grep -Fx "$c" && echo "unexpected" || echo "clean"`
+
+Expected result:
+
+- The container appears in both list commands while running.
+- After `cleanup`, the container is no longer returned by `list-all`.
+
+Automated equivalent:
+
+- `./smoke-upgrade-container.sh`
+- Optional type: `./smoke-upgrade-container.sh --type not-in-place`
+
+### Safety notes
+
+- The harness always performs real create/start/destroy operations for its test containers.
+- The script includes best-effort exit cleanup for containers it creates.

--- a/upgrade/upgrade-scripts/tests/smoke-upgrade-container.sh
+++ b/upgrade/upgrade-scripts/tests/smoke-upgrade-container.sh
@@ -1,0 +1,115 @@
+#!/bin/bash
+
+set -euo pipefail
+
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+UC_SCRIPT="$SCRIPT_DIR/../upgrade-container"
+
+TYPE="in-place"
+SMOKE_CONTAINER=""
+
+usage() {
+	cat <<-EOF
+	Usage: $(basename "$0") [--type <in-place|not-in-place|rollback>]
+
+	Runs a quick smoke validation for recent upgrade-container changes:
+	  1) create + start one container
+	  2) verify list-all and list-started include it
+	  3) cleanup and verify removal
+	EOF
+}
+
+log() {
+	echo "[INFO] $*"
+}
+
+pass() {
+	echo "[PASS] $*"
+}
+
+fail() {
+	echo "[FAIL] $*" >&2
+	exit 1
+}
+
+parse_args() {
+	while [[ $# -gt 0 ]]; do
+		case "$1" in
+		--type)
+			[[ $# -ge 2 ]] || fail "missing value for --type"
+			TYPE="$2"
+			shift
+			;;
+		-h | --help)
+			usage
+			exit 0
+			;;
+		*)
+			fail "unknown argument: '$1'"
+			;;
+		esac
+		shift
+	done
+
+	case "$TYPE" in
+	in-place | not-in-place | rollback) ;;
+	*) fail "invalid type '$TYPE'" ;;
+	esac
+}
+
+require_prereqs() {
+	[[ "$EUID" -eq 0 ]] || fail "must run as root"
+	[[ -x "$UC_SCRIPT" ]] || fail "missing executable script: $UC_SCRIPT"
+	command -v grep >/dev/null || fail "grep not found"
+	command -v machinectl >/dev/null || fail "machinectl not found"
+}
+
+contains_line() {
+	local output="$1"
+	local needle="$2"
+	printf '%s\n' "$output" | grep -Fxq "$needle"
+}
+
+main() {
+	parse_args "$@"
+	require_prereqs
+
+	cleanup_on_exit() {
+		set +e
+		if [[ -n "$SMOKE_CONTAINER" ]]; then
+			"$UC_SCRIPT" cleanup "$SMOKE_CONTAINER" >/dev/null 2>&1 || true
+		fi
+	}
+	trap cleanup_on_exit EXIT
+
+	log "Creating container (type=$TYPE)"
+	SMOKE_CONTAINER=$("$UC_SCRIPT" create "$TYPE")
+	[[ -n "$SMOKE_CONTAINER" ]] || fail "create returned empty container name"
+	pass "Created '$SMOKE_CONTAINER'"
+
+	log "Starting '$SMOKE_CONTAINER'"
+	"$UC_SCRIPT" start "$SMOKE_CONTAINER"
+	pass "Started '$SMOKE_CONTAINER'"
+
+	all_out=$("$UC_SCRIPT" list-all)
+	contains_line "$all_out" "$SMOKE_CONTAINER" || fail "list-all did not include '$SMOKE_CONTAINER'"
+	pass "list-all includes '$SMOKE_CONTAINER'"
+
+	started_out=$("$UC_SCRIPT" list-started)
+	contains_line "$started_out" "$SMOKE_CONTAINER" || fail "list-started did not include '$SMOKE_CONTAINER'"
+	pass "list-started includes '$SMOKE_CONTAINER'"
+
+	log "Running cleanup"
+	"$UC_SCRIPT" cleanup "$SMOKE_CONTAINER"
+
+	all_after=$("$UC_SCRIPT" list-all)
+	if contains_line "$all_after" "$SMOKE_CONTAINER"; then
+		fail "container '$SMOKE_CONTAINER' still present after cleanup"
+	fi
+	pass "cleanup removed '$SMOKE_CONTAINER'"
+
+	SMOKE_CONTAINER=""
+	pass "Smoke test completed successfully"
+}
+
+main "$@"

--- a/upgrade/upgrade-scripts/tests/test-upgrade-container-changes.sh
+++ b/upgrade/upgrade-scripts/tests/test-upgrade-container-changes.sh
@@ -1,0 +1,162 @@
+#!/bin/bash
+
+set -euo pipefail
+
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+UPGRADE_CONTAINER_SCRIPT="$SCRIPT_DIR/../upgrade-container"
+
+TEST_TYPE="in-place"
+TEST_CONTAINER1=""
+TEST_CONTAINER2=""
+
+usage() {
+	cat <<-EOF
+	Usage: $(basename "$0") [--type <in-place|not-in-place|rollback>]
+
+	Tests recent changes in 'upgrade-container':
+	  - list-started
+	  - list-all
+	  - cleanup <container> (single container)
+	EOF
+}
+
+log() {
+	echo "[INFO] $*"
+}
+
+pass() {
+	echo "[PASS] $*"
+}
+
+fail() {
+	echo "[FAIL] $*" >&2
+	exit 1
+}
+
+run_uc() {
+	"$UPGRADE_CONTAINER_SCRIPT" "$@"
+}
+
+assert_contains_line() {
+	local haystack="$1"
+	local needle="$2"
+	if ! printf '%s\n' "$haystack" | grep -Fxq "$needle"; then
+		echo "----- output -----"
+		printf '%s\n' "$haystack"
+		echo "------------------"
+		fail "expected line '$needle'"
+	fi
+}
+
+assert_not_contains_line() {
+	local haystack="$1"
+	local needle="$2"
+	if printf '%s\n' "$haystack" | grep -Fxq "$needle"; then
+		echo "----- output -----"
+		printf '%s\n' "$haystack"
+		echo "------------------"
+		fail "unexpected line '$needle'"
+	fi
+}
+
+container_running() {
+	machinectl status "$1" &>/dev/null
+}
+
+parse_args() {
+	while [[ $# -gt 0 ]]; do
+		case "$1" in
+		--type)
+			[[ $# -ge 2 ]] || fail "missing value for --type"
+			TEST_TYPE="$2"
+			shift
+			;;
+		-h | --help)
+			usage
+			exit 0
+			;;
+		*)
+			fail "unknown argument: '$1'"
+			;;
+		esac
+		shift
+	done
+
+	case "$TEST_TYPE" in
+	in-place | not-in-place | rollback) ;;
+	*) fail "invalid type '$TEST_TYPE'" ;;
+	esac
+}
+
+require_prereqs() {
+	[[ "$EUID" -eq 0 ]] || fail "must run as root"
+	[[ -x "$UPGRADE_CONTAINER_SCRIPT" ]] || fail "missing executable: $UPGRADE_CONTAINER_SCRIPT"
+	command -v machinectl >/dev/null || fail "machinectl not found"
+	command -v awk >/dev/null || fail "awk not found"
+	command -v grep >/dev/null || fail "grep not found"
+}
+
+main() {
+	parse_args "$@"
+	require_prereqs
+
+	local before_all before_started after_all after_started
+	TEST_CONTAINER1="uc-test-$(date +%s)-a"
+	TEST_CONTAINER2="uc-test-$(date +%s)-b"
+
+	# create uses internally generated names; capture them for test flow
+	log "Creating first test container (type=$TEST_TYPE)"
+	TEST_CONTAINER1=$(run_uc create "$TEST_TYPE")
+	[[ -n "$TEST_CONTAINER1" ]] || fail "create returned empty container name"
+	pass "Created '$TEST_CONTAINER1'"
+
+	# Best-effort cleanup on script exit for containers created here.
+	cleanup_on_exit() {
+		set +e
+		for c in "$TEST_CONTAINER1" "$TEST_CONTAINER2"; do
+			[[ -n "$c" ]] || continue
+			if run_uc list-all | grep -Fxq "$c"; then
+				run_uc cleanup "$c" >/dev/null 2>&1 || true
+			fi
+		done
+	}
+	trap cleanup_on_exit EXIT
+
+	before_all=$(run_uc list-all)
+	assert_contains_line "$before_all" "$TEST_CONTAINER1"
+	pass "list-all includes newly created container"
+
+	before_started=$(run_uc list-started)
+	assert_not_contains_line "$before_started" "$TEST_CONTAINER1"
+	pass "list-started excludes non-running container"
+
+	log "Starting container and validating list-started"
+	run_uc start "$TEST_CONTAINER1"
+	after_started=$(run_uc list-started)
+	assert_contains_line "$after_started" "$TEST_CONTAINER1"
+	pass "list-started includes running container"
+
+	log "Validating cleanup for single running container"
+	run_uc cleanup "$TEST_CONTAINER1"
+	after_all=$(run_uc list-all)
+	assert_not_contains_line "$after_all" "$TEST_CONTAINER1"
+	if container_running "$TEST_CONTAINER1"; then
+		fail "container '$TEST_CONTAINER1' still running after cleanup"
+	fi
+	pass "cleanup destroyed the container"
+
+	log "Creating second test container"
+	TEST_CONTAINER2=$(run_uc create "$TEST_TYPE")
+	[[ -n "$TEST_CONTAINER2" ]] || fail "second create returned empty container name"
+	pass "Created '$TEST_CONTAINER2'"
+
+	log "Validating cleanup for second stopped container"
+	run_uc cleanup "$TEST_CONTAINER2"
+	final_all=$(run_uc list-all)
+	assert_not_contains_line "$final_all" "$TEST_CONTAINER2"
+	pass "cleanup removed second container"
+
+	pass "All requested tests completed"
+}
+
+main "$@"

--- a/upgrade/upgrade-scripts/upgrade-container
+++ b/upgrade/upgrade-scripts/upgrade-container
@@ -593,6 +593,71 @@ function shell() {
 	machinectl shell "$CONTAINER"
 }
 
+function is_upgrade_container() {
+	local container="$1"
+
+	[[ -d "/var/lib/machines/$container" ]] || return 1
+	[[ -f "/etc/systemd/nspawn/$container.nspawn" ]] || return 1
+	zfs list "rpool/ROOT/$container" &>/dev/null || return 1
+
+	return 0
+}
+
+function is_container_running() {
+	local container="$1"
+	machinectl status "$container" &>/dev/null
+}
+
+function list_started() {
+	local machine
+
+	while IFS= read -r machine; do
+		[[ -n "$machine" ]] || continue
+
+		if is_upgrade_container "$machine"; then
+			echo "$machine"
+		fi
+	done < <(machinectl list --no-legend --no-pager | awk '{ print $1 }')
+}
+
+function list_all() {
+	local container
+
+	for container_dir in /var/lib/machines/*; do
+		[[ -d "$container_dir" ]] || continue
+		container=$(basename "$container_dir")
+
+		if is_upgrade_container "$container"; then
+			echo "$container"
+		fi
+	done
+}
+
+function cleanup_container() {
+	local container="$1"
+
+	if ! is_upgrade_container "$container"; then
+		die "container '$container' non-existent or mis-configured"
+	fi
+
+	if is_container_running "$container"; then
+		echo "stopping container '$container'"
+		CONTAINER="$container"
+		stop
+	fi
+
+	echo "destroying container '$container'"
+	CONTAINER="$container"
+	destroy
+}
+
+function cleanup() {
+	[[ $# -lt 1 ]] && usage "too few arguments specified"
+	[[ $# -gt 1 ]] && usage "too many arguments specified"
+
+	cleanup_container "$1"
+}
+
 function convert_to_rootfs() {
 	#
 	# We're relying on the "mountpoint" property for the "data" and
@@ -659,6 +724,9 @@ function usage() {
 	echo "$PREFIX_SPACES destroy <container>"
 	echo "$PREFIX_SPACES run <container> <command>"
 	echo "$PREFIX_SPACES shell <container>"
+	echo "$PREFIX_SPACES list-started"
+	echo "$PREFIX_SPACES list-all"
+	echo "$PREFIX_SPACES cleanup <container>"
 	echo "$PREFIX_SPACES upgrade <container>"
 	echo "$PREFIX_SPACES convert-to-rootfs <container>"
 	echo "$PREFIX_SPACES get-type <container>"
@@ -712,6 +780,18 @@ shell)
 	CONTAINER="$2"
 	shift 2
 	shell
+	;;
+list-started)
+	[[ $# -gt 1 ]] && usage "too many arguments specified"
+	list_started
+	;;
+list-all)
+	[[ $# -gt 1 ]] && usage "too many arguments specified"
+	list_all
+	;;
+cleanup)
+	shift
+	cleanup "$@"
 	;;
 upgrade)
 	[[ $# -lt 2 ]] && usage "too few arguments specified"


### PR DESCRIPTION
<!--
<details open>
<summary><h2> Background </h2></summary>

</details>
-->

<details open>
<summary><h2> Problem </h2></summary>

Authorship: This PR description content was generated by GitHub Copilot.

Today, upgrade-container has no easy/safe way to 1) list upgrade containers by state and 2) clean up a specific upgrade container directly. This makes day-2 operations harder and increases manual error risk when cleaning up stale containers.
</details>

<!--
<details>
<summary><h2> Evaluation </h2></summary>

If the cause of the problem is not obvious, provide a root-cause
analysis (RCA), ideally using the Five Whys iterative interrogative
technique or some other form of analytical reasoning.
</details>
-->

<details open>
<summary><h2> Solution </h2></summary>
Add operational commands to upgrade-container for visibility and direct cleanup:

- list-started: shows running upgrade containers only
- list-all: shows all upgrade containers
- cleanup <container>: stops (if needed) and destroys one container
- Updated smoke and test harness scripts plus README guidance to match the simplified cleanup flow

</details>


<details>
<summary><h2> Testing Done </h2></summary>

- Updated automated validation for the command set (list-started, list-all, cleanup single).
- Verified stopped containers are excluded from list-started, running containers are included, and list-all includes created containers.
- Verified cleanup <container> removes the target container and leaves it non-running.
- Updated smoke flow to validate create/start/list/cleanup end-to-end with the simplified cleanup interface.
- Ran shell syntax validation on modified scripts:
  - bash -n upgrade/upgrade-scripts/upgrade-container
  - bash -n upgrade/upgrade-scripts/tests/test-upgrade-container-changes.sh
  - bash -n upgrade/upgrade-scripts/tests/smoke-upgrade-container.sh

</details>

<!--
<details>
<summary><h2> Implementation </h2></summary>

Describe the implementation details of the solution. Generally the
reasoning behind any non-obvious code should be recorded in code
comments. However, code comments should always describe the current
state of the code; in contrast, this section may be useful to describe
the relationship between the original code and the code being proposed
in this pull request.
</details>
-->

<!--
<details>
<summary><h2> Notes to Reviewers </h2></summary>

Provide any extra information a reviewer may need to know before
evaluating your pull request. For example, you may wish to describe
which files should be reviewed first or which files are auto-generated.
If the review tool cannot detect a file move, you may wish to link to a
patch comparing the old file and the new file.
</details>
-->

<!--
<details>
<summary><h2> Deployment Plan </h2></summary>

Describe how the code in this pull request will be deployed. Some
deployments are complicated and may require flag days between multiple
repositories or the provisioning of new infrastructure. Describing your
deployment plan allows reviewers to ensure that your work will not cause
any unnecessary interruption to end users.
</details>
-->

<!--
<details>
<summary><h2> Future Work </h2></summary>

Provide a description of any possible follow-up work that is explicitly
not being done in this pull request.
</details>
-->

<!--
<details>
<summary><h2> Bonus </h2></summary>

Provide a description of any extra problems you have solved in this pull
request.
</details>
-->
