### PR TITLE
DLPX-96807 dpkg --configure -a in upgrade execute script missing non-interactive options

### DIFF
--- a/upgrade/upgrade-scripts/execute
+++ b/upgrade/upgrade-scripts/execute
@@ -268,7 +268,9 @@ fi
 # When an upgrade gets interrupted while it’s in the middle of upgrading
 # packages, the package manager can get into a state where “dpkg --configure -a”
 # needs to be manually run to enable the upgrade to be restarted.
-dpkg --configure -a || die "failed to run dpkg --configure -a"
+DEBIAN_FRONTEND=noninteractive dpkg --configure -a \
+	--force-confdef --force-confold ||
+	die "failed to run dpkg --configure -a"
 
 #
 # Older versions (i.e. before 9.0.0.0 release) of the "nfs-kernel-server"


### PR DESCRIPTION
<details open>
<summary><h2> Problem </h2></summary>

The `dpkg --configure -a` command in the upgrade `execute` script can hang
waiting for interactive input if it encounters a configuration file conflict
during package reconfiguration. This can happen when an upgrade is interrupted
and then restarted, leaving packages in an unconfigured state. Since upgrades
run non-interactively, any interactive prompt will cause the upgrade to stall
indefinitely.
</details>

<details open>
<summary><h2> Solution </h2></summary>

Add `DEBIAN_FRONTEND=noninteractive`, `--force-confdef`, and `--force-confold`
to the `dpkg --configure -a` invocation, consistent with how `apt-get` is
already invoked via the `apt_get()` wrapper in `common.sh`. This ensures that
any configuration file conflicts are resolved automatically by keeping the
existing configuration file, preventing interactive prompts from stalling the
upgrade.
</details>