### PR TITLE
DLPX-96818 nightly appliance-build jobs failing with docker package conflicts

### DIFF
--- a/bootstrap/roles/appliance-build.bootstrap/tasks/main.yml
+++ b/bootstrap/roles/appliance-build.bootstrap/tasks/main.yml
@@ -1,5 +1,5 @@
 #
-# Copyright 2018-2025 Delphix
+# Copyright 2018-2026 Delphix
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -58,7 +58,6 @@
       - bc
       - coreutils
       - devscripts
-      - docker.io
       - equivs
       - gdisk
       - git

--- a/live-build/misc/ansible-roles/appliance-build.buildserver-internal/tasks/main.yml
+++ b/live-build/misc/ansible-roles/appliance-build.buildserver-internal/tasks/main.yml
@@ -1,5 +1,5 @@
 #
-# Copyright 2022 Delphix
+# Copyright 2022-2026 Delphix
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -21,7 +21,6 @@
       - openjdk-8-jdk-headless
       - openjdk-17-jdk-headless
       - curl
-      - docker.io
       - fakeroot
       - git
       - gnupg

--- a/live-build/misc/ansible-roles/appliance-build.unittest-internal/tasks/main.yml
+++ b/live-build/misc/ansible-roles/appliance-build.unittest-internal/tasks/main.yml
@@ -1,5 +1,5 @@
 #
-# Copyright 2019 Delphix
+# Copyright 2019-2026 Delphix
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -22,7 +22,6 @@
       - ant
       - bash
       - build-essential
-      - docker.io
       - git
       - python3-minimal
     state: present


### PR DESCRIPTION

<details open>
<summary><h2> Problem </h2></summary>

See https://perforce.slack.com/archives/C07QNNXT1DK/p1774254473906239 and comments below on this PR for more discussion/context.

Since March 17 certain nightly image builds (internal-unittest-aws, internal-dct-*) are failing with errors like: 

<code>
00:18:06  TASK [appliance-build.unittest-internal : apt] *********************************
00:18:06  task path: /export/home/delphix/jenkins/workspace/appliance-build-stage1/post-push/appliance-build/live-build/misc/ansible-roles/appliance-build.unittest-internal/tasks/main.yml:18
00:18:08  redirecting (type: connection) ansible.builtin.chroot to community.general.chroot
00:18:08  fatal: [binary]: FAILED! => {"cache_update_time": 1773731286, "cache_updated": false, "changed": false, "msg": "'/usr/bin/apt-get -y -o \"Dpkg::Options::=--force-confdef\" -o \"Dpkg::Options::=--force-confold\"       install 'openjdk-8-jdk-headless=8u482-ga~us1-0ubuntu1~24.04' 'openjdk-17-jdk-headless=17.0.18+8-1~24.04.1' 'ant=1.10.14-1' 'build-essential=12.10ubuntu1' 'docker.io=28.2.2-0ubuntu1~24.04.1' 'git=1:2.43.0-1ubuntu7.3'' failed: E: Error, pkgProblemResolver::Resolve generated breaks, this may be caused by held packages.\n", "rc": 100, "stderr": "E: Error, pkgProblemResolver::Resolve generated breaks, this may be caused by held packages.\n", "stderr_lines": ["E: Error, pkgProblemResolver::Resolve generated breaks, this may be caused by held packages."], "stdout": "Reading package lists...\nBuilding dependency tree...\nReading state information...\nSome packages could not be installed. This may mean that you have\nrequested an impossible situation or if you are using the unstable\ndistribution that some required packages have not yet been created\nor been moved out of Incoming.\nThe following information may help to resolve the situation:\n\nThe following packages have unmet dependencies:\n containerd.io : Conflicts: containerd\n", "stdout_lines": ["Reading package lists...", "Building dependency tree...", "Reading state information...", "Some packages could not be installed. This may mean that you have", "requested an impossible situation or if you are using the unstable", "distribution that some required packages have not yet been created", "or been moved out of Incoming.", "The following information may help to resolve the situation:", "", "The following packages have unmet dependencies:", " containerd.io : Conflicts: containerd"]}
</code>

https://ops-jenkins.eng-tools-prd.aws.delphixcloud.com/job/appliance-build/job/develop/job/nightly/1099/

This means new DCoA images are not being published for these variants since the 17th. For example:
```
lyric.lake@dlpxdc:~$ dc groups list | grep internal-unittest-develop
dlpx-internal-unittest-develop                   2026-03-17-10-03  Delphix Engine 2026.3.0.0  42860 22405bbd
```

This is caused by the move from docker.io to docker-ce in the delphix-virtualization package in https://github.com/delphix/dlpx-app-gate/pull/3929. appliance-build still tries to install docker.io, which conflicts with the docker-ce dependency declared by delphix-virtualization.
</details>

<!--
<details>
<summary><h2> Evaluation </h2></summary>

If the cause of the problem is not obvious, provide a root-cause
analysis (RCA), ideally using the Five Whys iterative interrogative
technique or some other form of analytical reasoning.
</details>
-->

<details open>
<summary><h2> Solution </h2></summary>
In delphix/delphix-platform/pull/555 the dependency on docker in the delphix-platform build was removed, so it can also be removed from the top-level appliance-build bootstrap role. If it's needed by a certain variant it will be pulled in by other dependencies (e.g., delphix-virtualization). Also removed the explicit docker dependency from the buildserver and unittest variants.
</details>


<details open>
<summary><h2> Testing Done </h2></summary>

Manually kicked off a nightly run with these changes: https://ops-jenkins.eng-tools-prd.aws.delphixcloud.com/job/appliance-build/job/develop/job/nightly/1107/
DCT images are still failing for reasons outside of this PR, see discussion below.

EDIT: replayed now that virtualization revert is merged: PASSED https://ops-jenkins.eng-tools-prd.aws.delphixcloud.com/job/appliance-build/job/develop/job/nightly/1112/


internal-unittest-aws suceeds, and we can see from the build that it still pulls in docker even though it's been removed from the ansible role:
<code>
16:05:48  The following additional packages will be installed:
......... snip............
16:05:48    dnsutils docker-ce docker-ce-cli
</code>
</details>

<!--
<details>
<summary><h2> Implementation </h2></summary>

Describe the implementation details of the solution. Generally the
reasoning behind any non-obvious code should be recorded in code
comments. However, code comments should always describe the current
state of the code; in contrast, this section may be useful to describe
the relationship between the original code and the code being proposed
in this pull request.
</details>
-->

<!--
<details>
<summary><h2> Notes to Reviewers </h2></summary>

Provide any extra information a reviewer may need to know before
evaluating your pull request. For example, you may wish to describe
which files should be reviewed first or which files are auto-generated.
If the review tool cannot detect a file move, you may wish to link to a
patch comparing the old file and the new file.
</details>
-->

<!--
<details>
<summary><h2> Deployment Plan </h2></summary>

Describe how the code in this pull request will be deployed. Some
deployments are complicated and may require flag days between multiple
repositories or the provisioning of new infrastructure. Describing your
deployment plan allows reviewers to ensure that your work will not cause
any unnecessary interruption to end users.
</details>
-->

<!--
<details>
<summary><h2> Future Work </h2></summary>

Provide a description of any possible follow-up work that is explicitly
not being done in this pull request.
</details>
-->

<!--
<details>
<summary><h2> Bonus </h2></summary>

Provide a description of any extra problems you have solved in this pull
request.
</details>
-->
