### PR TITLE
DLPX-97162 Add internal-claude variant for Claude Code developer environments

### DIFF
--- a/live-build/config/hooks/configuration/80-build-configuration.binary
+++ b/live-build/config/hooks/configuration/80-build-configuration.binary
@@ -29,21 +29,22 @@ if [[ -e /etc/resolv.conf ]]; then
 	cp /etc/resolv.conf binary/etc/resolv.conf
 fi
 
+cleanup() {
+	for dir in /dev /sys /proc; do
+		umount -R "binary/${dir}" 2>/dev/null || true
+	done
+	if [[ -e binary/etc/resolv.conf ]]; then
+		rm binary/etc/resolv.conf
+	fi
+	if [[ -e binary/etc/resolv.conf.orig || -L binary/etc/resolv.conf ]]; then
+		mv binary/etc/resolv.conf.orig binary/etc/resolv.conf
+	fi
+}
+trap cleanup EXIT
+
 for dir in /proc /sys /dev; do
 	mount --rbind "$dir" "binary/${dir}"
 	mount --make-rslave "binary/${dir}"
 done
 
 ansible-playbook -vv -c chroot -i binary, ansible/playbook.yml
-
-for dir in /proc /sys /dev; do
-	umount -R "binary/${dir}"
-done
-
-if [[ -e binary/etc/resolv.conf ]]; then
-	rm binary/etc/resolv.conf
-fi
-
-if [[ -e binary/etc/resolv.conf.orig || -L binary/etc/resolv.conf ]]; then
-	mv binary/etc/resolv.conf.orig binary/etc/resolv.conf
-fi

--- a/live-build/misc/ansible-roles/appliance-build.claude-internal/tasks/main.yml
+++ b/live-build/misc/ansible-roles/appliance-build.claude-internal/tasks/main.yml
@@ -1,0 +1,119 @@
+#
+# Copyright 2026 Delphix
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+---
+- name: Assert GITHUB_TOKEN is set
+  ansible.builtin.assert:
+    that:
+      - lookup('env', 'GITHUB_TOKEN') | length > 0
+    fail_msg: "GITHUB_TOKEN must be set to build the internal-claude variant."
+
+- name: Install NFS client
+  ansible.builtin.apt:
+    name: nfs-common
+    state: present
+
+- name: Create support-tools group
+  ansible.builtin.group:
+    name: support-tools
+    gid: 4000
+    state: present
+
+- name: Add delphix user to support-tools group
+  ansible.builtin.user:
+    name: delphix
+    groups: support-tools
+    append: true
+
+- name: Create /nas mount point
+  ansible.builtin.file:
+    path: /nas
+    state: directory
+    mode: "0755"
+
+- name: Add /nas fstab entry for support-tools NFS share
+  ansible.posix.mount:
+    path: /nas
+    src: "support-tools-nas.delphix.com:/"
+    fstype: nfs4
+    opts: "defaults,_netdev"
+    state: present
+
+- name: Install Claude CLI
+  ansible.builtin.shell: |
+    set -o pipefail
+    curl -fsSL https://claude.ai/install.sh | bash
+  args:
+    creates: /usr/local/bin/claude
+    executable: /bin/bash
+
+- name: Create /export/home/delphix/src directory
+  ansible.builtin.file:
+    path: /export/home/delphix/src
+    state: directory
+    owner: delphix
+    group: staff
+    mode: "g+w"
+
+- name: Clone product repositories
+  ansible.builtin.git:
+    repo: "https://{{ lookup('env', 'GITHUB_TOKEN') }}@github.com/{{ item.org }}/{{ item.name }}.git"
+    dest: "/export/home/delphix/src/{{ item.name }}"
+    version: "{{ item.version }}"
+    update: false
+  loop:
+    - { org: delphix, name: dlpx-app-gate, version: develop }
+    - { org: delphix, name: dms-core-gate, version: develop }
+    - { org: delphix, name: zfs,           version: develop }
+    - { org: delphix, name: cd-aidlc,      version: main }
+    - { org: delphix, name: git-utils,     version: main }
+  no_log: true
+
+- name: Reset clone URLs to SSH (strips the build-time bot token)
+  ansible.builtin.command:
+    cmd: >
+      git -C /export/home/delphix/src/{{ item.name }}
+      remote set-url origin git@github.com:{{ item.org }}/{{ item.name }}.git
+  loop:
+    - { org: delphix, name: dlpx-app-gate }
+    - { org: delphix, name: dms-core-gate }
+    - { org: delphix, name: zfs }
+    - { org: delphix, name: cd-aidlc }
+    - { org: delphix, name: git-utils }
+  no_log: true
+
+- name: Ensure ~delphix/src is owned by delphix:staff with group-write
+  ansible.builtin.file:
+    path: /export/home/delphix/src
+    state: directory
+    owner: delphix
+    group: staff
+    mode: "g+w"
+    recurse: true
+
+- name: Allow apt sources to be modified post-boot
+  ansible.builtin.copy:
+    dest: /etc/cloud/cloud.cfg.d/99-delphix-claude.cfg
+    mode: "0644"
+    content: |
+      apt:
+        preserve_sources_list: false
+
+- name: Add git-utils/bin to PATH for login shells
+  ansible.builtin.copy:
+    dest: /etc/profile.d/git-utils-path.sh
+    mode: "0644"
+    content: 'export PATH="$PATH:/export/home/delphix/src/git-utils/bin"'

--- a/live-build/misc/ansible-roles/appliance-build.claude-internal/tasks/main.yml
+++ b/live-build/misc/ansible-roles/appliance-build.claude-internal/tasks/main.yml
@@ -52,13 +52,19 @@
     opts: "defaults,_netdev"
     state: present
 
-- name: Install Claude CLI
-  ansible.builtin.shell: |
-    set -o pipefail
-    curl -fsSL https://claude.ai/install.sh | bash
+- name: Install curl, git, and Node.js
+  ansible.builtin.apt:
+    name:
+      - curl
+      - git
+      - nodejs
+      - npm
+    state: present
+
+- name: Install Claude CLI via npm
+  ansible.builtin.shell: npm install -g @anthropic-ai/claude-code
   args:
     creates: /usr/local/bin/claude
-    executable: /bin/bash
 
 - name: Create /export/home/delphix/src directory
   ansible.builtin.file:

--- a/live-build/variants/internal-claude/ansible/playbook.yml
+++ b/live-build/variants/internal-claude/ansible/playbook.yml
@@ -1,0 +1,26 @@
+#
+# Copyright 2018 Delphix
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+---
+- hosts: all
+  gather_facts: no
+  vars:
+    ansible_python_interpreter: /usr/bin/python3
+  roles:
+    - appliance-build.minimal-common
+    - appliance-build.minimal-internal
+    - appliance-build.minimal-development
+    - appliance-build.claude-internal

--- a/live-build/variants/internal-claude/ansible/roles
+++ b/live-build/variants/internal-claude/ansible/roles
@@ -1,0 +1,1 @@
+../../../misc/ansible-roles


### PR DESCRIPTION
<details open>
<summary><h2> Problem </h2></summary>

Developers working with Claude Code need a pre-configured appliance image that
is ready to use on first boot — with the Claude CLI installed, product repos
pre-cloned, and standard tooling wired up. Today there is no such image; each
developer must manually install and configure everything on a stock internal VM.
</details>

<details open>
<summary><h2> Solution </h2></summary>

Add a new `internal-claude` appliance variant (AWS-only) that layers a
`claude-internal` Ansible role on top of `minimal-common + minimal-internal +
minimal-development`. On first boot the VM provides:

- **Claude CLI** installed via npm (`/usr/local/bin/claude`)
- **Six product repos** pre-cloned under `~delphix/src/` at their configured
  branches, with remote URLs rewritten to SSH form (no build-time token on disk):
  - `delphix/dlpx-app-gate` @ `develop`
  - `delphix/dlpx-qa-gate` @ `develop`
  - `delphix/dms-core-gate` @ `develop`
  - `delphix/zfs` @ `develop`
  - `delphix/cd-aidlc` @ `main`
  - `delphix/git-utils` @ `main`
- **support-tools group** (gid 4000) with `delphix` as a member
- **NAS mount** at `/nas` via a systemd `nas.mount` unit
  (`After/Wants=network-online.target`); uses a unit file rather than
  `/etc/fstab` because `90-raw-disk-image.binary` overwrites fstab after the
  ansible chroot stage
- **apt sources** modifiable post-boot (cloud-init override in
  `/etc/cloud/cloud.cfg.d/99-delphix-claude.cfg`)
- **git-utils/bin** in the login shell PATH via `/etc/profile.d/`

Also fixes `80-build-configuration.binary` to use `trap cleanup EXIT` so
`/proc`, `/sys`, and `/dev` bind mounts are always torn down even when the
ansible playbook fails mid-run.

The build requires `GITHUB_TOKEN` to be set (asserted at the top of the role);
without it the build fails fast with a clear message.
</details>

<details open>
<summary><h2> Testing Done </h2></summary>

- `./gradlew buildInternalClaudeAws` succeeds with `GITHUB_TOKEN` set —
  produces `internal-claude-aws.{vmdk,debs.tar.gz,packages.list}`
- `./gradlew buildInternalClaudeAws` without `GITHUB_TOKEN` fails fast at the
  assertion task with the expected `fail_msg`
- `git-ab-pre-push -v internal-claude --no-tests` passed CI
  (appliance-build pre-push #13984, stage1 #62229)
- Boot-verify checks 4.1–4.10 all passed on a VM cloned from the produced AMI:
  - `claude --version` → `2.1.132 (Claude Code)`
  - All 6 repos present at correct branches with SSH remote URLs
  - `support-tools` gid 4000, `delphix` in group
  - `nas.mount` enabled, unit file correct
  - `99-delphix-claude.cfg` present with correct content
  - 61 GB free (> 50 GB)
  - `git-utils/bin` in PATH
  - No embedded credentials
  - No `~/.claude/settings.json`
</details>

<details>
<summary><h2> Future Work </h2></summary>

- Ship `~/.claude/settings.json` with "Generated with Claude" attribution
  defaults (deferred to a follow-on spec)
- Preload common build dependencies to speed up first use (out of scope)
</details>

JIRA: https://perforce.atlassian.net/browse/DLPX-97162