### PR TITLE
DLPX-86523 CIS: /home filesystem and mount options (with reworked upgrade migration)

### DIFF
--- a/live-build/config/hooks/vm-artifacts/90-raw-disk-image.binary
+++ b/live-build/config/hooks/vm-artifacts/90-raw-disk-image.binary
@@ -1,6 +1,6 @@
 #!/bin/bash -ex
 #
-# Copyright 2018 Delphix
+# Copyright 2018, 2026 Delphix
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -274,8 +274,8 @@ zfs create \
 # contents. During normal boot up, we'll rely on "/etc/fstab" to handle
 # these mounts.
 #
-mkdir -p "$DIRECTORY/export/home"
-mount -t zfs "$FSNAME/ROOT/$FSNAME/home" "$DIRECTORY/export/home"
+mkdir -p "$DIRECTORY/home"
+mount -t zfs "$FSNAME/ROOT/$FSNAME/home" "$DIRECTORY/home"
 
 mkdir -p "$DIRECTORY/var/delphix"
 mount -t zfs "$FSNAME/ROOT/$FSNAME/data" "$DIRECTORY/var/delphix"
@@ -314,7 +314,7 @@ rsync --info=stats3 -WaAX binary/* "$DIRECTORY/"
 # automatically whenever we boot into the crash kernel.
 #
 cat <<-EOF >"$DIRECTORY/etc/fstab"
-	rpool/ROOT/$FSNAME/home /export/home zfs defaults,x-systemd.before=zfs-import-cache.service 0 0
+	rpool/ROOT/$FSNAME/home /home zfs defaults,nodev,nosuid,x-systemd.before=zfs-import-cache.service 0 0
 	rpool/ROOT/$FSNAME/data /var/delphix zfs defaults,x-systemd.before=zfs-import-cache.service 0 0
 	rpool/ROOT/$FSNAME/log  /var/log     zfs defaults,x-systemd.before=zfs-import-cache.service 0 0
 	rpool/ROOT/$FSNAME/tmp  /tmp     zfs defaults,nosuid,nodev,exec,x-systemd.before=zfs-import-cache.service 0 0
@@ -440,7 +440,7 @@ done
 
 umount "$DIRECTORY/var/log"
 umount "$DIRECTORY/var/delphix"
-umount "$DIRECTORY/export/home"
+umount "$DIRECTORY/home"
 umount "$DIRECTORY/tmp"
 umount "$DIRECTORY/var/tmp"
 umount "/var/crash"

--- a/live-build/misc/ansible-roles/appliance-build.delphix-ldap/tasks/main.yml
+++ b/live-build/misc/ansible-roles/appliance-build.delphix-ldap/tasks/main.yml
@@ -63,10 +63,6 @@
     group: root
     mode: 0755
 
-- lineinfile:
-    dest: etc/auto.master
-    line: "/home   auto_home    -nobrowse"
-
 - copy:
     src: 80-internal-ldap
     dest: /etc/sudoers.d/

--- a/live-build/misc/ansible-roles/appliance-build.masking-development/tasks/main.yml
+++ b/live-build/misc/ansible-roles/appliance-build.masking-development/tasks/main.yml
@@ -1,5 +1,5 @@
 #
-# Copyright 2018 Delphix
+# Copyright 2018, 2026 Delphix
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -26,14 +26,14 @@
 - git:
     repo: "https://{{ lookup('env', 'GITHUB_TOKEN') }}@github.com/delphix/dms-core-gate.git"
     dest:
-      "/export/home/delphix/dms-core-gate"
+      "/home/delphix/dms-core-gate"
     version: "develop"
     accept_hostkey: yes
     update: no
   when: lookup('env', 'GITHUB_TOKEN') != ''
 
 - file:
-    path: "/export/home/delphix/{{ item }}"
+    path: "/home/delphix/{{ item }}"
     owner: delphix
     group: staff
     mode: "g+w"

--- a/live-build/misc/ansible-roles/appliance-build.minimal-common/tasks/main.yml
+++ b/live-build/misc/ansible-roles/appliance-build.minimal-common/tasks/main.yml
@@ -1,5 +1,5 @@
 #
-# Copyright 2018 Delphix
+# Copyright 2018, 2026 Delphix
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -26,7 +26,7 @@
   no_log: true
 
 - file:
-    path: /export/home
+    path: /home
     state: directory
     mode: 0755
 
@@ -39,7 +39,7 @@
     shell: /bin/bash
     create_home: yes
     comment: Delphix User
-    home: /export/home/delphix
+    home: /home/delphix
     password:
       "{{ lookup('env', 'APPLIANCE_PASSWORD') | password_hash('sha512') }}"
 

--- a/live-build/misc/ansible-roles/appliance-build.minimal-internal/tasks/main.yml
+++ b/live-build/misc/ansible-roles/appliance-build.minimal-internal/tasks/main.yml
@@ -34,6 +34,7 @@
   ansible.builtin.pip:
     name: awscli
     break_system_packages: true
+    extra_args: --no-cache-dir
   become: true
 
 # Add /usr/local/bin to the PATH (awscli needs it)

--- a/live-build/misc/ansible-roles/appliance-build.unittest-internal/tasks/main.yml
+++ b/live-build/misc/ansible-roles/appliance-build.unittest-internal/tasks/main.yml
@@ -94,7 +94,7 @@
 - user:
     name: testrunner
     comment: "Delphix"
-    home: /export/home/testrunner
+    home: /home/testrunner
     groups: docker
     password:
       "$6$pWQE0MPZWgue7fNC$8RvR0u04Mt67792b.x4ao0G2Z/H/hrYPWezOqCkz59MIA\

--- a/live-build/misc/ansible-roles/appliance-build.virtualization-development/tasks/main.yml
+++ b/live-build/misc/ansible-roles/appliance-build.virtualization-development/tasks/main.yml
@@ -1,5 +1,5 @@
 #
-# Copyright 2018 Delphix
+# Copyright 2018, 2026 Delphix
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -73,14 +73,14 @@
 
 - git:
     repo: "https://{{ lookup('env', 'GITHUB_TOKEN') }}@github.com/delphix/dlpx-app-gate.git"
-    dest: "/export/home/delphix/dlpx-app-gate"
+    dest: "/home/delphix/dlpx-app-gate"
     version: "develop"
     accept_hostkey: yes
     update: no
   when: lookup('env', 'GITHUB_TOKEN') != ''
 
 - file:
-    path: "/export/home/delphix/{{ item }}"
+    path: "/home/delphix/{{ item }}"
     owner: delphix
     group: staff
     mode: "g+w"

--- a/live-build/misc/ansible-roles/appliance-build.zfsonlinux-development/tasks/main.yml
+++ b/live-build/misc/ansible-roles/appliance-build.zfsonlinux-development/tasks/main.yml
@@ -1,5 +1,5 @@
 #
-# Copyright 2018 Delphix
+# Copyright 2018, 2026 Delphix
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -67,26 +67,26 @@
 - git:
     repo: "https://{{ lookup('env', 'GITHUB_TOKEN') }}@github.com/delphix/zfs.git"
     dest:
-      "/export/home/delphix/zfs"
+      "/home/delphix/zfs"
     version: develop
     accept_hostkey: yes
     update: no
   when: lookup('env', 'GITHUB_TOKEN') != ''
 
 - file:
-    path: "/export/home/delphix/zfs"
+    path: "/home/delphix/zfs"
     owner: delphix
     group: staff
     state: directory
     recurse: yes
 
 - file:
-    path: "/export/home/delphix/.cargo/"
+    path: "/home/delphix/.cargo/"
     state: directory
     owner: delphix
     group: staff
 - copy:
-    dest: "/export/home/delphix/.cargo/config.toml"
+    dest: "/home/delphix/.cargo/config.toml"
     content: |
         [target.x86_64-unknown-linux-gnu]
         rustflags = ["-C", "link-arg=-B/usr/libexec/mold"]

--- a/upgrade/FAQ.md
+++ b/upgrade/FAQ.md
@@ -89,7 +89,7 @@ resemble the following:
 
 A "rootfs container" is a collection of ZFS datasets that can be used as
 the "root filesytsem" of the appliance. This includes a dataset for "/"
-of the appliance, but also seperate datasets for "/export/home" and
+of the appliance, but also seperate datasets for "/home" and
 "/var/delphix".
 
 Here's an example of the datasets for a rootfs container:

--- a/upgrade/upgrade-scripts/common.sh
+++ b/upgrade/upgrade-scripts/common.sh
@@ -529,3 +529,88 @@ function fix_and_migrate_services() {
 		telegraf.service
 	EOF
 }
+
+#
+# Home directories were historically mounted at /export/home. For CIS
+# compliance, the home dataset is now mounted at /home instead. This
+# function migrates an engine that is being upgraded in place from the
+# old layout to the new one.
+#
+# The home dataset uses a legacy ZFS mountpoint, so /etc/fstab controls
+# where it is mounted. We repoint the home dataset's fstab entry and any
+# affected /etc/passwd home directory from /export/home to /home, then
+# mount the dataset at /home.
+#
+# The pre-existing /export/home mount is intentionally left in place: the
+# dataset stays mounted at both /export/home and /home until the next
+# reboot. This avoids disrupting processes that hold /export/home open and
+# prevents a busy unmount from failing the upgrade. After a reboot only
+# /home is mounted, since /export/home is no longer present in fstab.
+#
+# The function is idempotent. If /etc/fstab no longer maps the home
+# dataset to /export/home -- because the engine was already migrated, or
+# the image was built to use /home -- it returns without making changes.
+# This also makes it a harmless no-op inside an upgrade container, whose
+# fstab is generated with the /home mountpoint already.
+#
+function migrate_export_home_to_home() {
+	#
+	# Identify the home dataset's fstab entry: a "<pool>/.../home"
+	# source mounted at /export/home. If it is absent, there is
+	# nothing to migrate.
+	#
+	if ! grep -qE '^[^#]*/home[[:space:]]+/export/home[[:space:]]' /etc/fstab; then
+		return
+	fi
+
+	#
+	# Repoint only the home dataset's mountpoint field, leaving every
+	# other fstab entry (and any comments) untouched.
+	#
+	sed -i -E \
+		'/^[^#]*\/home[[:space:]]+\/export\/home[[:space:]]/ s|/export/home|/home|' \
+		/etc/fstab ||
+		die "failed to update home mountpoint in /etc/fstab"
+
+	#
+	# Repoint the home-directory field (field 6) of any user whose home
+	# lived under /export/home, so logins resolve to the new location.
+	#
+	sed -i -E \
+		's|^([^:]*:[^:]*:[^:]*:[^:]*:[^:]*:)/export/home|\1/home|' \
+		/etc/passwd ||
+		die "failed to update home directories in /etc/passwd"
+
+	#
+	# Mount the home dataset at its new /home location. The existing
+	# /export/home mount is deliberately left mounted until reboot.
+	#
+	mkdir -p /home || die "failed to create /home mountpoint"
+	mount /home || die "failed to mount /home"
+}
+
+#
+# Ensure the /home entry in /etc/fstab carries the nodev and nosuid mount
+# options, required for CIS compliance on systems being upgraded that
+# predate this hardening. This is idempotent and a no-op where the options
+# are already present (fresh installs and upgrade containers set them via
+# their fstab templates), so it is safe to call regardless of context.
+#
+function harden_home_mount_options() {
+	#
+	# Nothing to do if there is no /home entry in /etc/fstab.
+	#
+	grep -qE '^[^#].*[[:space:]]/home[[:space:]]' /etc/fstab || return
+
+	#
+	# Nothing to do if both options are already present.
+	#
+	if grep -qE '^[^#].*[[:space:]]/home[[:space:]].*nodev' /etc/fstab &&
+		grep -qE '^[^#].*[[:space:]]/home[[:space:]].*nosuid' /etc/fstab; then
+		return
+	fi
+
+	sed -i '/^[^#].*[[:space:]]\/home[[:space:]]/ s/defaults/defaults,nodev,nosuid/' \
+		/etc/fstab ||
+		die "failed to add nodev,nosuid to /home entry in /etc/fstab"
+}

--- a/upgrade/upgrade-scripts/execute
+++ b/upgrade/upgrade-scripts/execute
@@ -752,6 +752,25 @@ if ! systemd-detect-virt -qc; then
 		die "failed to set-bootfs '$ROOTFS_CONTAINER'"
 fi
 
+#
+# Migrate the home dataset's mountpoint from /export/home to /home for
+# engines upgrading from a release that predates this change. The function
+# (in common.sh) self-guards on the fstab entry: it is a no-op unless the
+# home dataset is still mapped to /export/home, which only happens on an
+# in-place upgrade of a pre-change engine (fresh installs and upgrade
+# containers already use /home). It must run before the nodev/nosuid block
+# below, which hardens the /home fstab entry this migration creates.
+#
+migrate_export_home_to_home
+
+#
+# Harden the /home mount options (nodev,nosuid) in /etc/fstab for CIS
+# compliance. The function (in common.sh) self-guards and is a no-op where
+# the options are already present; it must run after the migration above
+# creates the /home entry.
+#
+harden_home_mount_options
+
 systemctl reload delphix-platform.service ||
 	die "failed to reload delphix-platform.service"
 

--- a/upgrade/upgrade-scripts/upgrade-container
+++ b/upgrade/upgrade-scripts/upgrade-container
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright 2018, 2025 Delphix
+# Copyright 2018, 2026 Delphix
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -177,7 +177,7 @@ function create_upgrade_container() {
 		-o mountpoint=legacy \
 		"$ROOTFS_DATASET/home@$SNAPSHOT_NAME" \
 		"rpool/ROOT/$CONTAINER/home" ||
-		die "failed to create upgrade /export/home clone"
+		die "failed to create upgrade /home clone"
 
 	zfs clone \
 		-o mountpoint=legacy \
@@ -213,7 +213,7 @@ function create_upgrade_container() {
 	# before the zfs-import service is run.
 	#
 	cat <<-EOF >"$DIRECTORY/etc/fstab"
-		rpool/ROOT/$CONTAINER/home /export/home zfs defaults,x-systemd.before=zfs-import-cache.service 0 0
+		rpool/ROOT/$CONTAINER/home /home zfs defaults,nodev,nosuid,x-systemd.before=zfs-import-cache.service 0 0
 		rpool/ROOT/$CONTAINER/data /var/delphix zfs defaults,x-systemd.before=zfs-import-cache.service 0 0
 		rpool/ROOT/$CONTAINER/log  /var/log     zfs defaults,x-systemd.before=zfs-import-cache.service 0 0
 		rpool/crashdump            /var/crash   zfs defaults,x-systemd.before=zfs-import-cache.service,x-systemd.before=kdump-tools.service 0 0


### PR DESCRIPTION
<details open>
<summary><h2> Background </h2></summary>

Consolidates the CIS `/home` work into two commits on `develop`:

1. **`DLPX-86523 CIS: /home filesystem and mount options`** — a squash of #756 (authored by Sanjeev), unchanged in intent: mount the home ZFS dataset at `/home` instead of `/export/home`, with `nodev,nosuid` on the `/home` fstab entry (build-side fstab, `upgrade-container` template, ansible path updates, and the upgrade `execute` changes).
2. **`DLPX-86523 Re-implement /home upgrade migration; drop dev-only autofs /home`** — our changes on top (see Solution).

(Supersedes the earlier stacked-on-#756 form of this PR.)
</details>

<details open>
<summary><h2> Problem </h2></summary>

#756's upgrade migration ran inline near the top of `execute` using a whole-file `sed 's|/export/home|/home|g'` on `/etc/fstab` and `/etc/passwd` (broad; runs before package maintainer scripts settle `/etc/passwd`). Separately, on dev images `/home` is an autofs automount (`auto_home`, added by the `delphix-ldap` role); mounting the home dataset at `/home` collides with it.
</details>

<details open>
<summary><h2> Solution </h2></summary>

Commit 2 reworks the upgrade path:

- **`common.sh`** — idempotent `migrate_export_home_to_home()`: targeted `/etc/fstab` mountpoint rewrite (home dataset line only) and targeted `/etc/passwd` field-6 rewrite, then `mkdir -p /home` + `mount /home`, leaving the old `/export/home` mount live until reboot. Self-guards on the fstab entry → no-op once migrated or inside an already-`/home` upgrade container.
- **`execute`** — replace #756's inline block with a single guarded call placed late (after the package phase and `set-bootfs`, before the `nodev,nosuid` block that hardens the `/home` entry it creates).
- **`delphix-ldap`** — stop adding `/home auto_home -nobrowse`. This dev-only autofs map reasserts `/home` on its timeout, shadowing the dataset and breaking home-dir access / SSH login. Customer variants never applied it, so no upgrade-migration handling is needed.
</details>

<details open>
<summary><h2> Testing Done </h2></summary>

**Static:** `shellcheck` (`-e SC1090 -e SC1091 -e SC2329`) and `shfmt` clean on `common.sh`/`execute`; `bash -n` clean. sed transforms verified on representative `fstab`/`passwd` samples.

**On-engine (dcoa `dlpx-develop`, `2026.4.0.0`):**
- ✅ Migration function in isolation — fstab/passwd repointed, dataset mounted at both `/home` and `/export/home`.
- ✅ **autofs conflict** found and fixed (the `delphix-ldap` change); validated `/home` stable across reboot once removed.
- ✅ **In-place upgrade** (`upgrade -v deferred`, exit 0) + reboot — fstab→`/home`, passwd→`/home/delphix`, dual-mount pre-reboot, single `/home` zfs mount post-reboot, home contents intact, SSH login works.
- ✅ **Idempotency** — re-run is a no-op, `/etc/fstab`+`/etc/passwd` byte-identical.
- 🟡 **Full build + upgrade-from 2026.3.0.0** (covers not-in-place on a branch-built image): `ab-pre-push` build in progress — result posted in comments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)