### PR TITLE
DLPX-86523 CIS: /home filesystem and mount options

### DIFF
--- a/live-build/config/hooks/vm-artifacts/90-raw-disk-image.binary
+++ b/live-build/config/hooks/vm-artifacts/90-raw-disk-image.binary
@@ -1,6 +1,6 @@
 #!/bin/bash -ex
 #
-# Copyright 2018 Delphix
+# Copyright 2018, 2026 Delphix
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -274,8 +274,8 @@ zfs create \
 # contents. During normal boot up, we'll rely on "/etc/fstab" to handle
 # these mounts.
 #
-mkdir -p "$DIRECTORY/export/home"
-mount -t zfs "$FSNAME/ROOT/$FSNAME/home" "$DIRECTORY/export/home"
+mkdir -p "$DIRECTORY/home"
+mount -t zfs "$FSNAME/ROOT/$FSNAME/home" "$DIRECTORY/home"
 
 mkdir -p "$DIRECTORY/var/delphix"
 mount -t zfs "$FSNAME/ROOT/$FSNAME/data" "$DIRECTORY/var/delphix"
@@ -314,7 +314,7 @@ rsync --info=stats3 -WaAX binary/* "$DIRECTORY/"
 # automatically whenever we boot into the crash kernel.
 #
 cat <<-EOF >"$DIRECTORY/etc/fstab"
-	rpool/ROOT/$FSNAME/home /export/home zfs defaults,x-systemd.before=zfs-import-cache.service 0 0
+	rpool/ROOT/$FSNAME/home /home zfs defaults,nodev,nosuid,x-systemd.before=zfs-import-cache.service 0 0
 	rpool/ROOT/$FSNAME/data /var/delphix zfs defaults,x-systemd.before=zfs-import-cache.service 0 0
 	rpool/ROOT/$FSNAME/log  /var/log     zfs defaults,x-systemd.before=zfs-import-cache.service 0 0
 	rpool/ROOT/$FSNAME/tmp  /tmp     zfs defaults,nosuid,nodev,exec,x-systemd.before=zfs-import-cache.service 0 0
@@ -440,7 +440,7 @@ done
 
 umount "$DIRECTORY/var/log"
 umount "$DIRECTORY/var/delphix"
-umount "$DIRECTORY/export/home"
+umount "$DIRECTORY/home"
 umount "$DIRECTORY/tmp"
 umount "$DIRECTORY/var/tmp"
 umount "/var/crash"

--- a/live-build/misc/ansible-roles/appliance-build.delphix-ldap/tasks/main.yml
+++ b/live-build/misc/ansible-roles/appliance-build.delphix-ldap/tasks/main.yml
@@ -63,10 +63,6 @@
     group: root
     mode: 0755
 
-- lineinfile:
-    dest: etc/auto.master
-    line: "/home   auto_home    -nobrowse"
-
 - copy:
     src: 80-internal-ldap
     dest: /etc/sudoers.d/

--- a/live-build/misc/ansible-roles/appliance-build.masking-development/tasks/main.yml
+++ b/live-build/misc/ansible-roles/appliance-build.masking-development/tasks/main.yml
@@ -1,5 +1,5 @@
 #
-# Copyright 2018 Delphix
+# Copyright 2018, 2026 Delphix
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -26,14 +26,14 @@
 - git:
     repo: "https://{{ lookup('env', 'GITHUB_TOKEN') }}@github.com/delphix/dms-core-gate.git"
     dest:
-      "/export/home/delphix/dms-core-gate"
+      "/home/delphix/dms-core-gate"
     version: "develop"
     accept_hostkey: yes
     update: no
   when: lookup('env', 'GITHUB_TOKEN') != ''
 
 - file:
-    path: "/export/home/delphix/{{ item }}"
+    path: "/home/delphix/{{ item }}"
     owner: delphix
     group: staff
     mode: "g+w"

--- a/live-build/misc/ansible-roles/appliance-build.minimal-common/tasks/main.yml
+++ b/live-build/misc/ansible-roles/appliance-build.minimal-common/tasks/main.yml
@@ -1,5 +1,5 @@
 #
-# Copyright 2018 Delphix
+# Copyright 2018, 2026 Delphix
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -26,7 +26,7 @@
   no_log: true
 
 - file:
-    path: /export/home
+    path: /home
     state: directory
     mode: 0755
 
@@ -39,7 +39,7 @@
     shell: /bin/bash
     create_home: yes
     comment: Delphix User
-    home: /export/home/delphix
+    home: /home/delphix
     password:
       "{{ lookup('env', 'APPLIANCE_PASSWORD') | password_hash('sha512') }}"
 

--- a/live-build/misc/ansible-roles/appliance-build.minimal-internal/tasks/main.yml
+++ b/live-build/misc/ansible-roles/appliance-build.minimal-internal/tasks/main.yml
@@ -34,6 +34,7 @@
   ansible.builtin.pip:
     name: awscli
     break_system_packages: true
+    extra_args: --no-cache-dir
   become: true
 
 # Add /usr/local/bin to the PATH (awscli needs it)

--- a/live-build/misc/ansible-roles/appliance-build.unittest-internal/tasks/main.yml
+++ b/live-build/misc/ansible-roles/appliance-build.unittest-internal/tasks/main.yml
@@ -94,7 +94,7 @@
 - user:
     name: testrunner
     comment: "Delphix"
-    home: /export/home/testrunner
+    home: /home/testrunner
     groups: docker
     password:
       "$6$pWQE0MPZWgue7fNC$8RvR0u04Mt67792b.x4ao0G2Z/H/hrYPWezOqCkz59MIA\

--- a/live-build/misc/ansible-roles/appliance-build.virtualization-development/tasks/main.yml
+++ b/live-build/misc/ansible-roles/appliance-build.virtualization-development/tasks/main.yml
@@ -1,5 +1,5 @@
 #
-# Copyright 2018 Delphix
+# Copyright 2018, 2026 Delphix
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -73,14 +73,14 @@
 
 - git:
     repo: "https://{{ lookup('env', 'GITHUB_TOKEN') }}@github.com/delphix/dlpx-app-gate.git"
-    dest: "/export/home/delphix/dlpx-app-gate"
+    dest: "/home/delphix/dlpx-app-gate"
     version: "develop"
     accept_hostkey: yes
     update: no
   when: lookup('env', 'GITHUB_TOKEN') != ''
 
 - file:
-    path: "/export/home/delphix/{{ item }}"
+    path: "/home/delphix/{{ item }}"
     owner: delphix
     group: staff
     mode: "g+w"

--- a/live-build/misc/ansible-roles/appliance-build.zfsonlinux-development/tasks/main.yml
+++ b/live-build/misc/ansible-roles/appliance-build.zfsonlinux-development/tasks/main.yml
@@ -1,5 +1,5 @@
 #
-# Copyright 2018 Delphix
+# Copyright 2018, 2026 Delphix
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -67,26 +67,26 @@
 - git:
     repo: "https://{{ lookup('env', 'GITHUB_TOKEN') }}@github.com/delphix/zfs.git"
     dest:
-      "/export/home/delphix/zfs"
+      "/home/delphix/zfs"
     version: develop
     accept_hostkey: yes
     update: no
   when: lookup('env', 'GITHUB_TOKEN') != ''
 
 - file:
-    path: "/export/home/delphix/zfs"
+    path: "/home/delphix/zfs"
     owner: delphix
     group: staff
     state: directory
     recurse: yes
 
 - file:
-    path: "/export/home/delphix/.cargo/"
+    path: "/home/delphix/.cargo/"
     state: directory
     owner: delphix
     group: staff
 - copy:
-    dest: "/export/home/delphix/.cargo/config.toml"
+    dest: "/home/delphix/.cargo/config.toml"
     content: |
         [target.x86_64-unknown-linux-gnu]
         rustflags = ["-C", "link-arg=-B/usr/libexec/mold"]

--- a/upgrade/FAQ.md
+++ b/upgrade/FAQ.md
@@ -89,7 +89,7 @@ resemble the following:
 
 A "rootfs container" is a collection of ZFS datasets that can be used as
 the "root filesytsem" of the appliance. This includes a dataset for "/"
-of the appliance, but also seperate datasets for "/export/home" and
+of the appliance, but also seperate datasets for "/home" and
 "/var/delphix".
 
 Here's an example of the datasets for a rootfs container:

--- a/upgrade/upgrade-scripts/common.sh
+++ b/upgrade/upgrade-scripts/common.sh
@@ -529,3 +529,99 @@ function fix_and_migrate_services() {
 		telegraf.service
 	EOF
 }
+
+#
+# Home directories were historically mounted at /export/home. For CIS
+# compliance, the home dataset is now mounted at /home instead. This
+# function migrates an engine that is being upgraded in place from the
+# old layout to the new one.
+#
+# The home dataset uses a legacy ZFS mountpoint, so /etc/fstab controls
+# where it is mounted. We repoint the home dataset's fstab entry and any
+# affected /etc/passwd home directory from /export/home to /home, then
+# mount the dataset at /home.
+#
+# The pre-existing /export/home mount is intentionally left in place: the
+# dataset stays mounted at both /export/home and /home until the next
+# reboot. This avoids disrupting processes that hold /export/home open and
+# prevents a busy unmount from failing the upgrade. After a reboot only
+# /home is mounted, since /export/home is no longer present in fstab.
+#
+# The function is idempotent. If /etc/fstab no longer maps the home
+# dataset to /export/home -- because the engine was already migrated, or
+# the image was built to use /home -- it returns without making changes.
+# This also makes it a harmless no-op inside an upgrade container, whose
+# fstab is generated with the /home mountpoint already.
+#
+function migrate_export_home_to_home() {
+	#
+	# Identify the home dataset's fstab entry: a "<pool>/.../home"
+	# source mounted at /export/home. If it is absent, there is
+	# nothing to migrate.
+	#
+	if ! grep -qE '^[^#]*/home[[:space:]]+/export/home[[:space:]]' /etc/fstab; then
+		return
+	fi
+
+	#
+	# Repoint only the home dataset's mountpoint field, leaving every
+	# other fstab entry (and any comments) untouched.
+	#
+	sed -i -E \
+		'/^[^#]*\/home[[:space:]]+\/export\/home[[:space:]]/ s|/export/home|/home|' \
+		/etc/fstab ||
+		die "failed to update home mountpoint in /etc/fstab"
+
+	#
+	# Repoint the home-directory field (field 6) of any user whose home
+	# lived under /export/home, so logins resolve to the new location.
+	#
+	sed -i -E \
+		's|^([^:]*:[^:]*:[^:]*:[^:]*:[^:]*:)/export/home(/[^:]*)?:|\1/home\2:|' \
+		/etc/passwd ||
+		die "failed to update home directories in /etc/passwd"
+
+	#
+	# Mount the home dataset at its new /home location. The existing
+	# /export/home mount is deliberately left mounted until reboot.
+	#
+	mkdir -p /home || die "failed to create /home mountpoint"
+	mount /home || die "failed to mount /home"
+}
+
+#
+# Ensure the /home entry in /etc/fstab carries the nodev and nosuid mount
+# options, required for CIS compliance on systems being upgraded that
+# predate this hardening. This is idempotent and a no-op where the options
+# are already present (fresh installs and upgrade containers set them via
+# their fstab templates), so it is safe to call regardless of context.
+#
+function harden_home_mount_options() {
+	#
+	# Nothing to do if there is no /home entry in /etc/fstab.
+	#
+	grep -qE '^[^#].*[[:space:]]/home[[:space:]]' /etc/fstab || return
+
+	#
+	# Nothing to do if both options are already present.
+	#
+	if grep -qE '^[^#].*[[:space:]]/home[[:space:]].*nodev' /etc/fstab &&
+		grep -qE '^[^#].*[[:space:]]/home[[:space:]].*nosuid' /etc/fstab; then
+		return
+	fi
+
+	sed -i '/^[^#].*[[:space:]]\/home[[:space:]]/ s/defaults/defaults,nodev,nosuid/' \
+		/etc/fstab ||
+		die "failed to add nodev,nosuid to /home entry in /etc/fstab"
+
+	#
+	# Verify the options were actually applied. The substitution above
+	# relies on the /home entry carrying the "defaults" token; if a
+	# hand-edited fstab lacks it, the sed would be a no-op and silently
+	# leave this CIS control unsatisfied. Fail loudly instead.
+	#
+	if ! { grep -qE '^[^#].*[[:space:]]/home[[:space:]].*nodev' /etc/fstab &&
+		grep -qE '^[^#].*[[:space:]]/home[[:space:]].*nosuid' /etc/fstab; }; then
+		die "failed to add nodev,nosuid to /home entry in /etc/fstab"
+	fi
+}

--- a/upgrade/upgrade-scripts/execute
+++ b/upgrade/upgrade-scripts/execute
@@ -265,6 +265,25 @@ if compare_versions "$CURRENT_VERSION" lt "2025.6.0.0-0"; then
 fi
 
 #
+# Migrate the home dataset's mountpoint from /export/home to /home, and
+# harden it with nodev,nosuid, for engines upgrading from a release that
+# predates this change.
+#
+# This must run *before* the package phase below. Package maintainer
+# scripts (e.g. the delphix-platform postinst) now operate in terms of
+# /home, so the home dataset must already be mounted there by the time they
+# run; otherwise they would create/modify content under a /home directory on
+# the root filesystem that the dataset mount later shadows.
+#
+# Both functions (in common.sh) self-guard and are no-ops once the engine
+# already uses /home -- i.e. on fresh installs and inside upgrade
+# containers, whose fstab maps the dataset to /home. migrate must run before
+# harden, which hardens the /home fstab entry the migration creates.
+#
+migrate_export_home_to_home
+harden_home_mount_options
+
+#
 # When an upgrade gets interrupted while it’s in the middle of upgrading
 # packages, the package manager can get into a state where “dpkg --configure -a”
 # needs to be manually run to enable the upgrade to be restarted.

--- a/upgrade/upgrade-scripts/upgrade-container
+++ b/upgrade/upgrade-scripts/upgrade-container
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright 2018, 2025 Delphix
+# Copyright 2018, 2026 Delphix
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -177,7 +177,7 @@ function create_upgrade_container() {
 		-o mountpoint=legacy \
 		"$ROOTFS_DATASET/home@$SNAPSHOT_NAME" \
 		"rpool/ROOT/$CONTAINER/home" ||
-		die "failed to create upgrade /export/home clone"
+		die "failed to create upgrade /home clone"
 
 	zfs clone \
 		-o mountpoint=legacy \
@@ -213,7 +213,7 @@ function create_upgrade_container() {
 	# before the zfs-import service is run.
 	#
 	cat <<-EOF >"$DIRECTORY/etc/fstab"
-		rpool/ROOT/$CONTAINER/home /export/home zfs defaults,x-systemd.before=zfs-import-cache.service 0 0
+		rpool/ROOT/$CONTAINER/home /home zfs defaults,nodev,nosuid,x-systemd.before=zfs-import-cache.service 0 0
 		rpool/ROOT/$CONTAINER/data /var/delphix zfs defaults,x-systemd.before=zfs-import-cache.service 0 0
 		rpool/ROOT/$CONTAINER/log  /var/log     zfs defaults,x-systemd.before=zfs-import-cache.service 0 0
 		rpool/crashdump            /var/crash   zfs defaults,x-systemd.before=zfs-import-cache.service,x-systemd.before=kdump-tools.service 0 0


### PR DESCRIPTION
<details open>
<summary><h2> Problem </h2></summary>

The appliance's home ZFS dataset is mounted at `/export/home`, without the `nodev` or
`nosuid` mount options. CIS requires a dedicated `/home` filesystem carrying those
options, so the current layout fails the relevant controls for the `/home` partition
and its mount options.
</details>

<details open>
<summary><h2> Solution </h2></summary>

The solution taken in this PR is to mount the home dataset at `/home`, with
`nodev,nosuid`, on both fresh installs and in-place upgrades.

**Fresh installs / build:**
- Create and mount the home dataset at `/home` (raw-disk-image hook and
  upgrade-container template), with `nodev,nosuid` on the `/home` fstab entry.
- Update ansible roles and the FAQ for the new path, and set the `delphix` user's home
  to `/home/delphix`.

**In-place upgrades** (`upgrade/upgrade-scripts`):
- `migrate_export_home_to_home()` (`common.sh`) repoints the home dataset's
  `/etc/fstab` entry, and any affected `/etc/passwd` home directories, from
  `/export/home` to `/home`, then mounts `/home`. The pre-existing `/export/home`
  mount is left live until the next reboot, so running processes that hold it open are
  not disrupted and a busy unmount cannot fail the upgrade. The function self-guards on
  the fstab entry, so it is a no-op once migrated, and on systems that already use
  `/home`.
- `harden_home_mount_options()` (`common.sh`) ensures the `/home` fstab entry carries
  `nodev,nosuid`. It is idempotent.
- `execute` calls both functions before the package phase, so package maintainer
  scripts (e.g. the `delphix-platform` `postinst`) operate on the home dataset already
  mounted at `/home`, rather than on a `/home` directory on the root filesystem that
  the dataset mount would later shadow. The migration runs before the hardening, which
  depends on the `/home` entry the migration creates. Neither call is host-only. The
  functions self-guard and no-op inside upgrade containers.

**Dev images:**
- The `delphix-ldap` role (internal-dev / internal-dcenter only) no longer adds the
  `/home auto_home -nobrowse` autofs map. With the home dataset at `/home`, that
  automount reasserts `/home` on its timeout, shadowing the dataset and breaking
  home-directory access and SSH login. Customer variants never applied it.
</details>

<details open>
<summary><h2> Companion change </h2></summary>

This must land together with two companion PRs that move the remaining `/export/home`
references to `/home`:

- delphix/delphix-platform#565 moves the `delphix` user's home directory (and
  `.bashrc`) from `/export/home/delphix` to `/home/delphix` in the `delphix-platform`
  package. Without it, the `internal-dev` image build fails sourcing
  `/export/home/delphix/.bashrc`.
- delphix/dlpx-app-gate#4346 repoints the remaining runtime/build `/export/home`
  references to `/home`, most notably the `cli` user's home (`/home/cli`) and the
  `sshd_config` `AuthorizedKeysFile` path in `appliance/packaging/postinst`.

Because that `postinst` now operates in terms of `/home`, the home-dataset migration
runs before the package phase (see Solution above), so the dataset is mounted at
`/home` by the time those maintainer scripts run.
</details>

<details open>
<summary><h2> Testing Done </h2></summary>

**Static:** `shellcheck` (`-e SC1090 -e SC1091 -e SC2329`), `shfmt`, and `bash -n`
clean on `common.sh` and `execute`. The `sed` transforms were verified against
representative `fstab` and `passwd` samples, including boundary cases such as
`/export/home2/...`, which must not be rewritten.

**On-engine** (dcoa `dlpx-develop`, `2026.4.0.0`, with the autofs `/home` map removed
to mirror the fixed config):
- Migration function in isolation: `/etc/fstab` and `/etc/passwd` repointed to `/home`,
  dataset mounted at both `/home` and `/export/home`.
- In-place upgrade (`upgrade -v deferred`, exit 0) followed by reboot: fstab to
  `/home`, passwd to `/home/delphix`, dual-mount pre-reboot, a single `/home` zfs mount
  after reboot, home-directory contents intact, SSH login works.
- Idempotency: re-running the migration is a no-op (`/etc/fstab` and `/etc/passwd`
  byte-identical).
- The `/home` autofs conflict surfaced here, and was fixed (the `delphix-ldap` change);
  `/home` is stable across reboot once the map is removed.

**Full build and end-to-end upgrade:** `git ab-pre-push` with this branch plus both
companion PRs (delphix-platform#565 and dlpx-app-gate#4346, via `--extra-repo`), and
upgrade testing:
- [appliance-build-orchestrator-pre-push #14210](https://selfservice-jenkins.eng-tools-prd.aws.delphixcloud.com/job/appliance-build-orchestrator-pre-push/14210/) (in progress)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
