### PR TITLE
DLPX-97495 prevent delphix-mgmt auto-restart during package upgrade

### DIFF
--- a/upgrade/upgrade-scripts/common.sh
+++ b/upgrade/upgrade-scripts/common.sh
@@ -424,6 +424,65 @@ function should_mask_service() {
 }
 
 #
+# DLPX-97495: admin-owned drop-in (under /etc/systemd/system, so the delphix-mgmt
+# package upgrade cannot clobber it) used to disarm delphix-mgmt's restart during
+# a package upgrade. See disarm_mgmt_restart() / rearm_mgmt_restart() below.
+#
+MGMT_RESTART_DROPIN_DIR=/etc/systemd/system/delphix-mgmt.service.d
+MGMT_RESTART_DROPIN_FILE="$MGMT_RESTART_DROPIN_DIR/dlpx-97495-no-restart.conf"
+
+#
+# DLPX-97495: disarm delphix-mgmt's automatic restart for the duration of the
+# package upgrade, without stopping the running JVM. The live JVM has the shared
+# libraries that the dpkg phase replaces mapped, so a fork/exec mid-dpkg can
+# abort() it (SIGABRT). The unit ships Restart=always, so systemd would then
+# resurrect the mgmt stack mid-upgrade -- which desyncs the upgrade version state
+# machine and clears upgrade.properties, stranding the FULL finish-deferred
+# auto-reboot trigger and leaving the engine stuck in DEFERRED on the old kernel.
+#
+# A "Restart=no" drop-in (plus a reload, so it applies to the already running
+# unit) leaves the JVM up but stops systemd from restarting it if it crashes.
+# rearm_mgmt_restart() removes it before the final "systemctl restart
+# delphix.target", which starts mgmt exactly once regardless of Restart=.
+#
+# We can't "mask" the unit instead: a masked unit can't be enabled, and
+# delphix-virtualization's postinst runs "systemctl enable delphix-mgmt.service"
+# during the dpkg phase, so masking fails the package install (verify
+# regression). "disable" does not work either -- it does not block Restart=.
+#
+function disarm_mgmt_restart() {
+	mkdir -p "$MGMT_RESTART_DROPIN_DIR" ||
+		die "failed to create $MGMT_RESTART_DROPIN_DIR"
+	cat >"$MGMT_RESTART_DROPIN_FILE" <<-EOF ||
+		[Service]
+		Restart=no
+		EOF
+		die "failed to write delphix-mgmt Restart=no drop-in"
+	systemctl daemon-reload ||
+		die "failed to reload systemd after installing delphix-mgmt drop-in"
+}
+
+#
+# DLPX-97495: re-arm delphix-mgmt's restart by removing the drop-in that
+# disarm_mgmt_restart() installed, restoring Restart=always before the final
+# delphix.target restart. If the JVM crashed while disarmed the unit is left
+# "failed"; reset it so the restart starts cleanly (belt-and-suspenders -- an
+# explicit restart clears "failed" anyway).
+#
+function rearm_mgmt_restart() {
+	rm -f "$MGMT_RESTART_DROPIN_FILE" ||
+		die "failed to remove delphix-mgmt Restart=no drop-in"
+	#
+	# Best-effort: rmdir only removes an empty directory, so leave it (and don't
+	# fail the upgrade) if another drop-in is installed in delphix-mgmt.service.d.
+	#
+	rmdir "$MGMT_RESTART_DROPIN_DIR" 2>/dev/null || true
+	systemctl daemon-reload ||
+		die "failed to reload systemd after removing delphix-mgmt drop-in"
+	systemctl reset-failed delphix-mgmt.service 2>/dev/null || true
+}
+
+#
 # This function has 2 tasks:
 #  1. Fix/update the state of some services to be in line with what is expected
 #     in this version of the appliance.

--- a/upgrade/upgrade-scripts/execute
+++ b/upgrade/upgrade-scripts/execute
@@ -265,6 +265,15 @@ if compare_versions "$CURRENT_VERSION" lt "2025.6.0.0-0"; then
 fi
 
 #
+# DLPX-97495: disarm delphix-mgmt's restart so a JVM that crashes against
+# dpkg-replaced libraries isn't resurrected mid-upgrade (which would strand the
+# FULL auto-reboot trigger). Re-armed before the final delphix.target restart.
+# Unconditional, unlike the version-gated docker mask above, because the crash
+# applies to any source version. See disarm_mgmt_restart() in common.sh.
+#
+disarm_mgmt_restart
+
+#
 # Migrate the home dataset's mountpoint from /export/home to /home, and
 # harden it with nodev,nosuid, for engines upgrading from a release that
 # predates this change.
@@ -633,6 +642,13 @@ if compare_versions "$CURRENT_VERSION" lt "2025.6.0.0-0"; then
 	#
 	systemctl unmask docker.service
 fi
+
+#
+# DLPX-97495: re-arm delphix-mgmt's automatic restart (disarmed near the start
+# of the upgrade) before the "systemctl restart delphix.target" below brings
+# mgmt up exactly once. See rearm_mgmt_restart() in common.sh.
+#
+rearm_mgmt_restart
 
 stop_stdout_redirect_to_system_log
 stop_stderr_redirect_to_system_log


### PR DESCRIPTION
## Problem

On a FULL upgrade, `delphix-mgmt` (the management JVM) is left running while `execute` runs `dpkg` to replace shared libraries that the live JVM has mapped (`libcrypto.so.3`, `libzfs.so`, the JVM libs, etc.). A routine API request (e.g. `GET /delphix/about` spawning a helper) mid-`dpkg` can fork/exec against the yanked libraries and `abort()` the JVM (SIGABRT). systemd's `Restart=always` (`RestartUSec=100ms`) then auto-restarts the management stack in the middle of the upgrade. Those extra `StackStartup` runs desync the upgrade version state machine and clear `/var/dlpx-update/upgrade.properties`, so the FULL "finish-deferred and reboot" trigger never fires; the engine finishes the upgrade stuck in `DEFERRED`, on the old kernel, and never reboots.

## Solution

Disarm the unit's automatic restart for the duration of the package upgrade, without stopping the running JVM. `execute` installs a transient `Restart=no` drop-in at `/etc/systemd/system/delphix-mgmt.service.d/dlpx-97495-no-restart.conf` (with a `daemon-reload`, so it applies to the already-running unit) before the `dpkg` phase, and removes it (plus another `daemon-reload`) before the final `systemctl restart delphix.target`. The JVM keeps serving until/unless it crashes; if it does crash, systemd does **not** bring it back up mid-upgrade, so `upgrade.properties` is left untouched and the single intended restart at the end brings mgmt up exactly once — where the FULL trigger fires correctly.

The install/teardown live in two helpers in `common.sh` — `disarm_mgmt_restart` (create the drop-in + `daemon-reload`) and `rearm_mgmt_restart` (remove the drop-in + `daemon-reload` + `reset-failed`) — invoked from `execute` around the `dpkg` phase, keeping the call sites in `execute` to one line each.

A few notes on what was deliberately not done:

- **`Restart=no` drop-in, not `systemctl mask`.** An earlier revision masked the unit. That broke upgrade-**verify**: verify runs `execute` inside an in-place container, whose `dpkg` phase configures `delphix-virtualization`, whose postinst runs `systemctl enable delphix-mgmt.service`. A masked unit cannot be enabled, so the postinst failed, the package install failed with `failed to install packages listed in packages.list.gz`, and verify aborted with `Fail to setup 'in-place' upgrade container for verification`. The `Restart=no` drop-in gives the same protection (no auto-restart of a crashed JVM) while leaving the unit enable-able, so the postinst succeeds.
- **`Restart=no`, not `disable`.** `disable` only drops the `WantedBy` symlink and does not affect `Restart=`, so the crashed JVM would still get restarted (verified on a real engine running systemd 255).
- **Not stopped (`mask --now`/`stop`).** Proactively stopping the JVM would also suppress the SIGABRT and the core dump, but that's a larger behavior change; with the drop-in the crash itself can still occur (the core dump and `alert.system.startup.management.unexpected` still fire on internal engines), and this change removes only the mid-upgrade restart cascade that strands the FULL reboot.
- The drop-in lives under `/etc/systemd/system/...` (admin-owned), so the `delphix-mgmt` package upgrade does not clobber it; the final `systemctl restart delphix.target` starts the unit explicitly, regardless of `Restart=`.
- Unconditional, unlike the version-gated docker mask, since the crash applies to any source version doing a package upgrade.

## Testing Done

### Manual FULL-upgrade validation (Hong Wong): PASSED

- Confirmed 2026-06-22: with this change the FULL upgrade completes — the engine reaches `finish_deferred` and reboots, instead of stranding in `DEFERRED` on the old kernel.
- Run: `AWS_2026300_TO_DEVELOP_SMALL_FULL_UPGRADE_DEV_BUILD` #16, engine `dlpx-qa-2026300-bb-chain-16-b8f97e0c.dlpxdc.co`.
- As designed (see the "not stopped" note above), the JVM SIGABRT still produces a crash dump during the `dpkg` phase — e.g. `/var/crash/core.http-nio-127.0...`. The dlpx-qa-gate upgrade test treated any such dump as a failure, so the automated suites flagged it even though the upgrade itself succeeded. The companion qa-gate change has since merged — **DLPXQA-52963** ([dlpx-qa-gate#8526](https://github.com/delphix/dlpx-qa-gate/pull/8526), merged 2026-06-23) — which marks the DLPX-97495 dump as known across the full / deferred / finish-deferred upgrade paths and extends `wait_for_stack` while the JVM recovers.

### ab-pre-push build #14345: UNSTABLE (expected — crash-dump flag only)

- Build: https://selfservice-jenkins.eng-tools-prd.aws.delphixcloud.com/job/appliance-build-orchestrator-pre-push/14345/
- Ran on the branch's net diff (built from `64569e0`, since reshaped into the single commit `7efb01d`; net diff unchanged).
- Config: `RUN_TESTS=true`, upgrade testing enabled (`TEST_UPGRADE_FROM_VERSION=2026.4.0.0`, `UPGRADE_TO_VARIANT=internal-qa`); variants `internal-dev internal-qa external-standard` on `aws`.
- Result: Build Necessary Packages, Build Appliance, and Import to DCenter all **SUCCESS**. `dx-integration-tests`: **SUCCESS**. `upgrade-testing` (#4520): **UNSTABLE** — the same expected JVM crash-dump flag described above, not an upgrade failure. This build ran 2026-06-22, before the qa-gate fix (DLPXQA-52963) merged; a fresh ab-pre-push picking up current `dlpx-qa-gate` develop should pass `upgrade-testing`.

### Prior ab-pre-push build #14330 (mask approach): FAILED

- Build: https://selfservice-jenkins.eng-tools-prd.aws.delphixcloud.com/job/appliance-build-orchestrator-pre-push/14330/
- Failed upgrade-verify with `Fail to setup 'in-place' upgrade container for verification` — root-caused to the `systemctl mask` breaking `delphix-virtualization`'s postinst (see Solution). Fixed by switching to the `Restart=no` drop-in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
