### PR TITLE
DLPX-97585 Sweep leaked postgres mask symlinks on upgrade

### DIFF
--- a/upgrade/upgrade-scripts/execute
+++ b/upgrade/upgrade-scripts/execute
@@ -242,6 +242,35 @@ EOF
 start_stdout_redirect_to_system_log
 start_stderr_redirect_to_system_log
 
+#
+# Remove orphaned systemd "mask" symlinks left behind by transient
+# delphix-postgres replication/serialization MDS instances (DLPX-97585;
+# follow-up to DLPX-97584 / ESCL-6046). At teardown these transient
+# instances were masked but never unmasked, so each one left a permanent
+# "/dev/null" symlink under "/etc/systemd/system". On affected engines
+# these accumulated into the hundreds of thousands, and since
+# "systemctl daemon-reload" is O(number of on-disk unit files), every
+# reload slowed to ~12s -- enough to blow the sd-bus timeout in
+# delphix-mgmt's prerm and abort the upgrade.
+#
+# We sweep them here, before "fix_and_migrate_services" and the
+# package-upgrade phase trigger their many daemon-reloads, so that those
+# reloads stay fast. The guards make this safe: "-maxdepth 1 -type l
+# -lname /dev/null" matches only top-level systemd masks (never a real
+# unit file or drop-in), and the name glob matches only the two leaked
+# transient families -- the real, long-lived instances ("_default",
+# "_test", data-dir paths) contain no "REPL". If such a name is ever
+# reused, the application unmasks it before starting, so removing the
+# stale mask cannot break a future instance.
+#
+# This is idempotent: on engines that never leaked, "find" matches
+# nothing and exits 0, and the "daemon-reload" is a harmless no-op.
+#
+find /etc/systemd/system -maxdepth 1 -type l -lname /dev/null \
+	-name 'delphix-postgres@*REPL*_db.service' -delete ||
+	die "failed to remove leaked delphix-postgres mask symlinks"
+systemctl daemon-reload || die "'systemctl daemon-reload' failed"
+
 fix_and_migrate_services
 
 #


### PR DESCRIPTION
**Related:** app-gate PR delphix/dlpx-app-gate#4435 (DLPX-97584) — the code fix that stops *new* mask-symlink leaks. This PR sweeps the backlog already accumulated on upgraded engines.

## Problem

Transient delphix-postgres replication/serialization MDS instances are masked
at teardown but never unmasked, leaving a permanent `/dev/null` mask symlink
under `/etc/systemd/system` for each one. On affected engines these accumulated
into the hundreds of thousands (~352,937 on Mizuho `sclfdlpxapprd01`, ESCL-6046).
Because `systemctl daemon-reload` is O(number of on-disk unit files), every
reload slowed to ~12s — enough to blow the sd-bus reply timeout in
`delphix-mgmt`'s prerm and abort the upgrade.

The app-gate fix (DLPX-97584) stops *new* leaks, but cannot remove the backlog
already on upgraded engines.

## Change

Add a one-time, idempotent sweep to the upgrade `execute` script, placed right
after the stderr log redirect and before `fix_and_migrate_services` — so it runs
before the package-upgrade phase triggers its many `daemon-reload`s and keeps
them fast:

```
find /etc/systemd/system -maxdepth 1 -type l -lname /dev/null \
	-name 'delphix-postgres@*REPL*_db.service' -delete || die ...
systemctl daemon-reload || die ...
```

### Safety
- `-maxdepth 1 -type l -lname /dev/null` matches only top-level systemd *masks* —
  never a real unit file or drop-in.
- The name glob matches only the two leaked transient families
  (`*_SRC-REPL-MDS-*`, `*REPLICATION*`); the real long-lived instances
  (`_default`, `_test`, data-dir paths) contain no `REPL`.
- The bundle's `systemctl-list-units.txt` showed 0 of these loaded. If a name is
  ever reused, app-gate's `SystemdServiceInstance.start()` self-unmasks before
  starting, so deletion cannot break a future instance.
- Idempotent: on engines that never leaked, `find` matches nothing and exits 0,
  and the `daemon-reload` is a no-op.

## Testing Done

**Seed-a-VM (reload speedup + correctness)** — ✅ PASS

Seeded 100,000 fake `/dev/null` masks matching the glob across both leaked
families on a dev engine (`/etc/systemd/system` baseline was 53 entries), then
ran the exact sweep command and timed `systemctl daemon-reload` before/after:

| | `daemon-reload` |
|---|---|
| With 100k-mask backlog | **2,590 ms** |
| After sweep | **465 ms** |

The sweep matched and removed all 100,000 seeded masks (0 remaining) and
`/etc/systemd/system` returned to exactly its 53-entry baseline — confirming it
touched only the leaked masks and nothing real. Reload time is linear in
on-disk unit count, consistent with the customer's ~12s at 352k symlinks.

**ab-pre-push (upgrade verification)** — _in progress_

[appliance-build-orchestrator-pre-push #14354](https://selfservice-jenkins.eng-tools-prd.aws.delphixcloud.com/job/appliance-build-orchestrator-pre-push/14354/)
— `--test-upgrade-from 2026.4.0.0 -p aws`, job-default variants, tests on.
Proves the sweep does not break a normal upgrade end-to-end.

DLPX-97585

