### PR TITLE
HF-1582 [appliance-build] Repoint hyperscale pkg path to develop/latest to fix ancillary-repository build (HM-4835)

### DIFF
--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -155,7 +155,7 @@ function download_hyperscale_artifacts() {
 
 	if [[ -z "$hyperscale_artifacts_uri" ]]; then
 		HYPERSCALE_S3_DIR="s3://snapshot-de-images"
-		HYPERSCALE_LATEST_PREFIX="builds/jenkins-masking/github/delphix/hyperscale-masking/build/debian-pkg/feature-closed-appliance/latest"
+		HYPERSCALE_LATEST_PREFIX="builds/jenkins-masking/github/delphix/hyperscale-masking/build/debian-pkg/develop/latest"
 
 		aws s3 cp "$HYPERSCALE_S3_DIR/$HYPERSCALE_LATEST_PREFIX" .
 


### PR DESCRIPTION
## Summary

Appliance-build half of **HF-1582** (backport of the ESCL-6013 timeflow-demotion sweep to 2025.5.0.2).

Cherry-picks `10c278c` (HM-4835, #852) onto the `release/2025.5.0.2` base so the hotfix image can build. Without it, `:live-build:ancillaryRepository` fails: `download_hyperscale_artifacts` falls back to `HYPERSCALE_LATEST_PREFIX`, which on this branch still pointed at the retired `hyperscale-masking/.../feature-closed-appliance/latest` S3 marker and 404s. The fix repoints it to `.../develop/latest` (which exists), matching what `develop` has carried since 2025-10-27.

Newer HF branches (cut after that date) already include this; HF-1582 was cut from the Aug-2025 release point and predates it.

## Delivered together with

- **app-gate:** delphix/dlpx-app-gate#4487 (the ESCL-6013 code fix)

⚠️ **Both PRs must land to deliver HF-1582.** This one only unblocks the appliance/hotfix build; the app-gate PR carries the actual customer-facing fix.

## Test plan

- Hotfix build: https://ops-jenkins.eng-tools-prd.aws.delphixcloud.com/job/hotfix-build/309/
