### PR TITLE
DLPX-86523 internal-buildserver: unhardened /home mount options

### DIFF
--- a/live-build/config/hooks/vm-artifacts/90-raw-disk-image.binary
+++ b/live-build/config/hooks/vm-artifacts/90-raw-disk-image.binary
@@ -313,8 +313,21 @@ rsync --info=stats3 -WaAX binary/* "$DIRECTORY/"
 # exist in /etc/fstab since that will ensure that it gets mounted
 # automatically whenever we boot into the crash kernel.
 #
+# The /home dataset is normally mounted with nodev and nosuid to satisfy
+# the CIS requirement for a hardened /home filesystem. The internal
+# buildserver variant is an exception: appliance-build runs its image and
+# upgrade builds out of a working tree under /home, and those builds create
+# device nodes and run setuid binaries there -- which the nodev and nosuid
+# options would block. So we mount its /home with the default (unhardened)
+# options. This variant is internal only and is never shipped to customers,
+# so relaxing CIS hardening here is acceptable.
+#
+HOME_MOUNT_OPTS="defaults,nodev,nosuid"
+if [[ "$APPLIANCE_VARIANT" == "internal-buildserver" ]]; then
+	HOME_MOUNT_OPTS="defaults"
+fi
 cat <<-EOF >"$DIRECTORY/etc/fstab"
-	rpool/ROOT/$FSNAME/home /home zfs defaults,nodev,nosuid,x-systemd.before=zfs-import-cache.service 0 0
+	rpool/ROOT/$FSNAME/home /home zfs ${HOME_MOUNT_OPTS},x-systemd.before=zfs-import-cache.service 0 0
 	rpool/ROOT/$FSNAME/data /var/delphix zfs defaults,x-systemd.before=zfs-import-cache.service 0 0
 	rpool/ROOT/$FSNAME/log  /var/log     zfs defaults,x-systemd.before=zfs-import-cache.service 0 0
 	rpool/ROOT/$FSNAME/tmp  /tmp     zfs defaults,nosuid,nodev,exec,x-systemd.before=zfs-import-cache.service 0 0


### PR DESCRIPTION
## Summary

The CIS `/home` hardening (DLPX-86523, #869) mounts the home ZFS dataset at
`/home` with `nodev,nosuid` for every variant. On the `internal-buildserver`
variant that breaks appliance-build: those builds run from a working tree under
`/home` and need to create device nodes and run setuid binaries there, which
`nodev`/`nosuid` block.

This mounts `/home` with plain `defaults` on the `internal-buildserver` variant
only. The raw-disk-image hook now computes a `HOME_MOUNT_OPTS` variable that
defaults to the hardened `defaults,nodev,nosuid` and is overridden to `defaults`
for that one variant, then interpolates it into the `/home` fstab entry. Every
other variant keeps `defaults,nodev,nosuid` byte-for-byte identical to today.

Scope is initial image generation only; the buildserver variant is never
upgraded, so no upgrade-scripts change is required. The variant is internal-only
and never shipped to customers, so relaxing the CIS hardening on it is
acceptable.

## Testing Done

### ab-pre-push build #14495: IN PROGRESS

- Build: https://selfservice-jenkins.eng-tools-prd.aws.delphixcloud.com/job/appliance-build-orchestrator-pre-push/14495/
- Tested: `appliance-build@995ce3e` (against `develop`)
- Variants: `internal-buildserver` (requested explicitly — the default variant set omits it, so this change is exercised directly) and `internal-qa` (covers the unchanged CIS-hardened default path)
- Status: running — result not yet available; re-run recording in completed mode once finished.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
