### PR TITLE
Add dedicated ucf user to the UCF appliance

### DIFF
--- a/live-build/misc/ansible-roles/appliance-build.ucf-common/tasks/main.yml
+++ b/live-build/misc/ansible-roles/appliance-build.ucf-common/tasks/main.yml
@@ -16,6 +16,37 @@
 
 ---
 #
+# UCF gets its own login user, separate from delphix, so that day-to-day
+# UCF administration (docker ps/logs, UCF service status, etc.) doesn't
+# require operators to su/sudo to root. It shares APPLIANCE_PASSWORD with
+# delphix/root (set by appliance-build.minimal-common), and mirrors the
+# same group membership delphix gets there: secondary membership in the
+# root group (appliance-build.minimal-common's mechanism for giving
+# delphix broad access to root-owned appliance files/services without
+# being uid 0), plus docker, for the same reason delphix has it on other
+# variants (see appliance-build.buildserver-internal,
+# appliance-build.unittest-internal).
+#
+# Note: both root-group and docker-group membership are root-equivalent
+# (root-group members can read/write many root-owned files; a docker-group
+# member can bind-mount the host filesystem via `docker run -v /:/host ...`
+# and get a root shell). This is an accepted tradeoff here, matching the
+# level of access delphix already has via the same mechanism.
+#
+- user:
+    name: ucf
+    uid: 65434
+    group: staff
+    groups: root,docker
+    append: true
+    shell: /bin/bash
+    create_home: yes
+    comment: UCF User
+    home: /home/ucf
+    password:
+      "{{ lookup('env', 'APPLIANCE_PASSWORD') | password_hash('sha512') }}"
+
+#
 # Installs the UCF (CDS) application packages from the ancillary apt
 # repository. The packages themselves are uploaded by the CDS team via
 # GitHub Actions to AWS_S3_URI_UCF_PACKAGES and pulled into the apt


### PR DESCRIPTION
## Summary
- Adds a dedicated `ucf` system user in `appliance-build.ucf-common`, so UCF administration (Docker containers, UCF services) no longer requires operators to `su`/`sudo` to `root` on the appliance.
- Mirrors the exact access model `appliance-build.minimal-common` gives `delphix`: primary group `staff`, secondary group `root`. Additionally adds the `docker` group so `docker ps`/`docker logs` work without escalating — the concrete pain point behind this change.
- Password reuses the existing `APPLIANCE_PASSWORD` build-time env var (same value/mechanism as `delphix`/`root`) — no new secret or plumbing needed.

## Scope
- Only affects `external-ucf` and `internal-ucf` — confirmed no other variant playbook includes `appliance-build.ucf-common`, and no role transitively depends on it via `meta/main.yml`.
- `delphix`/`root` are unchanged on every variant, including UCF's; `ucf` is purely additive.
- uid `65434` confirmed unused elsewhere in the repo (next free slot after `delphix`'s `65433`).

## Known follow-ups (tracked in PUPCLD-5189, not in scope for this PR)
- In-place appliance upgrades (`upgrade/upgrade-scripts`) only install `.deb` packages and don't run Ansible, so already-deployed appliances upgrading in place won't gain the `ucf` user from this change — only fresh builds will.
- Ownership of the actual UCF app files/directories/systemd units is controlled by the `puppetcloudops` package (separate repo, CDS team) — out of scope for `appliance-build`.

## Test plan
- [ ] `sudo ./gradlew buildInternalUcfKvm`, boot the resulting qcow2 in QEMU, confirm `id ucf` shows groups `staff,root,docker`
- [ ] Confirm `docker ps` works as `ucf` without `sudo`
- [ ] Confirm `delphix`/`root` behavior is unchanged
- [ ] Confirm `external-standard`/other variant builds are unaffected

Jira: PUPCLD-5189