### PR TITLE
PUPCLD-5189 ucf: add dedicated ucf user for UCF appliance administration

### DIFF
--- a/live-build/misc/ansible-roles/appliance-build.ucf-common/tasks/main.yml
+++ b/live-build/misc/ansible-roles/appliance-build.ucf-common/tasks/main.yml
@@ -16,6 +16,37 @@
 
 ---
 #
+# UCF gets its own login user, separate from delphix, so that day-to-day
+# UCF administration (docker ps/logs, UCF service status, etc.) doesn't
+# require operators to su/sudo to root. It shares APPLIANCE_PASSWORD with
+# delphix/root (set by appliance-build.minimal-common), and mirrors the
+# same group membership delphix gets there: secondary membership in the
+# root group (appliance-build.minimal-common's mechanism for giving
+# delphix broad access to root-owned appliance files/services without
+# being uid 0), plus docker, for the same reason delphix has it on other
+# variants (see appliance-build.buildserver-internal,
+# appliance-build.unittest-internal).
+#
+# Note: both root-group and docker-group membership are root-equivalent
+# (root-group members can read/write many root-owned files; a docker-group
+# member can bind-mount the host filesystem via `docker run -v /:/host ...`
+# and get a root shell). This is an accepted tradeoff here, matching the
+# level of access delphix already has via the same mechanism.
+#
+- user:
+    name: ucf
+    uid: 65434
+    group: staff
+    groups: root,docker
+    append: true
+    shell: /bin/bash
+    create_home: true
+    comment: UCF User
+    home: /home/ucf
+    password:
+      "{{ lookup('env', 'APPLIANCE_PASSWORD') | password_hash('sha512') }}"
+
+#
 # Installs the UCF (CDS) application packages from the ancillary apt
 # repository. The packages themselves are uploaded by the CDS team via
 # GitHub Actions to AWS_S3_URI_UCF_PACKAGES and pulled into the apt


### PR DESCRIPTION
## Problem

The UCF appliance (`external-ucf`, `internal-ucf`) only provisions `delphix`
and `root` system users (via `appliance-build.minimal-common`). Operators
have to `su`/`sudo` to root just to inspect UCF's own Docker containers and
services — there's no UCF-specific identity for day-to-day administration.

## Solution

Add a dedicated `ucf` system user in `appliance-build.ucf-common`:

- Mirrors the exact access model `appliance-build.minimal-common` gives
  `delphix`: primary group `staff`, secondary group `root`.
- Additionally a member of the `docker` group, so `docker ps`/`docker logs`
  work without escalating to root — the concrete pain point behind this
  change.
- Password reuses the existing `APPLIANCE_PASSWORD` build-time env var (same
  value/mechanism as `delphix`/`root`) — no new secret or plumbing needed.
- uid `65434`, confirmed unused elsewhere in the repo.

Scoped strictly to `external-ucf`/`internal-ucf`: confirmed no other variant
playbook includes `appliance-build.ucf-common`, and no role transitively
depends on it via `meta/main.yml`. `delphix`/`root` are unchanged on every
variant, including UCF's.

## Testing Done

- Verified via `git diff`/`grep` across the repo that only
  `appliance-build.ucf-common` is touched, and that it's referenced solely
  by `external-ucf`/`internal-ucf`.
- Confirmed uid `65434` is unused elsewhere and the `docker` group is
  guaranteed to exist by the time `ucf-common` runs (created earlier by
  `virtualization-common`'s dependency chain).

Tracking: PUPCLD-5189