### PR TITLE
TOOL-30552 appliance-build: git clone of dlpx-app-gate/dms-core-gate fails mid-transfer — fetch-pack "unexpected disconnect"/"early EOF" (regression since 2026-07-11 ~11:13am, blocking 2026.4)

### DIFF
--- a/live-build/misc/ansible-roles/appliance-build.masking-development/tasks/main.yml
+++ b/live-build/misc/ansible-roles/appliance-build.masking-development/tasks/main.yml
@@ -30,6 +30,16 @@
     version: "develop"
     accept_hostkey: yes
     update: no
+  environment:
+    # Abort a clone that stalls mid-transfer (throughput < 100 B/s for 60s)
+    # rather than hanging until the egress-path session timeout (~60 min)
+    # severs it, so the retry below can recover quickly.
+    GIT_HTTP_LOW_SPEED_LIMIT: "100"
+    GIT_HTTP_LOW_SPEED_TIME: "60"
+  register: dms_core_gate_clone
+  until: dms_core_gate_clone is not failed
+  retries: 3
+  delay: 30
   when: lookup('env', 'GITHUB_TOKEN') != ''
 
 - file:

--- a/live-build/misc/ansible-roles/appliance-build.virtualization-development/tasks/main.yml
+++ b/live-build/misc/ansible-roles/appliance-build.virtualization-development/tasks/main.yml
@@ -77,6 +77,16 @@
     version: "develop"
     accept_hostkey: yes
     update: no
+  environment:
+    # Abort a clone that stalls mid-transfer (throughput < 100 B/s for 60s)
+    # rather than hanging until the egress-path session timeout (~60 min)
+    # severs it, so the retry below can recover quickly.
+    GIT_HTTP_LOW_SPEED_LIMIT: "100"
+    GIT_HTTP_LOW_SPEED_TIME: "60"
+  register: dlpx_app_gate_clone
+  until: dlpx_app_gate_clone is not failed
+  retries: 3
+  delay: 30
   when: lookup('env', 'GITHUB_TOKEN') != ''
 
 - file:


### PR DESCRIPTION
**Ticket:** TOOL-30552 (forward port of TOOL-30548, which is the `release`-branch backport landed in #884 — see that PR/ticket for release-team approval).

## Problem

Since ~2026-07-11 11:13 PDT, nearly every `appliance-build` post-push/nightly run has failed at the ansible `git clone` of a large Delphix monorepo (`dlpx-app-gate` / `dms-core-gate`) during provisioning:

```
error: NNNN bytes of body are still expected
fetch-pack: unexpected disconnect while reading sideband packet
fatal: early EOF
fatal: fetch-pack: invalid index-pack output
```

## Root cause

Console-log analysis across the failing builds showed the clone **connects, transfers most of the pack, then stalls completely (0 B/s)** and hangs until a fixed **~61-minute session timeout on the AWS egress path** (build VM → github.com) reaps the dead connection — that's when git reports `early EOF`. The ~62 min is a reap timer, **not** transfer time: a healthy clone of these repos finishes in **~1–2 minutes**.

Evidence (clone start → drop):

| Build | Repo | Duration |
| --- | --- | --- |
| stage1 #266648 | dlpx-app-gate | 61.4 min |
| stage1 #266791 | dlpx-app-gate | 61.9 min |
| stage1 #266796 | dms-core-gate | 61.9 min |
| stage1 #266812 | dms-core-gate | 61.4 min |
| stage1 #266850 | dlpx-app-gate | 62.1 min |
| stage1 #266868 | dlpx-app-gate | 62.4 min |

The stall is intermittent per-connection, which is why the `release` line (more parallel variant/platform clones) failed on essentially every run while `develop` (fewer) intermittently stayed green — in one failed `develop` build, the *same* `dlpx-app-gate` clone succeeded in 1.9 min on one VM while stalling 61 min on two sibling VMs.

## Fix

Two changes to the `dlpx-app-gate` and `dms-core-gate` clone tasks:

1. **Fail fast on a stall** — set `GIT_HTTP_LOW_SPEED_LIMIT=100` / `GIT_HTTP_LOW_SPEED_TIME=60`, so git aborts a connection delivering <100 B/s for 60s instead of hanging for ~an hour. (Healthy clones run at MB/s, so this only trips on an effectively-dead connection.)
2. **Retry** — `retries: 3`, `delay: 30`, `until: <clone> is not failed`, mirroring the existing `apt` task idiom in these roles. Since a healthy clone takes ~2 min and the stall is intermittent, a retry almost always recovers.

This is a mitigation that unblocks the build reliably. **The underlying egress-path issue (what changed on the AWS network path at ~7/11 11:13, and why healthy connections now stall) still needs to be root-caused by the network/DevOps-infra team** — the overly-long ~3600s connection-reap timeout is a secondary aggravator worth shortening as well.

## Testing

- YAML validated for both roles.
- No behavior change on the happy path (retry wrapper + env vars only); clone target, ref, and dest are unchanged.

**Local validation of the fix mechanics** (throwaway repo/infra, no network changes, nothing pushed — see TOOL-30552 for full transcript):

Reproduced the stall+recovery locally: a ~300MB throwaway git repo served over HTTP, fronted by a toxiproxy bandwidth toxic (`rate: 0`) to simulate the mid-transfer 0 B/s stall, then ran the exact task YAML from this branch through `ansible-playbook`.

1. **git aborts a stalled transfer fast, instead of hanging.** With `GIT_HTTP_LOW_SPEED_LIMIT=100`/`GIT_HTTP_LOW_SPEED_TIME=5` (scaled down from 60 for a fast test) and the proxy stalled at 0 B/s: clone aborted in **5s** (`fatal: ... Operation too slow. Less than 100 bytes/sec transferred the last 5 seconds`). Control run with no env vars against the same stall: still hanging with zero output after 30s (killed manually). **PASS.**

2. **Ansible's task-level `environment:` reaches the `git` subprocess, and `until`/`retries`/`delay` recovers.** Ran the actual task (env vars, `register`/`until`/`retries: 3`/`delay` scaled to 5s) via `ansible-playbook -vvv`:
   - Unthrottled: `attempts: 1, changed: true` — succeeds first try (happy path unaffected).
   - Throttled, then toxic removed mid-retry-loop: 3 attempts each failed fast (~5s, via the libcurl low-speed abort, not a hang) with `FAILED - RETRYING`, then attempt 4 succeeded once the stall cleared → `attempts: 4, changed: true, ok=1`.
   - Negative control (throttle never removed): all 4 attempts (initial + 3 retries) failed fast via the same libcurl error; play ended `failed=1` after 38s total — confirming the env vars are honored on every retry, not just the first.
   **PASS.**

Both behaviors the fix depends on — fast-abort-on-stall and until/retry recovery with task-level `environment:` correctly propagated — are confirmed working as designed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

