### PR TITLE
DLPX-97940 appliance-build: skip downloading hyperscale artifacts when no hyperscale variant is built

### DIFF
--- a/live-build/build.gradle
+++ b/live-build/build.gradle
@@ -38,14 +38,20 @@ task ancillaryRepository(type: Exec) {
 
 /*
  * The ancillary repository is built once and shared by every variant built in
- * this gradle invocation, so only download the DCT packages when a DCT variant
- * is actually part of the build. We check the resolved task graph (which also
- * catches DCT variants pulled in via aggregate tasks) and register the result
- * as a task input so up-to-date checking rebuilds the repo when switching
- * DCT<->non-DCT. Every DCT variant build task is named build<...Dct...>, so
- * detection can only over-download (harmless), never miss a real DCT build.
+ * this gradle invocation, so only download an optional package group when a
+ * variant that installs it is actually part of the build. We check the resolved
+ * task graph (which also catches variants pulled in via aggregate tasks) and
+ * register each decision as a task input so up-to-date checking rebuilds the
+ * repo when switching between builds. Every hyperscale/DCT variant build task is
+ * named build<...Hyperscale...> / build<...Dct...>, so detection can only
+ * over-download (harmless), never miss a real build that needs the packages.
  */
 gradle.taskGraph.whenReady { graph ->
+    def buildHyperscale = graph.allTasks.any { it.name.contains("Hyperscale") }
+    ancillaryRepository.inputs.property("buildHyperscaleVariant", buildHyperscale)
+    ancillaryRepository.environment "DELPHIX_BUILD_HYPERSCALE_VARIANT",
+        buildHyperscale.toString()
+
     def buildDct = graph.allTasks.any { it.name.contains("Dct") }
     ancillaryRepository.inputs.property("buildDctVariant", buildDct)
     ancillaryRepository.environment "DELPHIX_BUILD_DCT_VARIANT", buildDct.toString()

--- a/scripts/build-ancillary-repository.sh
+++ b/scripts/build-ancillary-repository.sh
@@ -100,7 +100,22 @@ else
 	echo "Skipping DCT artifact download: no DCT variant is being built."
 fi
 
-download_hyperscale_artifacts "$AWS_S3_URI_HYPERSCALE_COMPLIANCE_PACKAGES" "$WORK_DIRECTORY/artifacts"
+#
+# The hyperscale compliance packages are only installed by the hyperscale
+# appliance variants, so only download them when a hyperscale variant is being
+# built (signalled by the ancillaryRepository gradle task via
+# DELPHIX_BUILD_HYPERSCALE_VARIANT). This avoids wastefully downloading them for
+# the many builds (external-standard, internal-dev, internal-qa, etc.) that
+# never install them. When a hyperscale variant is built,
+# AWS_S3_URI_HYPERSCALE_COMPLIANCE_PACKAGES (if set) still selects a specific
+# build; otherwise download_hyperscale_artifacts fetches the latest.
+#
+if [[ "$DELPHIX_BUILD_HYPERSCALE_VARIANT" == "true" ]]; then
+	download_hyperscale_artifacts "$AWS_S3_URI_HYPERSCALE_COMPLIANCE_PACKAGES" \
+		"$WORK_DIRECTORY/artifacts"
+else
+	echo "Skipping hyperscale artifact download: no hyperscale variant is being built."
+fi
 
 #
 # AWS_S3_URI_UCF_PACKAGES is an optional external variable set by the


### PR DESCRIPTION
## Problem
When appliance-build builds the ancillary APT repository (`build-ancillary-repository.sh`, invoked by the `ancillaryRepository` gradle task), it unconditionally downloads the hyperscale compliance packages via `download_hyperscale_artifacts` (added in HM-4132). With no explicit URI it falls back to fetching the latest develop hyperscale-masking build.

The hyperscale package (`delphix-hyperscale`) is only installed by the hyperscale variants (`external-hyperscale`, `internal-hyperscale`) via the `appliance-build.hyperscale-common` ansible role. Every other build — `external-standard`, `internal-dev`, `internal-qa`, etc. — downloads these artifacts into the ancillary repo but never installs them, wasting build time and bandwidth. Observed in appliance-build-stage1/post-push #267326, which builds only non-hyperscale variants yet still runs `download_hyperscale_artifacts`.

## Solution
Only download the hyperscale artifacts when a hyperscale variant is actually being built. The pipeline builds one `build<Variant><Platform>` task per gradle invocation, and `ancillaryRepository` is always its dependency in the same invocation, so the target variant is visible in the resolved task graph.

- `live-build/build.gradle`: in `gradle.taskGraph.whenReady`, detect whether any task in the resolved graph is a hyperscale variant (name contains `Hyperscale`). Set `DELPHIX_BUILD_HYPERSCALE_VARIANT` accordingly (both branches) on the `ancillaryRepository` task, and register the decision as a task input property so gradle up-to-date checking rebuilds the ancillary repo when switching hyperscale↔non-hyperscale in the same workspace. (This shares one `whenReady` block with the DCT gating already on develop from DLPX-97941.)
- `scripts/build-ancillary-repository.sh`: call `download_hyperscale_artifacts` only when that flag is `true`; otherwise log a skip. When a hyperscale variant *is* built, `AWS_S3_URI_HYPERSCALE_COMPLIANCE_PACKAGES` (if set) is still honored inside `download_hyperscale_artifacts` to pin a specific build.

No changes needed to the hyperscale build job or devops-gate — those invocations carry a `Hyperscale` task and keep downloading. Every hyperscale variant build task is named `build<...Hyperscale...>`, so detection can only over-download (harmless), never miss a real hyperscale build.

## Testing Done
- Manually exercised the gating conditional in isolation via an ad-hoc shell check (flag `true` → download; flag unset → skip). This repo has no automated test harness for `build-ancillary-repository.sh`, so no test file is added; the gating is validated end-to-end by the ab-pre-push builds below.
- `bash -n` syntax check.
- gradle `--dry-run`: `buildInternalHyperscaleAwsVmArtifacts` → flag true (download); `buildExternalStandardAwsVmArtifacts` → flag false (skip).

### ab-pre-push build #14553: SUCCESS (hyperscale-skip path verified)

- Build: https://selfservice-jenkins.eng-tools-prd.aws.delphixcloud.com/job/appliance-build-orchestrator-pre-push/14553/
- A full multi-variant (non-hyperscale) appliance build (downstream appliance-build/develop/pre-push #7003 → appliance-build-stage0/pre-push #12331) completed **SUCCESS**, exercising the skip path in the ancillary-repository step without regression.

### ab-pre-push build #14580: SUCCESS (hyperscale-download path verified)

- Build: https://selfservice-jenkins.eng-tools-prd.aws.delphixcloud.com/job/appliance-build-orchestrator-pre-push/14580/
- Tested: `appliance-build@1e63c01` (an earlier revision).
- Built `internal-hyperscale` on aws (`--no-tests`): pre-push #7029 → stage0 #12358 → stage1 #63817 — **SUCCESS**; `download_hyperscale_artifacts` ran and `delphix-hyperscale_2026.5.0_amd64.deb` was downloaded + added to the ancillary repo.

### ab-pre-push build #14584: SUCCESS (SHA-exact re-verification, post conflict-resolution)

- Build: https://selfservice-jenkins.eng-tools-prd.aws.delphixcloud.com/job/appliance-build-orchestrator-pre-push/14584/
- Tested: `appliance-build@2e5b04a` (against `develop`; **matches current PR head** — run after the `-n`-clause removal and after merging the DCT/hyperscale `whenReady` blocks into one when resolving the #886 conflict).
- Built `internal-hyperscale` on aws (`--no-tests`): pre-push #7033 → stage0 #12362 (`gradlew buildUpgradeImageInternalHyperscale`) → stage1 #63827 — **SUCCESS**.
- **Download + install verified:** stage1 #63827 ran `download_hyperscale_artifacts` (flag `true`), `delphix-hyperscale_2026.5.0_amd64.deb` downloaded + `[+] delphix-hyperscale_2026.5.0_amd64 added` to the ancillary repo, and the `appliance-build.hyperscale-common` ansible role then installed `delphix-hyperscale 2026.5.0` (4496 MB) into the image. Confirms the combined-block resolution builds hyperscale correctly.

## Review feedback
Addressed: the flag is registered as an `ancillaryRepository` input property and set on both branches (incremental up-to-date correctness); the code comment was reworded to state the real failure modes and then trimmed; and, per review, the gate now depends solely on the variant flag (the URI is still honored inside `download_hyperscale_artifacts` when a hyperscale variant is built).