### PR TITLE
DLPX-97941 appliance-build: skip downloading DCT artifacts when no DCT variant is built

### DIFF
--- a/live-build/build.gradle
+++ b/live-build/build.gradle
@@ -36,6 +36,21 @@ task ancillaryRepository(type: Exec) {
     commandLine "${rootProject.projectDir}/scripts/build-ancillary-repository.sh"
 }
 
+/*
+ * The ancillary repository is built once and shared by every variant built in
+ * this gradle invocation, so only download the DCT packages when a DCT variant
+ * is actually part of the build. We check the resolved task graph (which also
+ * catches DCT variants pulled in via aggregate tasks) and register the result
+ * as a task input so up-to-date checking rebuilds the repo when switching
+ * DCT<->non-DCT. Every DCT variant build task is named build<...Dct...>, so
+ * detection can only over-download (harmless), never miss a real DCT build.
+ */
+gradle.taskGraph.whenReady { graph ->
+    def buildDct = graph.allTasks.any { it.name.contains("Dct") }
+    ancillaryRepository.inputs.property("buildDctVariant", buildDct)
+    ancillaryRepository.environment "DELPHIX_BUILD_DCT_VARIANT", buildDct.toString()
+}
+
 createArtifactsDirTask(this)
 
 def artifactTypes = ["aws": "vmdk",

--- a/scripts/build-ancillary-repository.sh
+++ b/scripts/build-ancillary-repository.sh
@@ -85,10 +85,30 @@ mkdir -p "$WORK_DIRECTORY/artifacts"
 download_combined_packages_artifacts "$AWS_S3_URI_COMBINED_PACKAGES" \
 	"$WORK_DIRECTORY/artifacts"
 
-download_dct_artifacts "$AWS_S3_URI_DCT_PACKAGES" "$WORK_DIRECTORY/artifacts"
+#
+# The DCT packages are only installed by the DCT appliance variants, so only
+# download them when a DCT variant is being built (signalled by the
+# ancillaryRepository gradle task via DELPHIX_BUILD_DCT_VARIANT). This avoids
+# wastefully downloading them for the many builds (external-standard,
+# internal-dev, internal-qa, hyperscale, etc.) that never install them. When a
+# DCT variant is built, AWS_S3_URI_DCT_PACKAGES (if set) still selects a
+# specific build; otherwise download_dct_artifacts fetches the latest.
+#
+if [[ "$DELPHIX_BUILD_DCT_VARIANT" == "true" ]]; then
+	download_dct_artifacts "$AWS_S3_URI_DCT_PACKAGES" "$WORK_DIRECTORY/artifacts"
+else
+	echo "Skipping DCT artifact download: no DCT variant is being built."
+fi
 
 download_hyperscale_artifacts "$AWS_S3_URI_HYPERSCALE_COMPLIANCE_PACKAGES" "$WORK_DIRECTORY/artifacts"
 
+#
+# AWS_S3_URI_UCF_PACKAGES is an optional external variable set by the
+# devops-gate UCF pipeline; when it is unset, download_ucf_artifacts skips the
+# download. It is not a typo of AWS_S3_URI_DCT_PACKAGES, so the SC2153
+# misspelling warning below is a false positive and is disabled.
+#
+# shellcheck disable=SC2153
 download_ucf_artifacts "$AWS_S3_URI_UCF_PACKAGES" "$WORK_DIRECTORY/artifacts"
 
 #


### PR DESCRIPTION
## Problem
`build-ancillary-repository.sh` always calls `download_dct_artifacts`, which falls back to fetching the *latest* DCT build from S3 when no `AWS_S3_URI_DCT_PACKAGES` is provided. DCT packages are only installed by the DCT variants (`external-dct`, `internal-dct`), so every other build (`external-standard`, `internal-dev`, `internal-qa`, hyperscale, etc.) pulls DCT packages into the ancillary repo without ever installing them — wasting build time and bandwidth. This is the same pattern fixed for hyperscale in DLPX-97940.

(Note: UCF is not affected — `download_ucf_artifacts` already skips when no URI is set, since it never infers a `latest` path.)

## Solution
Gate the DCT download on whether a DCT variant is actually being built:
- `live-build/build.gradle`: in `gradle.taskGraph.whenReady`, detect a DCT variant (task name contains `Dct`) in the resolved graph, set `DELPHIX_BUILD_DCT_VARIANT` (both branches), and register it as an `ancillaryRepository` input property (correct up-to-date checking).
- `scripts/build-ancillary-repository.sh`: call `download_dct_artifacts` only when that flag is `true`; otherwise log a skip. When a DCT variant *is* built, `AWS_S3_URI_DCT_PACKAGES` (if set) is still honored inside `download_dct_artifacts` to pin a specific build.

Fails safe toward downloading; no devops-gate changes required.

## Testing Done
- Manually exercised the gating conditional in isolation via an ad-hoc shell check (flag `true` → download; flag unset → skip). This repo has no automated test harness for `build-ancillary-repository.sh`, so no test file is added (consistent with #885); the gating is validated end-to-end by the ab-pre-push builds below.
- `bash -n` syntax check.
- gradle `--dry-run`: `buildInternalDctAwsVmArtifacts` → DCT flag true (download); `buildExternalStandardAwsVmArtifacts` / `buildInternalHyperscaleAwsVmArtifacts` → DCT flag false (skip).

### ab-pre-push build #14559: FAILURE (unrelated infra; DCT-skip path verified)

- Build: https://selfservice-jenkins.eng-tools-prd.aws.delphixcloud.com/job/appliance-build-orchestrator-pre-push/14559/
- Tested: `appliance-build@d30da65` (against `develop`).
- Appliance build: **SUCCESS** — stage0 #12337 → stage1 #63751 / #63755 / #63757.
- **DCT-skip verified:** all three non-DCT stage1 builds logged `Skipping DCT artifact download: no DCT variant is being built.` and ran no `download_dct_artifacts` / DCT S3 sync.
- Suites: dx-integration-tests #35493 — SUCCESS; upgrade-testing #4581 (→ blackbox-chained #9485) — FAILURE, **unrelated to this change**: the QA engine VM became unreachable (HTTP/SSH connect timeouts, Windows iSCSI/RSS fetch error), not a build or package regression.
- The overall orchestrator FAILURE stems solely from that upgrade-testing environment timeout.

### ab-pre-push build #14579: SUCCESS (DCT-download path verified)

- Build: https://selfservice-jenkins.eng-tools-prd.aws.delphixcloud.com/job/appliance-build-orchestrator-pre-push/14579/
- Tested: `appliance-build@bf114de` (against `develop`; one commit behind current head — the later revision only dropped the redundant `-n "$AWS_S3_URI_DCT_PACKAGES"` clause, which does not change behavior when building DCT since the flag is `true`).
- Built `internal-dct` on aws (`--no-tests`): pre-push #7028 → stage0 #12357 (`gradlew buildUpgradeImageInternalDct`) → stage1 #63816 — **SUCCESS**.
- **DCT-download verified:** stage1 #63816 ran `download_dct_artifacts` (flag `true`) → `dct/develop/post-push/5314` → `delphix-dct_2026.5.0-….deb` downloaded, `SHA256SUMS OK`, `[+] delphix-dct… added` to the ancillary repo. Confirms the gating does not break the case where DCT packages are needed.