### PR TITLE
TOOL-30651 Install Java 21 on DCoL hosts

### DIFF
--- a/live-build/variants/internal-dcenter/package-lists/dcenter.list.chroot
+++ b/live-build/variants/internal-dcenter/package-lists/dcenter.list.chroot
@@ -25,6 +25,7 @@ libsasl2-dev
 nfs-kernel-server
 openjdk-11-jdk-headless
 openjdk-17-jdk-headless
+openjdk-21-jdk-headless
 python3.12
 python3.12-dev
 python3-venv


### PR DESCRIPTION
<h2> Problem </h2>

DCoL hosts (`dcol1`, `dcol2`, `dcol-dev`, `scale-dc`) are Jenkins static SSH agents whose
`javaPath` in devops-gate's JCasC is being bumped from JDK 17 to JDK 21
(delphix/devops-gate#4576, TOOL-30521). These hosts are not Docker containers and are not
covered by devops-gate's Ansible roles for Java — their JDK comes entirely from the
package list baked into the DCoL OVA image built from this repo. Without this change,
every static-agent connection using the new `javaPath` fails with `No such file or
directory` once devops-gate#4576 merges, since `openjdk-21-jdk-headless` is not present on
any DCoL host today. This already reproduced live on a devops-gate developer controller
against `dcol1`.

<h2> Solution </h2>

Add `openjdk-21-jdk-headless` to `dcenter.list.chroot`, following the identical additive
pattern used for the JDK 11 → 17 migration (#782, TOOL-21808) — keep the older JDK
packages in place, just add the new one.

Per the historical precedent, rollout is not uniform across DCoL hosts once this merges:
- `dcol-dev` and `dcol2` track `develop`-branch appliance builds and will pick this up
  automatically once `appliance-build-orchestrator-pre-push` builds the new OVA and
  `sync-ova-into-dcenter` pushes it.
- `dcol1` and `scale-dc` track a release-branch appliance build and will **not** pick this
  up automatically — last time (TOOL-21808) this required either a release-branch
  backport or a manual `apt install openjdk-17-jdk-headless` stopgap directly on the host.
  The same will likely be needed here for JDK 21.

<h2> Testing Done </h2>

- [x] Confirmed the package addition matches the exact pattern from #782 (diff-only,
  additive, no removals).


Companion to delphix/devops-gate#4576 and delphix/pipeline-shared#373 (TOOL-30521 /
TOOL-30651).
