### PR TITLE
DLPXQA-53429 dlpx-qa-develop image missing libharfbuzz0b causing all masking execution tests to fail with HTTP 500

### DIFF
--- a/live-build/misc/ansible-roles/appliance-build.masking-common/tasks/main.yml
+++ b/live-build/misc/ansible-roles/appliance-build.masking-common/tasks/main.yml
@@ -16,5 +16,8 @@
 
 ---
 - apt:
-    name: delphix-masking
+    name:
+      - delphix-masking
+      - libharfbuzz0b
+      - libgraphite2-3
     state: present


### PR DESCRIPTION
## Problem

All masking job execution tests fail with HTTP 500 on the `dlpx-qa-develop` image running **Java17 based masking engine** starting from the first test that calls `POST /masking/api/executions`. Once triggered, the error cascades — every subsequent execution test fails for the lifetime of the Tomcat process.

The root cause is that two native libraries required by `libfontmanager.so` in JDK 17 are absent on the `dlpx-qa-develop` image:

- `libharfbuzz0b` — HarfBuzz text shaping engine
- `libgraphite2-3` — Graphite2 font shaping library

When the masking service calls `generateInventoryReport()` as part of `createExecution`, JasperReports initializes the Java font stack, which tries to load `libfontmanager.so`, which fails with:

```
UnsatisfiedLinkError: libfontmanager.so: libharfbuzz.so.0: cannot open shared object file: No such file or directory
```

Because this happens in a static class initializer (`FontManagerNativeLibrary.<clinit>`), the JVM permanently marks the class as failed for the process lifetime. Every subsequent call to `generateInventoryReport` then throws `NoClassDefFoundError`, making all following execution tests fail with 500.

Both libraries are only `Recommends` (not `Depends`) on `openjdk-17-jre-headless`. Since image builds run with `--apt-recommends false` (set in `scripts/run-live-build.sh`), they are silently skipped. The `dlpx-develop` image was unaffected because `gdebi` (a dev tool absent from the QA image) accidentally dragged in `libharfbuzz0b` via its GTK3/Pango dependency chain.

## Solution

Explicitly add `libharfbuzz0b` and `libgraphite2-3` to the `appliance-build.masking-common` Ansible role. Since these are runtime dependencies of the masking service (not QA-specific), they belong alongside `delphix-masking` in the common role rather than in `qa-internal`.

## Changes

| File | Change |
|------|--------|
| `masking-common/tasks/main.yml` | Add `libharfbuzz0b` and `libgraphite2-3` as explicit apt dependencies alongside `delphix-masking` |

## Implementation Details

Both libraries are runtime dependencies of `/usr/lib/jvm/java-17-openjdk-amd64/lib/libfontmanager.so` introduced in JDK 11+. JDK 8's `libfontmanager.so` had no HarfBuzz or Graphite2 dependency, which is why the issue only surfaced after the Java 17 migration.

Confirmed missing on the failing image:
```
ldd /usr/lib/jvm/java-17-openjdk-amd64/lib/libfontmanager.so | grep "not found"
    libharfbuzz.so.0 => not found
    libgraphite2.so.3 => not found
```

Confirmed present on the passing image (arrived accidentally via `gdebi` → `libgtk-3-0t64` → `libpango-1.0-0` → `libharfbuzz0b`).

Tracked in DLPXQA-53429.

## Testing Done

Verified on a VM created with new image built with this PR fix (`ip-10-110-242-181`) using `pre-push` job:
https://selfservice-jenkins.eng-tools-prd.aws.delphixcloud.com/job/appliance-build-orchestrator-pre-push/14678/console
```
saurabh.rusia@dlpxdc:~$ dc clone-latest -w -S T3_XLARGE dlpx-saurabh.rusia-develop dlpx-develop-pre-push-srusia
dlpx-develop-pre-push-srusia - dlpx-saurabh.rusia-develop
APP                                       APPLIANCE_BUILD                           DLPX        IMAGE_IDENTIFIER                                                                                                          MASKING
fd2ccf07020bb635a55ce285d5fbc8fe430b6c08  844f06f917684ad3c501ece63706043ee8f53dd4  2026.5.0.0  s3://dev-de-images/builds/jenkins-selfservice/appliance-build/develop/pre-push/7118/internal-qa-aws/internal-qa-aws.vmdk  b4be0f47008303e7a72829f2acaa9d8dc7be1269
```

**Blackbox Tests**
https://selfservice-jenkins.eng-tools-prd.aws.delphixcloud.com/job/blackbox-self-service/225780/consoleFull

| Check | Result |
|-------|--------|
| `dpkg -l libharfbuzz0b libgraphite2-3` — both show `ii` (installed) | ✅ |
| Installed via Ansible apt task, NOT via `gdebi` or GTK/Pango chain | ✅ |
| `apt-cache rdepends --installed libharfbuzz0b` — only `openjdk-17-jre-headless` | ✅ |
| `gdebi` not installed on image | ✅ |
| `ldd libfontmanager.so \| grep "not found"` — only `libjvm.so` (expected ldd artifact) | ✅ |
| Library file permissions `644` (world-readable, masking user can load them) | ✅ |
| Masking service starts cleanly — no `UnsatisfiedLinkError` or `ExceptionInInitializerError` in `catalina.out` | ✅ |
| Masking execution tests pass | ✅ |

```
delphix@ip-10-110-242-181:~$ dpkg -l libharfbuzz0b libgraphite2-3
Desired=Unknown/Install/Remove/Purge/Hold
| Status=Not/Inst/Conf-files/Unpacked/halF-conf/Half-inst/trig-aWait/Trig-pend
|/ Err?=(none)/Reinst-required (Status,Err: uppercase=bad)
||/ Name                 Version                 Architecture Description
+++-====================-=======================-============-====================================================
ii  libgraphite2-3:amd64 1.3.14-2ubuntu0.24.04.1 amd64        Font rendering engine for Complex Scripts -- library
ii  libharfbuzz0b:amd64  8.3.0-2build2           amd64        OpenType text shaping engine (shared library)
delphix@ip-10-110-242-181:~$
delphix@ip-10-110-242-181:~$ apt-mark showmanual | grep -E "harfbuzz|graphite"
libgraphite2-3
libharfbuzz0b
delphix@ip-10-110-242-181:~$ apt-mark showauto  | grep -E "harfbuzz|graphite"
delphix@ip-10-110-242-181:~$ dpkg -l gdebi 2>/dev/null | grep -v "^[|+]"
delphix@ip-10-110-242-181:~$ apt-cache rdepends --installed libharfbuzz0b | grep -v libharfbuzz
Reverse Depends:
  openjdk-17-jre-headless
delphix@ip-10-110-242-181:~$ apt-cache rdepends --installed libharfbuzz0b | grep -v libharfbuzz
Reverse Depends:
  openjdk-17-jre-headless
delphix@ip-10-110-242-181:~$ ldd /usr/lib/jvm/java-17-openjdk-amd64/lib/libfontmanager.so | grep "not found"
	libjvm.so => not found
	libjvm.so => not found
	libjvm.so => not found
delphix@ip-10-110-242-181:~$ ls -la /lib/x86_64-linux-gnu/libharfbuzz.so* /lib/x86_64-linux-gnu/libgraphite2.so*
lrwxrwxrwx 1 root root      17 Jun 15 22:38 /lib/x86_64-linux-gnu/libgraphite2.so.2.0.0 -> libgraphite2.so.3
lrwxrwxrwx 1 root root      21 Jun 15 22:38 /lib/x86_64-linux-gnu/libgraphite2.so.3 -> libgraphite2.so.3.2.1
-rw-r--r-- 1 root root  149776 Jun 15 22:38 /lib/x86_64-linux-gnu/libgraphite2.so.3.2.1
lrwxrwxrwx 1 root root      24 Mar 31  2024 /lib/x86_64-linux-gnu/libharfbuzz.so.0 -> libharfbuzz.so.0.60830.0
-rw-r--r-- 1 root root 1101752 Mar 31  2024 /lib/x86_64-linux-gnu/libharfbuzz.so.0.60830.0
delphix@ip-10-110-242-181:~$
delphix@ip-10-110-242-181:~$ sudo systemctl status delphix-masking | head -10
● delphix-masking.service - Delphix Masking Service
     Loaded: loaded (/usr/lib/systemd/system/delphix-masking.service; disabled; preset: enabled)
     Active: active (running) since Fri 2026-07-31 11:04:51 UTC; 2min 16s ago
    Process: 13398 ExecStartPre=/opt/delphix/masking/bin/linux/svc-masking-pre-start.sh (code=exited, status=0/SUCCESS)
    Process: 13426 ExecStart=/opt/delphix/masking/bin/linux/svc-masking.sh (code=exited, status=0/SUCCESS)
   Main PID: 13476 (java)
      Tasks: 63 (limit: 18220)
     Memory: 1.7G (peak: 1.7G)
        CPU: 1min 51.682s
     CGroup: /system.slice/delphix-masking.service
delphix@ip-10-110-242-181:~$ grep -i "UnsatisfiedLinkError\|ExceptionInInitializer\|libharfbuzz\|libgraphite" \
    /var/delphix/masking/tomcat/logs/catalina.out | tail -20
delphix@ip-10-110-242-181:~$
```