### PR TITLE
DLPX-98271 Retire legacy autofs /home during upgrade so the home dataset stays mounted

### DIFF
--- a/upgrade/upgrade-scripts/common.sh
+++ b/upgrade/upgrade-scripts/common.sh
@@ -684,3 +684,73 @@ function harden_home_mount_options() {
 		die "failed to add nodev,nosuid to /home entry in /etc/fstab"
 	fi
 }
+
+#
+# Retire any legacy autofs management of /home before the home-dataset
+# migration and the package phase. Engines that automount home directories
+# via autofs (e.g. LDAP-integrated ones) carry a "/home auto_home" entry in
+# /etc/auto.master and run autofs.service. Inside the upgrade container that
+# service starts and takes over /home, deactivating the home-dataset mount
+# established from the container's fstab. The upgrade container has no
+# network, so the autofs map never resolves and /home is left empty; package
+# maintainer scripts that write under /home (e.g. the delphix-virtualization
+# postinst creating /home/cli/.ssh) then fail.
+#
+# Remove only the /home autofs mapping -- other maps (e.g. /net) are left
+# intact -- and ensure /home is the home dataset. This is a no-op on engines
+# that do not automount /home (fresh installs, non-LDAP engines), so it is
+# safe to call unconditionally.
+#
+function disable_autofs_home() {
+	local removed=false
+	local f
+
+	if grep -qE '^[[:space:]]*/home[[:space:]]' /etc/auto.master 2>/dev/null; then
+		sed -i -E '/^[[:space:]]*\/home[[:space:]]/d' /etc/auto.master ||
+			die "failed to remove /home entry from /etc/auto.master"
+		removed=true
+	fi
+
+	if [[ -d /etc/auto.master.d ]]; then
+		while IFS= read -r f; do
+			[[ -n "$f" ]] || continue
+			sed -i -E '/^[[:space:]]*\/home[[:space:]]/d' "$f" ||
+				die "failed to remove /home entry from '$f'"
+			removed=true
+		done < <(grep -rlE '^[[:space:]]*/home[[:space:]]' /etc/auto.master.d/ 2>/dev/null)
+	fi
+
+	#
+	# Nothing referenced /home via autofs; leave the system untouched.
+	#
+	$removed || return 0
+
+	#
+	# Fully stop autofs rather than reloading it: a running daemon
+	# asynchronously expires and unmounts /home shortly after we remount the
+	# dataset, so a reload races its cleanup thread. Stopping releases /home
+	# synchronously. Other maps (e.g. /net) are unused inside the upgrade
+	# container, and on the upgraded root autofs starts fresh from the edited
+	# maps -- without /home -- at boot. The map edit above is the durable
+	# protection: autofs will not reclaim /home even if it is later restarted.
+	#
+	timeout 30 systemctl stop autofs 2>/dev/null || true
+
+	#
+	# Ensure /home is the home dataset, not an autofs mount or an empty
+	# directory, before the package phase. Mount it via its systemd unit so
+	# systemd owns and tracks it; a bare "mount /home" leaves home.mount
+	# inactive and a later daemon-reload can unmount it. Only act when fstab
+	# maps a dataset to /home (the upgrade container and post-migration
+	# engines); on a pre-migration engine migrate_export_home_to_home mounts
+	# it after rewriting fstab.
+	#
+	if grep -qE '^[^#][^[:space:]]*[[:space:]]+/home[[:space:]]' /etc/fstab &&
+		[[ "$(findmnt -no FSTYPE /home 2>/dev/null)" != "zfs" ]]; then
+		umount /home 2>/dev/null || true
+		systemctl start home.mount 2>/dev/null || mount /home ||
+			die "failed to mount /home dataset after disabling autofs"
+		[[ "$(findmnt -no FSTYPE /home 2>/dev/null)" == "zfs" ]] ||
+			die "/home is not the home dataset after disabling autofs"
+	fi
+}

--- a/upgrade/upgrade-scripts/execute
+++ b/upgrade/upgrade-scripts/execute
@@ -313,11 +313,18 @@ disarm_mgmt_restart
 # run; otherwise they would create/modify content under a /home directory on
 # the root filesystem that the dataset mount later shadows.
 #
-# Both functions (in common.sh) self-guard and are no-ops once the engine
-# already uses /home -- i.e. on fresh installs and inside upgrade
+# disable_autofs_home must run first: on engines that automount /home via
+# autofs (e.g. LDAP-integrated), the cloned root starts autofs.service in the
+# container, which takes over /home and unmounts the home dataset. Retiring
+# the autofs /home mapping and remounting the dataset keeps /home populated
+# for the migration and the package phase.
+#
+# The remaining functions (in common.sh) self-guard and are no-ops once the
+# engine already uses /home -- i.e. on fresh installs and inside upgrade
 # containers, whose fstab maps the dataset to /home. migrate must run before
 # harden, which hardens the /home fstab entry the migration creates.
 #
+disable_autofs_home
 migrate_export_home_to_home
 harden_home_mount_options
 


### PR DESCRIPTION
## Problem

Upgrading to a release containing DLPX-86523 fails during the upgrade container's package phase on any engine that automounts `/home` via autofs (e.g. LDAP-integrated engines with a `/home auto_home` entry in `/etc/auto.master`). The `delphix-virtualization` postinst dies at `mkdir -m 700 /home/cli/.ssh` -> "No such file or directory", cascading to `delphix-masking`, then `execute` -> `upgrade-container:do_upgrade_container:700`.

DLPX-86523 mounts the home dataset at `/home` in the container (via fstab -> `home.mount`), but the container root is a clone of the source engine, which still runs `autofs.service` with a `/home auto_home` map. At container boot autofs takes over `/home` and deactivates the zfs mount; the container has no network so the LDAP map never resolves and `/home` is left empty. This also fails during upgrade *verify* (verify runs `execute` in a container). Standard CI/QA engines do not use autofs/LDAP home directories, which is why this was not caught.

## Solution

Add `disable_autofs_home()` (in `common.sh`), called from `execute` before `migrate_export_home_to_home` / the package phase:

- Remove the `/home` entry from `/etc/auto.master`(.d) -- durable: autofs will not reclaim `/home` even if restarted.
- **Stop** autofs rather than reloading it -- a running daemon asynchronously expires and re-unmounts `/home` ~1s after the remount, racing its cleanup thread.
- Mount the dataset via `systemctl start home.mount` so systemd owns/tracks it (a bare `mount /home` is left inactive and a later daemon-reload can unmount it), then assert `/home` is the zfs dataset.
- No-op on engines without an autofs `/home` (fresh installs, non-LDAP engines); other autofs maps (e.g. `/net`) are left intact.

## Testing Done

- Root-caused and reproduced on internal engines 10.43.1.30 and 10.43.1.31 (2026.1.0.0 -> 2026.4.0.0, both with LDAP-backed autofs `/home`); the container boot journal confirmed autofs deactivating `home.mount` followed by the `mkdir /home/cli/.ssh` failure.
- Prototyped on 10.43.1.30: an initial reload-based approach failed (a still-running autofs re-unmounted `/home` ~1s later); the committed stop-based approach got the upgrade past the previously-failing `delphix-virtualization`/`delphix-masking` configure step.
- Confirmed the change is a no-op on a non-autofs control engine (`dm-2025-5-0-2`): `disable_autofs_home` finds no `/home auto_home` entry and returns early.
- `bash -n` clean on `common.sh` and `execute`.
- Follow-ups before merge: a clean end-to-end upgrade on an autofs/LDAP engine (the prototype run stopped later at an unrelated memory precondition), and adding such an engine to the upgrade regression matrix to close the coverage gap.