### PR TITLE
DLPX-97456 use non-recursive bind for /domain0 in upgrade container

### DIFF
--- a/upgrade/upgrade-scripts/upgrade-container
+++ b/upgrade/upgrade-scripts/upgrade-container
@@ -363,9 +363,19 @@ function create_upgrade_container() {
 	# flyway migration) is compatible with the new version of the
 	# Virtualization application.
 	#
+	# We use "norbind" to make this a non-recursive bind mount, so
+	# that only the top-level "/domain0" filesystem is mounted in
+	# the container, rather than it and all of the (potentially,
+	# tens of thousands of) per-VDB filesystems mounted underneath
+	# it. The "daemon-reload" of systemd inside the container (e.g.
+	# run via the packaging scripts during upgrade) scales with the
+	# number of mounts in the container, so we must avoid these
+	# per-VDB mounts in the container, to avoid multi-minute reload
+	# times on systems with many VDBs; see DLPX-97456 for details.
+	#
 	if [[ -d "/domain0" ]]; then
 		cat >>"/etc/systemd/nspawn/$CONTAINER.nspawn" <<-EOF ||
-			Bind=/domain0
+			Bind=/domain0:/domain0:norbind
 		EOF
 			die "failed to add '/domain0' to container config file"
 	fi


### PR DESCRIPTION
<details open>
<summary><h2> Problem </h2></summary>

The `upgrade-container` script adds `Bind=/domain0` to the generated `.nspawn` file so the upgrade-verify JAR can validate MDS contents. `Bind=` is recursive by default, so every host mount underneath `/domain0` is inherited into the container's mount namespace.

On a large engine that is a problem. In ESCL-6013 the customer's engine carries ~14.4k mounted filesystems under `/domain0`, all of which the container's systemd tracks as mount units. Starting with Ubuntu 24.04 (systemd 255), `systemctl daemon-reload` is quadratic in the number of units (`unit_free()` -> `unit_add_family_to_cgroup_realize_queue()` recomputes slice member masks across all siblings per freed unit, introduced in systemd v247, commit `4c591f3996`), so once the in-container dist-upgrade re-execs into the new systemd, each of the ~136 postinst-triggered reloads takes 80-636s. The verify spends ~6.4h of a ~6.8h job inside reloads, and while PID 1 is reloading it doesn't service D-Bus, so bus clients give up after 25s; e.g. `systemctl enable auditd` in the `delphix-platform-esx` postinst fails with "Reload daemon failed: Connection timed out", which fails the verify, and `machinectl shell` from the host times out, which blocks support from diagnosing the container.

Measured on `dlpx-24.0.0.0` and `dlpx-2025.5.0.2` VMs with the same tooling and ~14k mounts:

```
24.0.0.0   (systemd 245):  1.4s @2k, 2.5s @5k, 4.7s @10k, 6.4s @14k    (linear)
2025.5.0.2 (systemd 255):  144.6s / 105.9s / 118.6s @14k               (quadratic)
```

This change already ships to customers in HF-1582 (2025.5.0.2) and HF-1588 (2026.2.0.1), but it exists on no mainline branch. https://www.github.com/delphix/appliance-build/pull/871 was closed while the timeflow-demotion work (DLPX-97587) was pursued as the root-cause fix, on the reasoning that demotion collapses the mount count on the host as well as in the container, rather than only hiding it from the container. That reasoning still holds, but it leaves two gaps. Demotion landed in `dlpx-app-gate` develop with the sweep gated off (`STORAGE.TIMEFLOW_DEMOTION.SWEEP_ENABLED` defaults to `false`), so nothing collapses the mount count unless an operator asks for it. And `upgrade-container` runs from the target version's upgrade image, so an engine sitting on 2025.5.0.2+HF-1582 today loses this protection the moment it upgrades onto a develop-based release.

</details>

<details open>
<summary><h2> Solution </h2></summary>

The solution taken in this PR is to make the bind non-recursive:

```
Bind=/domain0  ->  Bind=/domain0:/domain0:norbind
```

`/domain0` itself is still mounted and readable inside the container; only the per-VDB child mounts are excluded. The `norbind` option dates to systemd v233, so it's supported by the v245 nspawn on the oldest hosts we upgrade from.

This is complementary to demotion rather than a replacement for it. Demotion shrinks the mount count at its source and helps the running host after the apply; `norbind` keeps the container from inheriting the storm regardless of what the host looks like.

</details>

<details open>
<summary><h2> Testing Done </h2></summary>

The hunk here is byte-identical to `dfea14e63e468780de50e689323624122e318952` on `projects/HF-1582`, i.e. to what ships in HF-1582 and HF-1588; diffing the two patches shows no difference other than the blob index line. Note that the surrounding file has drifted on develop since the hotfix branched (copyright year, and the `/export/home` to `/home` move), so it's the applied hunk that is identical, not the whole file. It applied with no conflicts.

`check-shellcheck` and `check-ansible` pass. Locally, `shellcheck -e SC1090 -e SC1091 -e SC2329 upgrade/upgrade-scripts/upgrade-container` is also clean, matching the exclusions in `.github/workflows/main.yml`.

The change itself was validated on a 2025.5.0.2 VM with 14k mounts under `/domain0`: the container comes up with 51 mounts instead of 14,051, and `daemon-reload` drops from ~2 minutes to ~0.3s. It also passed a full `upgrade-testing` run on the original branch, https://selfservice-jenkins.eng-tools-prd.aws.delphixcloud.com/job/upgrade-testing/4487/. That run predates this PR, so it exercised the same one-line change on an older develop base.

</details>

<details open>
<summary><h2> Notes to Reviewers </h2></summary>

Two caveats from the ESCL-6013 analysis are still open and are unchanged here:

1. the bind is still propagation-slave with `norbind`, so mounts created on the host after container start still propagate in. That's bounded by host churn during the verify window (tens, not 14k), but could be eliminated entirely by making the bind source private
2. inside the container, the child dataset mountpoints under `/domain0` appear as empty directories. It'd be worth a confirmation from the app team that the upgrade-verify JAR only reads top-level `/domain0` contents and doesn't descend into the per-timeflow filesystems

Full analysis (bundle forensics, stack profiles, repro methodology) is in ESCL-6013.

</details>
