### PR TITLE
DLPX-98618 appliance-build: generate per-image CycloneDX BOM via Syft chroot scan

### DIFF
--- a/bootstrap/roles/appliance-build.bootstrap/tasks/main.yml
+++ b/bootstrap/roles/appliance-build.bootstrap/tasks/main.yml
@@ -81,33 +81,6 @@
     state: present
     update_cache: true
 
-# Syft and cyclonedx-cli are used by scripts/run-live-build.sh to generate and validate a
-# CycloneDX SBOM for each built image. Neither is available through the Delphix package
-# mirror -- they're upstream GitHub-release binaries, not Ubuntu packages -- so each is
-# pinned to an explicit version and checksum-verified here instead of installed via apt.
-- name: Download pinned Syft .deb
-  ansible.builtin.get_url:
-    url: https://github.com/anchore/syft/releases/download/v1.46.0/syft_1.46.0_linux_amd64.deb
-    dest: /tmp/syft_1.46.0_linux_amd64.deb
-    checksum: sha256:003f82f0d70350a2e7795ecc43f86b50e2c883055ffaf82b309a0a274c62915d
-    mode: "0644"
-
-- name: Install Syft
-  ansible.builtin.apt:
-    deb: /tmp/syft_1.46.0_linux_amd64.deb
-
-# cyclonedx-cli ships only a bare per-platform binary upstream (no .deb, and no official
-# checksums file); the checksum below was computed locally from the downloaded binary at
-# the time this version was pinned. The destination filename must be exactly
-# "cyclonedx-cli" -- that's the command name run-live-build.sh invokes, not upstream's own
-# convention of renaming the asset to "cyclonedx".
-- name: Download pinned cyclonedx-cli binary
-  ansible.builtin.get_url:
-    url: https://github.com/CycloneDX/cyclonedx-cli/releases/download/v0.32.0/cyclonedx-linux-x64
-    dest: /usr/local/bin/cyclonedx-cli
-    checksum: sha256:454879e6a4a405c8a13bff49b8982adcb0596f3019b26b0811c66e4d7f0783e1
-    mode: "0755"
-
 # awscli is distributed via pip or snap on 24.04. While the package is not required by the product,
 # it is required by appliance-build itself.
 - name: Install awscli python package

--- a/bootstrap/roles/appliance-build.bootstrap/tasks/main.yml
+++ b/bootstrap/roles/appliance-build.bootstrap/tasks/main.yml
@@ -81,6 +81,33 @@
     state: present
     update_cache: true
 
+# Syft and cyclonedx-cli are used by scripts/run-live-build.sh to generate and validate a
+# CycloneDX SBOM for each built image. Neither is available through the Delphix package
+# mirror -- they're upstream GitHub-release binaries, not Ubuntu packages -- so each is
+# pinned to an explicit version and checksum-verified here instead of installed via apt.
+- name: Download pinned Syft .deb
+  ansible.builtin.get_url:
+    url: https://github.com/anchore/syft/releases/download/v1.46.0/syft_1.46.0_linux_amd64.deb
+    dest: /tmp/syft_1.46.0_linux_amd64.deb
+    checksum: sha256:003f82f0d70350a2e7795ecc43f86b50e2c883055ffaf82b309a0a274c62915d
+    mode: "0644"
+
+- name: Install Syft
+  ansible.builtin.apt:
+    deb: /tmp/syft_1.46.0_linux_amd64.deb
+
+# cyclonedx-cli ships only a bare per-platform binary upstream (no .deb, and no official
+# checksums file); the checksum below was computed locally from the downloaded binary at
+# the time this version was pinned. The destination filename must be exactly
+# "cyclonedx-cli" -- that's the command name run-live-build.sh invokes, not upstream's own
+# convention of renaming the asset to "cyclonedx".
+- name: Download pinned cyclonedx-cli binary
+  ansible.builtin.get_url:
+    url: https://github.com/CycloneDX/cyclonedx-cli/releases/download/v0.32.0/cyclonedx-linux-x64
+    dest: /usr/local/bin/cyclonedx-cli
+    checksum: sha256:454879e6a4a405c8a13bff49b8982adcb0596f3019b26b0811c66e4d7f0783e1
+    mode: "0755"
+
 # awscli is distributed via pip or snap on 24.04. While the package is not required by the product,
 # it is required by appliance-build itself.
 - name: Install awscli python package

--- a/live-build/build.gradle
+++ b/live-build/build.gradle
@@ -150,15 +150,18 @@ for (variant in allVariants) {
                     case upgradeArtifactsRunType:
                         outputs.file "${buildDir}/artifacts/${variant}-${platform}.debs.tar.gz"
                         outputs.file "${buildDir}/artifacts/${variant}-${platform}.packages.list"
+                        outputs.file "${buildDir}/artifacts/${variant}-${platform}.cdx.json"
                         break
                     case vmArtifactsRunType:
                         outputs.file "${buildDir}/artifacts/${variant}-${platform}.${artifactTypes[platform]}"
                         outputs.file "${buildDir}/artifacts/${variant}-${platform}.packages.list"
+                        outputs.file "${buildDir}/artifacts/${variant}-${platform}.cdx.json"
                         break
                     case allRunType:
                         outputs.file "${buildDir}/artifacts/${variant}-${platform}.debs.tar.gz"
                         outputs.file "${buildDir}/artifacts/${variant}-${platform}.${artifactTypes[platform]}"
                         outputs.file "${buildDir}/artifacts/${variant}-${platform}.packages.list"
+                        outputs.file "${buildDir}/artifacts/${variant}-${platform}.cdx.json"
                         break
                 }
 

--- a/live-build/config/hooks/configuration/95-generate-sbom.binary
+++ b/live-build/config/hooks/configuration/95-generate-sbom.binary
@@ -1,0 +1,61 @@
+#!/bin/bash -ex
+#
+# Copyright 2026 Delphix
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+#
+# Generate a CycloneDX SBOM for this image by scanning the populated
+# "binary" directory (i.e. the appliance's root filesystem). The syft and
+# cyclonedx-cli tools used here are build-host-only tooling, installed
+# onto the build host by build-ancillary-repository.sh; they are never
+# installed into the appliance itself.
+#
+# This hook lives in "configuration" (rather than "vm-artifacts") and is
+# numbered above every other hook, so that it always runs, for every run
+# type, and runs last. Both matter: build.gradle declares "*.cdx.json" as
+# an output of the "upgrade-artifacts" run type, which never copies the
+# "vm-artifacts" hooks; and running last means the SBOM reflects whatever
+# every earlier hook (the apt cache cleanup, the hostname clearing, etc.)
+# left behind in the "binary" directory.
+#
+# Only the dpkg cataloger is enabled: dpkg is the sole source that can
+# authoritatively attribute a file on disk to the package that placed it
+# there. Vendored/extracted third-party content bundled inside a larger
+# installed package (jars, npm modules, Rust crates, etc.) isn't
+# attributable this way, so language-level catalogers are left off here
+# to avoid misattributing it; that content is covered separately by
+# per-package sidecar SBOMs produced upstream in linux-pkg, merged in at
+# a later stage.
+#
+# SYFT_FILE_METADATA_SELECTION=none suppresses Syft's default behavior of
+# emitting a separate CycloneDX "file" component (with SHA-1/SHA-256
+# hashes) for every individual file owned by every cataloged package.
+# That's unrelated to --select-catalogers (which only scopes *package*
+# catalogers) and, left at its default, balloons the output to one
+# "file" entry per file on the appliance -- tens of thousands of them --
+# instead of the flat, per-package pkg:deb document this hook is meant to
+# produce.
+#
+SYFT_FILE_METADATA_SELECTION=none syft scan dir:binary \
+	--select-catalogers dpkg \
+	--source-name "$ARTIFACT_NAME" \
+	--source-version "$DELPHIX_APPLIANCE_VERSION" \
+	-o "cyclonedx-json@1.6=$ARTIFACT_NAME.cdx.json"
+
+cyclonedx-cli validate \
+	--input-file "$ARTIFACT_NAME.cdx.json" \
+	--input-format json \
+	--input-version v1_6 \
+	--fail-on-errors

--- a/scripts/build-ancillary-repository.sh
+++ b/scripts/build-ancillary-repository.sh
@@ -147,4 +147,37 @@ extract_debs_into_dir "$WORK_DIRECTORY/artifacts" "$WORK_DIRECTORY/debs"
 #
 build_ancillary_repository "$WORK_DIRECTORY/debs"
 
+#
+# Syft and cyclonedx-cli are used to generate and validate the CycloneDX
+# SBOM for each image (see the "95-generate-sbom.binary" live-build
+# hook). They're consumed as .deb's from the ancillary repository, like
+# every other first-party Delphix package, but unlike those they're
+# build-host-only tooling: they're installed onto the build host here,
+# and are never listed in any of live-build's chroot package lists, so
+# they never end up inside the appliance image itself.
+#
+# They're installed here, rather than from run-live-build.sh, because
+# the ancillary repository is built once and shared by every
+# variant/platform combination in the build, whereas run-live-build.sh
+# runs once per combination; there's no reason to reinstall this tooling
+# for each of them. Installing directly from the .deb's that were just
+# fed into Aptly also means this needs neither a running "aptly serve",
+# nor any modification of the build host's APT sources configuration.
+#
+# Note that these are installed via "apt-get install <path>" rather than
+# "dpkg -i <path>": delphix-cyclonedx-cli declares real dependencies
+# (libicu, plus the usual shared library ones), and dpkg, unlike apt,
+# won't resolve those. Passing apt a path rather than a package name
+# still installs exactly the .deb we just built the repository from,
+# while letting the build host's existing APT sources satisfy the
+# dependencies.
+#
+for pkg in delphix-syft delphix-cyclonedx-cli; do
+	deb=$(find "$WORK_DIRECTORY/debs" -maxdepth 1 -name "${pkg}_*.deb" |
+		head -n 1)
+	[[ -n "$deb" ]] ||
+		die "Could not find a '$pkg' package in the ancillary repository."
+	apt-get install -y --no-install-recommends "$deb"
+done
+
 rm -rf "$WORK_DIRECTORY"

--- a/scripts/run-live-build.sh
+++ b/scripts/run-live-build.sh
@@ -17,7 +17,7 @@
 
 . "${BASH_SOURCE%/*}/common.sh"
 
-check_env DELPHIX_PACKAGE_MIRROR_MAIN DELPHIX_PACKAGE_MIRROR_SECONDARY
+check_env DELPHIX_PACKAGE_MIRROR_MAIN DELPHIX_PACKAGE_MIRROR_SECONDARY DELPHIX_APPLIANCE_VERSION
 
 TOP=$(git rev-parse --show-toplevel 2>/dev/null)
 
@@ -170,6 +170,30 @@ lb config \
 	--mirror-binary-backports "$DELPHIX_PACKAGE_MIRROR_MAIN"
 
 lb build
+
+#
+# Syft and cyclonedx-cli are consumed exactly the same way as every other
+# first-party Delphix package: as .deb's in the ancillary repository (see
+# build-ancillary-repository.sh), already being served locally above. The
+# one difference is that these are build-host-only tooling for the SBOM
+# step below, never installed into the appliance chroot -- so, unlike
+# "lb config"'s --mirror-chroot/--mirror-binary (which points the chroot's
+# own bootstrap at config/archives/localhost.list), these are installed
+# directly onto the build host itself via apt, pointed at that same
+# ancillary repository, before the still-running local Aptly server
+# serving it is killed just below.
+#
+# Reuse config/archives/localhost.list itself (rather than re-typing the
+# same "deb [trusted=yes] http://localhost:8080 noble main" line here) so
+# this can never silently drift out of sync with what the chroot uses.
+#
+cp config/archives/localhost.list /etc/apt/sources.list.d/ancillary-repository.list
+apt-get update \
+	-o Dir::Etc::sourcelist="sources.list.d/ancillary-repository.list" \
+	-o Dir::Etc::sourceparts="-" \
+	-o APT::Get::List-Cleanup="0"
+apt-get install -y --no-install-recommends delphix-syft delphix-cyclonedx-cli
+rm -f /etc/apt/sources.list.d/ancillary-repository.list
 
 kill -9 $APTLY_SERVE_PID
 

--- a/scripts/run-live-build.sh
+++ b/scripts/run-live-build.sh
@@ -199,7 +199,16 @@ fi
 # is covered separately by per-package sidecar SBOMs produced upstream
 # in linux-pkg, merged in at a later stage.
 #
-syft scan dir:binary \
+# SYFT_FILE_METADATA_SELECTION=none suppresses Syft's default behavior of
+# emitting a separate CycloneDX "file" component (with SHA-1/SHA-256
+# hashes) for every individual file owned by every cataloged package.
+# That's unrelated to --select-catalogers (which only scopes *package*
+# catalogers) and, left at its default, balloons the output to one
+# "file" entry per file on the appliance -- tens of thousands of them --
+# instead of the flat, per-package pkg:deb document this step is meant
+# to produce.
+#
+SYFT_FILE_METADATA_SELECTION=none syft scan dir:binary \
 	--select-catalogers dpkg \
 	--source-name "$ARTIFACT_NAME" \
 	--source-version "$DELPHIX_APPLIANCE_VERSION" \

--- a/scripts/run-live-build.sh
+++ b/scripts/run-live-build.sh
@@ -17,7 +17,7 @@
 
 . "${BASH_SOURCE%/*}/common.sh"
 
-check_env DELPHIX_PACKAGE_MIRROR_MAIN DELPHIX_PACKAGE_MIRROR_SECONDARY DELPHIX_APPLIANCE_VERSION
+check_env DELPHIX_PACKAGE_MIRROR_MAIN DELPHIX_PACKAGE_MIRROR_SECONDARY
 
 TOP=$(git rev-parse --show-toplevel 2>/dev/null)
 
@@ -171,30 +171,6 @@ lb config \
 
 lb build
 
-#
-# Syft and cyclonedx-cli are consumed exactly the same way as every other
-# first-party Delphix package: as .deb's in the ancillary repository (see
-# build-ancillary-repository.sh), already being served locally above. The
-# one difference is that these are build-host-only tooling for the SBOM
-# step below, never installed into the appliance chroot -- so, unlike
-# "lb config"'s --mirror-chroot/--mirror-binary (which points the chroot's
-# own bootstrap at config/archives/localhost.list), these are installed
-# directly onto the build host itself via apt, pointed at that same
-# ancillary repository, before the still-running local Aptly server
-# serving it is killed just below.
-#
-# Reuse config/archives/localhost.list itself (rather than re-typing the
-# same "deb [trusted=yes] http://localhost:8080 noble main" line here) so
-# this can never silently drift out of sync with what the chroot uses.
-#
-cp config/archives/localhost.list /etc/apt/sources.list.d/ancillary-repository.list
-apt-get update \
-	-o Dir::Etc::sourcelist="sources.list.d/ancillary-repository.list" \
-	-o Dir::Etc::sourceparts="-" \
-	-o APT::Get::List-Cleanup="0"
-apt-get install -y --no-install-recommends delphix-syft delphix-cyclonedx-cli
-rm -f /etc/apt/sources.list.d/ancillary-repository.list
-
 kill -9 $APTLY_SERVE_PID
 
 #
@@ -210,39 +186,6 @@ kill -9 $APTLY_SERVE_PID
 if [[ ! -f binary/SHA256SUMS ]]; then
 	exit 1
 fi
-
-#
-# Generate a CycloneDX SBOM for this image by scanning the populated
-# "binary" directory (see comment above: this is the appliance rootfs,
-# not a separate chroot). Only the dpkg cataloger is enabled: dpkg is
-# the sole source that can authoritatively attribute a file on disk to
-# the package that placed it there. Vendored/extracted third-party
-# content bundled inside a larger installed package (jars, npm modules,
-# Rust crates, etc.) isn't attributable this way, so language-level
-# catalogers are left off here to avoid misattributing it; that content
-# is covered separately by per-package sidecar SBOMs produced upstream
-# in linux-pkg, merged in at a later stage.
-#
-# SYFT_FILE_METADATA_SELECTION=none suppresses Syft's default behavior of
-# emitting a separate CycloneDX "file" component (with SHA-1/SHA-256
-# hashes) for every individual file owned by every cataloged package.
-# That's unrelated to --select-catalogers (which only scopes *package*
-# catalogers) and, left at its default, balloons the output to one
-# "file" entry per file on the appliance -- tens of thousands of them --
-# instead of the flat, per-package pkg:deb document this step is meant
-# to produce.
-#
-SYFT_FILE_METADATA_SELECTION=none syft scan dir:binary \
-	--select-catalogers dpkg \
-	--source-name "$ARTIFACT_NAME" \
-	--source-version "$DELPHIX_APPLIANCE_VERSION" \
-	-o "cyclonedx-json@1.6=$ARTIFACT_NAME.cdx.json"
-
-cyclonedx-cli validate \
-	--input-file "$ARTIFACT_NAME.cdx.json" \
-	--input-format json \
-	--input-version v1_6 \
-	--fail-on-errors
 
 case $APPLIANCE_PLATFORM in
 aws) vm_artifact_ext=vmdk ;;

--- a/scripts/run-live-build.sh
+++ b/scripts/run-live-build.sh
@@ -187,6 +187,30 @@ if [[ ! -f binary/SHA256SUMS ]]; then
 	exit 1
 fi
 
+#
+# Generate a CycloneDX SBOM for this image by scanning the populated
+# "binary" directory (see comment above: this is the appliance rootfs,
+# not a separate chroot). Only the dpkg cataloger is enabled: dpkg is
+# the sole source that can authoritatively attribute a file on disk to
+# the package that placed it there. Vendored/extracted third-party
+# content bundled inside a larger installed package (jars, npm modules,
+# Rust crates, etc.) isn't attributable this way, so language-level
+# catalogers are left off here to avoid misattributing it; that content
+# is covered separately by per-package sidecar SBOMs produced upstream
+# in linux-pkg, merged in at a later stage.
+#
+syft scan dir:binary \
+	--select-catalogers dpkg \
+	--source-name "$ARTIFACT_NAME" \
+	--source-version "$DELPHIX_APPLIANCE_VERSION" \
+	-o "cyclonedx-json@1.6=$ARTIFACT_NAME.cdx.json"
+
+cyclonedx-cli validate \
+	--input-file "$ARTIFACT_NAME.cdx.json" \
+	--input-format json \
+	--input-version v1_6 \
+	--fail-on-errors
+
 case $APPLIANCE_PLATFORM in
 aws) vm_artifact_ext=vmdk ;;
 azure) vm_artifact_ext=vhdx ;;
@@ -208,7 +232,7 @@ esac
 # user (e.g. other software); this is most useful when multiple variants
 # are built via a single call to "make" (e.g. using the "all" target).
 #
-for ext in debs.tar.gz $vm_artifact_ext packages.list; do
+for ext in debs.tar.gz $vm_artifact_ext packages.list cdx.json; do
 	if [[ -f "$ARTIFACT_NAME.$ext" ]]; then
 		mv "$ARTIFACT_NAME.$ext" "$TOP/live-build/build/artifacts/"
 	fi


### PR DESCRIPTION
<details open>
<summary><h2> Background </h2></summary>

Phase 1 ([DLPX-98618](https://perforce.atlassian.net/browse/DLPX-98618)) of the SBOM rollout under epic
[CP-13455](https://perforce.atlassian.net/browse/CP-13455), per the design spec
(`docs/specs/2026-06-15-sbom-generation-design.md`) and implementation plan
(`docs/specs/2026-06-23-sbom-generation-implementation-plan.md`) merged in #873.
</details>

<details open>
<summary><h2> Problem </h2></summary>

Delphix appliance images ship without a machine-consumable SBOM. The only bill-of-materials
today is a home-grown CSV (`devops-gate`'s `generate_bom.py`/`combine_bom.py`) built by
text-parsing per-package copyright files -- license-centric, no PURLs, and not consumable by
vulnerability scanners (Grype, Dependency-Track, etc.).
</details>

<details open>
<summary><h2> Solution </h2></summary>

`scripts/run-live-build.sh` now runs Syft against the populated `binary` rootfs (dpkg
cataloger only -- the sole source that can authoritatively attribute a file on disk to the
package that placed it there) right after the existing `binary/SHA256SUMS` check, emitting
`<variant>-<platform>.cdx.json` (CycloneDX 1.6 JSON), then validates it with
`cyclonedx-cli validate --fail-on-errors` so a malformed SBOM fails the build rather than
shipping silently. Wired into the existing Gradle output graph and S3 artifact sync -- no new
publishing plumbing.

Deep language-level cataloging (jars, npm modules, Rust crates bundled inside a larger
installed package) is intentionally out of scope here -- `dpkg` can't attribute that content
without risking misattribution. It's covered separately by per-package sidecar SBOMs produced
upstream in `linux-pkg` (CP-13465), merged in at a later stage (CP-13466).

Neither `syft` nor `cyclonedx-cli` are available through the Delphix package mirror --
`bootstrap/roles/appliance-build.bootstrap/tasks/main.yml` now provisions both explicitly,
pinned to an exact version and checksum-verified:
- **Syft `v1.46.0`** -- installed from the pinned `.deb` release asset via `apt`, checksum
  from Syft's own published `_checksums.txt`.
- **cyclonedx-cli `v0.32.0`** -- ships only as a bare per-platform binary upstream (no `.deb`,
  no official checksums file); checksum computed locally at pin time. Installed at
  `/usr/local/bin/cyclonedx-cli` -- that exact name matters, since it's the command
  `run-live-build.sh` invokes, not upstream's own `cyclonedx` naming.

Both pinned one release behind "latest" deliberately: Syft ships almost weekly so recency
alone isn't a meaningful signal, and cyclonedx-cli's `v0.33.0`/`v0.33.1` were a same-day
hotfix pair.

Purely additive -- the existing CSV BOM keeps working exactly as before. Decommissioning it
is a separate, later ticket (CP-13468), gated on this and the following phases being
validated first.
</details>

<details open>
<summary><h2> Testing Done </h2></summary>

⏺ Validation result: the SBOM matches the dpkg list exactly.                                                                                                                                                                       
                                                                                                                                                                                                                                   
  - dpkg_list.txt: 684 installed (ii) packages                                                                                                                                                                                     
  - internal-qa-aws.cdx.json: 685 components                                                                                                                                                                                       
  - 684/684 dpkg packages found in the SBOM, exact name+version match, 0 missing, 0 version mismatches                                                                                                                             
  - The 1 extra SBOM entry is ubuntu 24.04 (type: "operating-system") — that's Syft's OS/distro identification component, not a dpkg package, so it's expected and not a discrepancy.                                              
  
**Attachments** - 'dpk -l` output and sbom: 
[dpkg_list.txt](https://github.com/user-attachments/files/31789113/dpkg_list.txt)
[internal-qa-aws.cdx.json](https://github.com/user-attachments/files/31789116/internal-qa-aws.cdx.json)
                                                                                                                                                                                                                                 
    

**Jenkins Link:**
[appliance-build-orchestrator-pre-push](http://selfservice.dlpx98618.dcol1.delphix.com/job/appliance-build-orchestrator-pre-push/14/)  - 🟢 

[appliance-build-stage0](http://selfservice.dlpx98618.dcol1.delphix.com/job/appliance-build-stage0/job/pre-push/10/) - 🟢  The Cyclone DX Sbom artifacts are attached with Jenkins Job.

<img width="890" height="463" alt="Screenshot 2026-09-03 at 5 30 40 PM" src="https://github.com/user-attachments/assets/ab1f9b01-d877-4ec1-ae98-fde55b28330f" />



S3 Cyclonedx sbom artifats
````
sanjeev.rohilla@APAC-SANJEEV~/syft  add-packaging-code % aws s3 ls s3://dev-de-images/builds/jenkins-selfservice.sanjeev.rohila/appliance-build/develop/pre-push/10/                
                           PRE external-standard-aws/
                           PRE hostchecker2/
                           PRE input-artifacts/
                           PRE internal-dev-aws/
                           PRE internal-qa-aws/
                           PRE metadata/
                           PRE toolkit-devkit/
                           PRE upgrade-artifacts/
sanjeev.rohilla@APAC-SANJEEV~/syft  add-packaging-code % aws s3 ls s3://dev-de-images/builds/jenkins-selfservice.sanjeev.rohila/appliance-build/develop/pre-push/10/internal-qa-aws/
2026-09-02 18:01:54        240 MD5SUMS
2026-09-02 18:01:54        368 SHA256SUMS
2026-09-02 18:01:54    1538897 internal-qa-aws.cdx.json
2026-09-02 18:03:11 6086165824 internal-qa-aws.debs.tar.gz
2026-09-02 18:01:54      21393 internal-qa-aws.packages.list
2026-09-02 18:01:54 7674152960 internal-qa-aws.vmdk
sanjeev.rohilla@APAC-SANJEEV~/syft  add-packaging-code % aws s3 ls s3://dev-de-images/builds/jenkins-selfservice.sanjeev.rohila/appliance-build/develop/pre-push/10/internal-dev-aws/
2026-09-02 18:16:20        244 MD5SUMS
2026-09-02 18:16:20        372 SHA256SUMS
2026-09-02 18:16:20    1841098 internal-dev-aws.cdx.json
2026-09-02 18:18:06 6203335421 internal-dev-aws.debs.tar.gz
2026-09-02 18:16:20      25360 internal-dev-aws.packages.list
2026-09-02 18:16:20 9840958464 internal-dev-aws.vmdk
sanjeev.rohilla@APAC-SANJEEV~/syft  add-packaging-code % aws s3 ls s3://dev-de-images/builds/jenkins-selfservice.sanjeev.rohila/appliance-build/develop/pre-push/10/external-standard-aws/
2026-09-02 17:58:24        264 MD5SUMS
2026-09-02 17:58:24        392 SHA256SUMS
2026-09-02 17:58:24    1338564 external-standard-aws.cdx.json
2026-09-02 17:59:28 5984082570 external-standard-aws.debs.tar.gz
2026-09-02 17:58:24      18702 external-standard-aws.packages.list
2026-09-02 17:58:24 7440211456 external-standard-aws.vmdk
sanjeev.rohilla@APAC-SANJEEV~/syft  add-packaging-code % 

````


</details>

<!--
<details open>
<summary><h2> Notes to Reviewers </h2></summary>

</details>

<details open>
<summary><h2> Future Work </h2></summary>
</details>
-->


