### PR TITLE
APIGW-25850 Remove masking-common from DCT and UCF variants

### DIFF
--- a/live-build/misc/ansible-roles/appliance-build.virtualization-common/tasks/main.yml
+++ b/live-build/misc/ansible-roles/appliance-build.virtualization-common/tasks/main.yml
@@ -74,9 +74,15 @@
 # The services in this section should be disabled & masked initially, but
 # can be later dynamically enabled by the appliance.
 #
+# delphix-fluentd.service and delphix-masking.service are owned by the
+# delphix-masking package, which isn't installed on variants (DCT, UCF)
+# that don't include the masking-common role; "disable" on a unit that
+# doesn't exist fails, so it's allowed to fail here. "mask" always
+# succeeds regardless of whether the unit exists.
+#
 - name: Disable and mask services that should not be running by default
   shell: |
-    systemctl disable {{ item }}
+    systemctl disable {{ item }} || true
     systemctl mask {{ item }}
   with_items:
     - delphix-fluentd.service

--- a/live-build/variants/external-dct/ansible/playbook.yml
+++ b/live-build/variants/external-dct/ansible/playbook.yml
@@ -22,5 +22,4 @@
   roles:
     - appliance-build.minimal-common
     - appliance-build.dct-common
-    - appliance-build.masking-common
     - appliance-build.virtualization-common

--- a/live-build/variants/external-ucf/ansible/playbook.yml
+++ b/live-build/variants/external-ucf/ansible/playbook.yml
@@ -19,13 +19,7 @@
   gather_facts: no
   vars:
     ansible_python_interpreter: /usr/bin/python3
-  #
-  # masking-common is required even though UCF doesn't use the masking
-  # workflow — the Delphix mgmt JVM hard-requires /opt/delphix/masking
-  # and setup_masking.sh on startup.
-  #
   roles:
     - appliance-build.minimal-common
-    - appliance-build.masking-common
     - appliance-build.virtualization-common
     - appliance-build.ucf-common

--- a/live-build/variants/internal-dct/ansible/playbook.yml
+++ b/live-build/variants/internal-dct/ansible/playbook.yml
@@ -24,8 +24,6 @@
     - appliance-build.minimal-internal
     - appliance-build.minimal-development
     - appliance-build.dct-common
-    - appliance-build.masking-common
-    - appliance-build.masking-development
     - appliance-build.virtualization-common
     - appliance-build.virtualization-development
     - appliance-build.qa-internal

--- a/live-build/variants/internal-ucf/ansible/playbook.yml
+++ b/live-build/variants/internal-ucf/ansible/playbook.yml
@@ -21,16 +21,13 @@
     ansible_python_interpreter: /usr/bin/python3
   #
   # UCF ships with Delphix's locked-down appliance + admin console
-  # (virtualization-common + masking-common) plus the UCF/CDS app.
-  # masking-common is required even though UCF doesn't use the masking
-  # workflow — the Delphix mgmt JVM hard-requires /opt/delphix/masking
-  # and setup_masking.sh on startup. We skip virtualization-development
-  # and qa-internal which target the full Delphix dev workflow (clones
-  # dlpx-app-gate, etc.) and are not applicable to UCF.
+  # (virtualization-common) plus the UCF/CDS app. We skip
+  # virtualization-development and qa-internal which target the full
+  # Delphix dev workflow (clones dlpx-app-gate, etc.) and are not
+  # applicable to UCF.
   #
   roles:
     - appliance-build.minimal-common
     - appliance-build.minimal-internal
-    - appliance-build.masking-common
     - appliance-build.virtualization-common
     - appliance-build.ucf-common


### PR DESCRIPTION
## Summary
- Neither the DCT nor UCF appliance variants use the masking product; `appliance-build.masking-common` was only bundled to satisfy the mgmt JVM's hard startup dependency on `/opt/delphix/masking`, which is now fixed (APIGW-25751).
- Removes `appliance-build.masking-common` (and `masking-development` on `internal-dct`) from all four affected playbooks: `external-dct`, `internal-dct`, `external-ucf`, `internal-ucf`.
- `appliance-build.virtualization-common` is retained on all four variants (needed for the sysadmin/appliance-setup and upgrade tooling), but its "Disable and mask services that should not be running by default" task unconditionally ran `systemctl disable delphix-masking.service` / `delphix-fluentd.service`, which fails when those units don't exist (i.e. once `delphix-masking` is no longer installed). Patched that task to tolerate the missing units (`systemctl disable ... || true`); `systemctl mask` already succeeds regardless of whether the unit exists.
- Dropped now-stale comments in the UCF playbooks explaining why `masking-common` was required.

## Root cause background (APIGW-25751)
`StackStartup.onApplicationEvent` unconditionally called `MaskingUtils.setupMasking()`, which threw a fatal exception if `/opt/delphix/masking` didn't exist. Verified empirically pre-fix: removing `delphix-masking` on a running appliance crash-looped `delphix-mgmt.service` with `DelphixFatalException: Masking home directory does not exist at /opt/delphix/masking`. That mgmt-JVM check has since been fixed, unblocking this change.

## Test plan
- [ ] Build `externalDct`, `internalDct`, `externalUcf`, `internalUcf` variants and confirm the Ansible provisioning run completes without failing on the service disable/mask step.
- [ ] Boot each built image and confirm `delphix-mgmt.service` starts and stays healthy with no `delphix-masking` package installed.
- [ ] Confirm `delphix-masking`, `libharfbuzz0b`, `libgraphite2-3` are no longer present on the built images.
- [ ] Exercise DCT/UCF appliance setup (sysadmin) and upgrade flows to confirm no regression from dropping masking-common.

Jira: APIGW-25850 (blocked by APIGW-25751, now resolved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)