### PR TITLE
TOOL-30934 Install git explicitly in virtualization-development

### DIFF
--- a/live-build/misc/ansible-roles/appliance-build.virtualization-development/tasks/main.yml
+++ b/live-build/misc/ansible-roles/appliance-build.virtualization-development/tasks/main.yml
@@ -71,6 +71,19 @@
       [Service]
       Environment=DLPX_PG_DEBUG=true
 
+#
+# git is required to clone dlpx-app-gate below. Install it explicitly here
+# rather than relying on another role in the playbook to have installed it
+# first (see TOOL-30934).
+#
+- apt:
+    name: git
+    state: present
+  register: result
+  until: result is not failed
+  retries: 3
+  delay: 60
+
 - git:
     repo: "https://{{ lookup('env', 'GITHUB_TOKEN') }}@github.com/delphix/dlpx-app-gate.git"
     dest: "/home/delphix/dlpx-app-gate"


### PR DESCRIPTION
## Summary
- `APIGW-25850` (PR #894, commit `1a3b460`) removed `masking-development` from the `internal-dct-*` playbook. That role's explicit `apt: name: git` task was the only thing installing `git` before `virtualization-development`'s own `git:` clone task ran — `qa-internal`, which also installs `git`, runs later in role order for this playbook.
- Result: every `internal-dct-*` nightly build failed with `Failed to find required executable "git"` (see [TOOL-30934](https://perforce.atlassian.net/browse/TOOL-30934)).
- Fix: add an explicit `apt: name: git` task to `appliance-build.virtualization-development` right before its `git:` clone task, so the role is self-sufficient regardless of playbook/role ordering (Option 1 from the root-cause analysis in the ticket).

## Test plan
- [ ] Verify the `internal-dct-*` nightly/post-push build passes (`git` task no longer fails with "Failed to find required executable").
- [ ] Confirm `internal-dev`/`internal-qa`/`external-dct`/`external-ucf` flavors are unaffected (they either already install git earlier, or don't run this task).

Fixes TOOL-30934

🤖 Generated with [Claude Code](https://claude.com/claude-code)