### PR TITLE
HM-11725 Remove masking-common from internal/external-hyperscale variant

### DIFF
--- a/live-build/variants/external-hyperscale/ansible/playbook.yml
+++ b/live-build/variants/external-hyperscale/ansible/playbook.yml
@@ -1,5 +1,5 @@
 #
-# Copyright 2025 Delphix
+# Copyright 2025, 2026 Delphix
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -22,13 +22,5 @@
     ansible_python_interpreter: /usr/bin/python3
   roles:
     - appliance-build.minimal-common
-    - appliance-build.masking-common
     - appliance-build.virtualization-common
-    #
-    # The hyperscale-common role requires the appliance configuration,
-    # essentially the 'masking' user creation, done by the masking-common
-    # role to be in place before the hyperscale-common role is applied.
-    # Thus, we need to ensure the hyperscale-common role is applied after
-    # the masking-common role.
-    #
     - appliance-build.hyperscale-common

--- a/live-build/variants/internal-hyperscale/ansible/playbook.yml
+++ b/live-build/variants/internal-hyperscale/ansible/playbook.yml
@@ -1,5 +1,5 @@
 #
-# Copyright 2025 Delphix
+# Copyright 2025, 2026 Delphix
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -24,16 +24,7 @@
     - appliance-build.minimal-common
     - appliance-build.minimal-internal
     - appliance-build.minimal-development
-    - appliance-build.masking-common
-    - appliance-build.masking-development
     - appliance-build.virtualization-common
     - appliance-build.virtualization-development
-    #
-    # The hyperscale-common role requires the appliance configuration,
-    # essentially the 'masking' user creation, done by the masking-common
-    # role to be in place before the hyperscale-common role is applied.
-    # Thus, we need to ensure the hyperscale-common role is applied after
-    # the masking-common role.
-    #
     - appliance-build.hyperscale-common
     - appliance-build.qa-internal


### PR DESCRIPTION
## Summary

Hyperscale doesn't use the masking product; `appliance-build.masking-common` (and `masking-development` on `internal-hyperscale`) were only bundled on the Hyperscale appliance variants for two reasons, both now resolved:

1. **mgmt JVM startup dependency** — `StackStartup.setupMasking()`/`upgradeMasking()` unconditionally assumed `/opt/delphix/masking` existed, hard-failing without it. Fixed for `HYPERSCALE` by **HM-11651** (dlpx-app-gate PR https://github.com/delphix/dlpx-app-gate/pull/4773), the same way it was already fixed for DCT/UCF (`APIGW-25751`).
2. **OS-level `masking` user creation** — `delphix-hyperscale`'s postinst assumes the `masking` user (uid 65436) already exists (`usermod -aG docker/systemd-journal masking`), and `delphix-hyperscale-manager.service` execs `application-manager` as that user at runtime. Previously that user only existed because `masking-common` installed `delphix-masking`, whose postinst created it. Fixed by **HM-11724** (hyperscale-masking PR https://github.com/delphix/hyperscale-masking/pull/2844), which moves that `useradd` directly into `delphix-hyperscale`'s own postinst.

With both blockers resolved, this PR removes `masking-common` from **both** Hyperscale variants — mirroring `appliance-build#894` ("Remove masking-common from DCT and UCF variants").

## Changes

- **`live-build/variants/internal-hyperscale/ansible/playbook.yml`**: removed `appliance-build.masking-common` and `appliance-build.masking-development` roles; removed the stale comment explaining why `hyperscale-common` had to run after `masking-common` (no longer true — see HM-11724).
- **`live-build/variants/external-hyperscale/ansible/playbook.yml`**: same removal of `appliance-build.masking-common` and the same stale ordering comment. (This variant never had `masking-development`.)
- No change needed to the shared `appliance-build.virtualization-common` role, which both variants keep — its "disable and mask services" task already tolerates `delphix-masking.service`/`delphix-fluentd.service` not existing (patched in `appliance-build#894`).
- No change needed to `appliance-build.hyperscale-common` itself (`apt install delphix-hyperscale` only) — role ordering relative to `virtualization-common`/`virtualization-development` is unchanged; only the now-unnecessary `masking-common`/`masking-development` roles and their explanatory comments are removed.

## Sequencing / Related work

This PR must land **after** HM-11724 (hyperscale-masking PR https://github.com/delphix/hyperscale-masking/pull/2844) is merged and released — merging this first would break both Hyperscale image builds, since the `masking` user wouldn't exist until that PR's postinst change ships.

- **HM-11651** — dlpx-app-gate PR https://github.com/delphix/dlpx-app-gate/pull/4773 (skip masking setup for HYPERSCALE in `StackStartup.java`)
- **HM-11724** — hyperscale-masking PR https://github.com/delphix/hyperscale-masking/pull/2844 (create the `masking` OS user in `delphix-hyperscale`'s own postinst — must land first)
- **HM-11725** — this PR (drops `masking-common`/`masking-development` from both `internal-hyperscale` and `external-hyperscale`)

## Test plan

- [ ] Build the `internalHyperscale` variant and confirm the Ansible provisioning run completes without error
- [ ] Build the `externalHyperscale` variant and confirm the Ansible provisioning run completes without error
- [ ] Boot each built image and confirm `delphix-hyperscale-manager.service` starts and `application-manager` runs as the `masking` user
- [ ] Confirm `delphix-masking`, `libharfbuzz0b`, `libgraphite2-3` are no longer present on either built image
- [ ] Confirm `delphix-mgmt.service` stays healthy on both variants with no `delphix-masking` package installed
- [ ] Integration pre-push: appliance build against all three PR branches together (this PR + dlpx-app-gate #4773 + hyperscale-masking #2844) — https://masking-jenkins.eng-tools-prd.aws.delphixcloud.com/job/github/job/delphix/job/hyperscale-masking/job/build/job/appliance-build/job/pre-push/241/

Jira: HM-11725 (depends on HM-11724, hyperscale-masking PR #2844)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
