### PR TITLE
APIGW-26202 Re-introduce appliance-build.masking-common on UCF variants

### DIFF
--- a/live-build/misc/ansible-roles/appliance-build.virtualization-common/tasks/main.yml
+++ b/live-build/misc/ansible-roles/appliance-build.virtualization-common/tasks/main.yml
@@ -75,10 +75,10 @@
 # can be later dynamically enabled by the appliance.
 #
 # delphix-fluentd.service and delphix-masking.service are owned by the
-# delphix-masking package, which isn't installed on variants (DCT, UCF)
-# that don't include the masking-common role; "disable" on a unit that
-# doesn't exist fails, so it's allowed to fail here. "mask" always
-# succeeds regardless of whether the unit exists.
+# delphix-masking package, which isn't installed on variants (DCT) that
+# don't include the masking-common role; "disable" on a unit that doesn't
+# exist fails, so it's allowed to fail here. "mask" always succeeds
+# regardless of whether the unit exists.
 #
 - name: Disable and mask services that should not be running by default
   shell: |

--- a/live-build/variants/external-ucf/ansible/playbook.yml
+++ b/live-build/variants/external-ucf/ansible/playbook.yml
@@ -19,7 +19,15 @@
   gather_facts: no
   vars:
     ansible_python_interpreter: /usr/bin/python3
+  #
+  # UCF requires appliance-build.masking-common: it installs
+  # delphix-masking, which owns /opt/delphix/masking and the
+  # delphix-masking.service / delphix-fluentd.service units.
+  # APIGW-25850 removed this role from the DCT and UCF variants;
+  # APIGW-26202 re-introduces it for UCF only. DCT remains without it.
+  #
   roles:
     - appliance-build.minimal-common
+    - appliance-build.masking-common
     - appliance-build.virtualization-common
     - appliance-build.ucf-common

--- a/live-build/variants/internal-ucf/ansible/playbook.yml
+++ b/live-build/variants/internal-ucf/ansible/playbook.yml
@@ -21,7 +21,10 @@
     ansible_python_interpreter: /usr/bin/python3
   #
   # UCF ships with Delphix's locked-down appliance + admin console
-  # (virtualization-common) plus the UCF/CDS app. We skip
+  # (virtualization-common + masking-common) plus the UCF/CDS app.
+  # APIGW-25850 removed masking-common from the DCT and UCF variants;
+  # APIGW-26202 re-introduces it for UCF only (DCT remains without
+  # it). We skip
   # virtualization-development and qa-internal which target the full
   # Delphix dev workflow (clones dlpx-app-gate, etc.) and are not
   # applicable to UCF.
@@ -29,5 +32,6 @@
   roles:
     - appliance-build.minimal-common
     - appliance-build.minimal-internal
+    - appliance-build.masking-common
     - appliance-build.virtualization-common
     - appliance-build.ucf-common


### PR DESCRIPTION
<details open>
<summary><h2> Problem </h2></summary>

APIGW-25850 (#894) removed `appliance-build.masking-common` from all four
DCT and UCF playbooks, on the basis that neither product uses the masking
workflow and the mgmt JVM's hard startup dependency on `/opt/delphix/masking`
had been fixed by APIGW-25751.

That is correct for DCT, but the UCF variants need `masking-common` back.
</details>

<details open>
<summary><h2> Solution </h2></summary>

Re-add `appliance-build.masking-common` to the two UCF playbooks only. DCT
is left exactly as APIGW-25850 left it.

- `external-ucf`: role re-added between `minimal-common` and
  `virtualization-common`.
- `internal-ucf`: role re-added between `minimal-internal` and
  `virtualization-common`.

Both placements restore the ordering convention used by the other variants
that carry the role (`external-standard`, `internal-dev`, `internal-qa`,
`external-hyperscale`, `internal-hyperscale`): `masking-common` before
`virtualization-common`.
</details>

<details open>
<summary><h2> Implementation </h2></summary>

Three files change; two are role-list entries and the rest is comments.

`appliance-build.virtualization-common` keeps the
`systemctl disable {{ item }} || true` tolerance that APIGW-25850 added to
its "Disable and mask services that should not be running by default" task.
That tolerance is still required, because the DCT variants still ship without
`delphix-masking` and therefore without the `delphix-masking.service` /
`delphix-fluentd.service` units. Only the explanatory comment changed: it
claimed the units are absent on "(DCT, UCF)", which is no longer true of UCF,
so it now reads "(DCT)".

`masking-development` is deliberately **not** re-added anywhere.
APIGW-25850 dropped it from `internal-dct`; `internal-ucf` never carried it,
so there is nothing to restore.
</details>

<details open>
<summary><h2> Testing Done </h2></summary>

Static verification only so far:

- All three changed files parse as YAML.
- Confirmed by grep that `masking-common` is referenced from no other place
  in the repo that would need a matching update — the remaining `masking`
  references are `external-standard`, `internal-qa`, `internal-dev`,
  `external-hyperscale`, `internal-hyperscale` (all unchanged and all already
  carrying the role), the two masking roles themselves, `.ansible-lint-ignore`,
  the `upgrade/upgrade-scripts/common.sh` mask list (unchanged behaviour), and
  the SBOM design docs.

Still to do, and the reason this is a draft:

- [ ] Build `externalUcf` and `internalUcf` via
      `appliance-build-orchestrator-pre-push` and confirm the Ansible run
      completes.
- [ ] Confirm `delphix-masking` is present on the built UCF images and that
      `delphix-masking.service` / `delphix-fluentd.service` come up
      disabled + masked.
- [ ] Confirm the DCT variants still build, i.e. the `|| true` tolerance is
      still doing its job now that UCF no longer needs it.
</details>