### PR TITLE
TOOL-30975 Retry "aws s3 sync" to survive transient S3 connection drops

### DIFF
--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -23,6 +23,46 @@ function die() {
 	exit 2
 }
 
+#
+# The number of times an "aws s3 sync" is attempted before giving up, and the
+# delay in seconds before the first retry. The delay doubles after every
+# failed attempt.
+#
+S3_SYNC_ATTEMPTS=3
+S3_SYNC_DELAY=5
+
+#
+# Run "aws s3 sync" with the given arguments, retrying it if it fails.
+#
+# The AWS CLI does not retry every transient failure on its own. A connection
+# that is dropped mid-transfer surfaces as "An HTTP Client raised an unhandled
+# exception: I/O operation on closed file.", which the CLI treats as fatal
+# rather than retryable, so a single dropped connection fails the whole sync
+# even though every other object was copied successfully. Raising max_attempts
+# or setting retry_mode in the AWS config does not help, as that exception
+# bypasses botocore's retry handling entirely.
+#
+# Retrying is always safe here because "aws s3 sync" is idempotent: it skips
+# objects that are already present in the destination, so a retry only
+# re-fetches whatever is still missing.
+#
+# The final attempt is run outside the loop so that its exit status propagates
+# to the caller, which is running under "set -o errexit".
+#
+function s3_sync() {
+	local attempt delay=$S3_SYNC_DELAY
+
+	for ((attempt = 1; attempt < S3_SYNC_ATTEMPTS; attempt++)); do
+		aws s3 sync "$@" && return 0
+		echo "'aws s3 sync $*' failed (attempt $attempt of" \
+			"$S3_SYNC_ATTEMPTS); retrying in ${delay}s." 1>&2
+		sleep "$delay"
+		delay=$((delay * 2))
+	done
+
+	aws s3 sync "$@"
+}
+
 function resolve_s3_uri() {
 	local pkg_uri="$1"
 
@@ -93,10 +133,10 @@ function download_combined_packages_artifacts() {
 	pushd "$target_dir" &>/dev/null
 
 	if [[ -n "$pkg" ]]; then
-		aws s3 sync --exclude 'packages/*' --include "packages/$pkg/*" \
+		s3_sync --exclude 'packages/*' --include "packages/$pkg/*" \
 			--only-show-errors "$combined_pkgs_uri" .
 	else
-		aws s3 sync --only-show-errors "$combined_pkgs_uri" .
+		s3_sync --only-show-errors "$combined_pkgs_uri" .
 	fi
 
 	if [[ -d packages ]]; then
@@ -115,7 +155,7 @@ function download_combined_packages_artifacts() {
 		[[ -n "$pkg" ]] && [[ "$pkg" != "$pkgname" ]] && continue
 		mkdir "$pkgname"
 		pushd "$pkgname" &>/dev/null
-		aws s3 sync --only-show-errors "$s3uri" .
+		s3_sync --only-show-errors "$s3uri" .
 		sha256sum -c --strict SHA256SUMS
 		popd &>/dev/null
 	done <../COMPONENTS
@@ -143,7 +183,7 @@ function download_dct_artifacts() {
 	mkdir "$target_dir/dct"
 	pushd "$target_dir/dct" &>/dev/null || exit 1
 
-	aws s3 sync "$dct_artifacts_uri" .
+	s3_sync "$dct_artifacts_uri" .
 	sha256sum -c SHA256SUMS
 
 	popd &>/dev/null || exit 1
@@ -175,11 +215,13 @@ function download_ucf_artifacts() {
 	# sets to linux-build-publish credentials).
 	#
 	if [[ -n "${AWS_UCF_ACCESS_KEY_ID:-}" && -n "${AWS_UCF_SECRET_ACCESS_KEY:-}" ]]; then
-		AWS_ACCESS_KEY_ID="$AWS_UCF_ACCESS_KEY_ID" \
-		AWS_SECRET_ACCESS_KEY="$AWS_UCF_SECRET_ACCESS_KEY" \
-			aws s3 sync "$ucf_artifacts_uri" .
+		(
+			export AWS_ACCESS_KEY_ID="$AWS_UCF_ACCESS_KEY_ID"
+			export AWS_SECRET_ACCESS_KEY="$AWS_UCF_SECRET_ACCESS_KEY"
+			s3_sync "$ucf_artifacts_uri" .
+		)
 	else
-		aws s3 sync "$ucf_artifacts_uri" .
+		s3_sync "$ucf_artifacts_uri" .
 	fi
 
 	#
@@ -213,7 +255,7 @@ function download_hyperscale_artifacts() {
 	mkdir "$target_dir/hyperscale"
 	pushd "$target_dir/hyperscale" &>/dev/null || exit 1
 
-	aws s3 sync "$hyperscale_artifacts_uri" .
+	s3_sync "$hyperscale_artifacts_uri" .
 	sha256sum -c SHA256SUMS
 
 	popd &>/dev/null || exit 1

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -24,43 +24,44 @@ function die() {
 }
 
 #
-# The number of times an "aws s3 sync" is attempted before giving up, and the
-# delay in seconds before the first retry. The delay doubles after every
+# The number of times a command is attempted by retry() before giving up, and
+# the delay in seconds before the first retry. The delay doubles after every
 # failed attempt.
 #
-S3_SYNC_ATTEMPTS=3
-S3_SYNC_DELAY=5
+RETRY_ATTEMPTS=3
+RETRY_DELAY=5
 
 #
-# Run "aws s3 sync" with the given arguments, retrying it if it fails.
+# Run the given command, retrying it if it fails.
 #
-# The AWS CLI does not retry every transient failure on its own. A connection
-# that is dropped mid-transfer surfaces as "An HTTP Client raised an unhandled
-# exception: I/O operation on closed file.", which the CLI treats as fatal
-# rather than retryable, so a single dropped connection fails the whole sync
-# even though every other object was copied successfully. Raising max_attempts
-# or setting retry_mode in the AWS config does not help, as that exception
-# bypasses botocore's retry handling entirely.
+# This exists because the AWS CLI does not retry every transient failure on its
+# own. A connection that is dropped mid-transfer surfaces as "An HTTP Client
+# raised an unhandled exception: I/O operation on closed file.", which the CLI
+# treats as fatal rather than retryable, so a single dropped connection fails
+# the whole transfer even though every other object was copied successfully.
+# Raising max_attempts or setting retry_mode in the AWS config does not help,
+# as that exception bypasses botocore's retry handling entirely.
 #
-# Retrying is always safe here because "aws s3 sync" is idempotent: it skips
-# objects that are already present in the destination, so a retry only
-# re-fetches whatever is still missing.
+# Only use this for commands that are safe to run more than once. Every current
+# caller wraps "aws s3 sync", which is idempotent: it skips objects that are
+# already present in the destination, so a retry only re-fetches whatever is
+# still missing.
 #
 # The final attempt is run outside the loop so that its exit status propagates
 # to the caller, which is running under "set -o errexit".
 #
-function s3_sync() {
-	local attempt delay=$S3_SYNC_DELAY
+function retry() {
+	local attempt delay=$RETRY_DELAY
 
-	for ((attempt = 1; attempt < S3_SYNC_ATTEMPTS; attempt++)); do
-		aws s3 sync "$@" && return 0
-		echo "'aws s3 sync $*' failed (attempt $attempt of" \
-			"$S3_SYNC_ATTEMPTS); retrying in ${delay}s." 1>&2
+	for ((attempt = 1; attempt < RETRY_ATTEMPTS; attempt++)); do
+		"$@" && return 0
+		echo "'$*' failed (attempt $attempt of $RETRY_ATTEMPTS);" \
+			"retrying in ${delay}s." 1>&2
 		sleep "$delay"
 		delay=$((delay * 2))
 	done
 
-	aws s3 sync "$@"
+	"$@"
 }
 
 function resolve_s3_uri() {
@@ -133,10 +134,11 @@ function download_combined_packages_artifacts() {
 	pushd "$target_dir" &>/dev/null
 
 	if [[ -n "$pkg" ]]; then
-		s3_sync --exclude 'packages/*' --include "packages/$pkg/*" \
-			--only-show-errors "$combined_pkgs_uri" .
+		retry aws s3 sync --exclude 'packages/*' \
+			--include "packages/$pkg/*" --only-show-errors \
+			"$combined_pkgs_uri" .
 	else
-		s3_sync --only-show-errors "$combined_pkgs_uri" .
+		retry aws s3 sync --only-show-errors "$combined_pkgs_uri" .
 	fi
 
 	if [[ -d packages ]]; then
@@ -155,7 +157,7 @@ function download_combined_packages_artifacts() {
 		[[ -n "$pkg" ]] && [[ "$pkg" != "$pkgname" ]] && continue
 		mkdir "$pkgname"
 		pushd "$pkgname" &>/dev/null
-		s3_sync --only-show-errors "$s3uri" .
+		retry aws s3 sync --only-show-errors "$s3uri" .
 		sha256sum -c --strict SHA256SUMS
 		popd &>/dev/null
 	done <../COMPONENTS
@@ -183,7 +185,7 @@ function download_dct_artifacts() {
 	mkdir "$target_dir/dct"
 	pushd "$target_dir/dct" &>/dev/null || exit 1
 
-	s3_sync "$dct_artifacts_uri" .
+	retry aws s3 sync "$dct_artifacts_uri" .
 	sha256sum -c SHA256SUMS
 
 	popd &>/dev/null || exit 1
@@ -218,10 +220,10 @@ function download_ucf_artifacts() {
 		(
 			export AWS_ACCESS_KEY_ID="$AWS_UCF_ACCESS_KEY_ID"
 			export AWS_SECRET_ACCESS_KEY="$AWS_UCF_SECRET_ACCESS_KEY"
-			s3_sync "$ucf_artifacts_uri" .
+			retry aws s3 sync "$ucf_artifacts_uri" .
 		)
 	else
-		s3_sync "$ucf_artifacts_uri" .
+		retry aws s3 sync "$ucf_artifacts_uri" .
 	fi
 
 	#
@@ -255,7 +257,7 @@ function download_hyperscale_artifacts() {
 	mkdir "$target_dir/hyperscale"
 	pushd "$target_dir/hyperscale" &>/dev/null || exit 1
 
-	s3_sync "$hyperscale_artifacts_uri" .
+	retry aws s3 sync "$hyperscale_artifacts_uri" .
 	sha256sum -c SHA256SUMS
 
 	popd &>/dev/null || exit 1


### PR DESCRIPTION
## Problem

A single dropped HTTPS connection during the `aws s3 sync` of combined-packages
artifacts fails the entire `appliance-build-stage1` build.

Example: [appliance-build-stage1/post-push #274808](https://ops-jenkins.eng-tools-prd.aws.delphixcloud.com/job/appliance-build-stage1/job/post-push/274808/console)

```
+ aws s3 sync --only-show-errors s3://snapshot-de-images/.../combined-packages .
download failed: s3://.../packages/virtualization/hostchecker2/tars/hostchecker_linux_ppc64le.tar
  An HTTP Client raised an unhandled exception: I/O operation on closed file.

> Task :live-build:ancillaryRepository FAILED
```

`I/O operation on closed file.` is the awscli/s3transfer symptom of a connection
dropped mid-transfer: urllib3 closes the socket's file object and the in-flight
read raises `ValueError`, which s3transfer surfaces as "an unhandled exception"
rather than a retryable S3 error. The CLI does not retry it, so one dropped
connection out of hundreds of objects exits non-zero. Under `set -o errexit` in
`build-ancillary-repository.sh`, that aborts the build.

Raising `max_attempts` or setting `retry_mode` in the AWS config does not help —
that exception bypasses botocore's retry handling entirely.

The failure is transient, not a bad artifact: sibling stage1 builds fanned out
from the same stage0 parent at the same instant, reading the same S3 prefix, all
passed (274807 SUCCESS, **274808 FAILURE**, 274809 SUCCESS, 274810 SUCCESS).

## Solution

Add an `s3_sync` helper to `scripts/common.sh` that runs `aws s3 sync` with the
caller's arguments and retries on failure — 3 attempts, 5s then 10s backoff. All
seven `aws s3 sync` call sites in the repo now go through it.

The helper is deliberately specific to `aws s3 sync` rather than a generic
retrier, because that is what makes the retry trivially safe to justify: `aws s3
sync` is idempotent, skipping objects already present at the destination, so a
retry only re-fetches whatever is still missing.

The final attempt runs outside the loop so its exit status propagates naturally
to callers running under `set -o errexit` — behavior on genuine failure is
unchanged.

One call site needed rework: `download_ucf_artifacts` used a bash assignment
prefix to scope the UCF credentials to the sync. Prefix assignments on a
function call leak into the caller's shell, unlike on a simple command, so that
site now uses a subshell with plain `export`s.

`aws s3 cp` is left alone — those three calls only fetch the tiny `latest`
pointer file and are not the exposure here.

## Testing Done

- `shellcheck scripts/common.sh` — clean (this is what CI runs).
- `shfmt -d scripts/common.sh` — no diff.
- Exercised the helper against the real `common.sh` with a stub `aws` on `PATH`,
  under `set -o errexit`:
  - succeeds on first attempt → 1 invocation, rc 0, no retry output
  - fails twice, succeeds on attempt 3 → rc 0
  - UCF subshell → child process sees the UCF key, caller's
    `AWS_ACCESS_KEY_ID` is unchanged (no leak)
  - all 3 attempts fail → script aborts with exit 1, code after the call is
    never reached
  - stub echoed its argv each time, confirming flags forward intact
    (`s3 sync --only-show-errors s3://bucket/x .`)

Not exercised against real S3 — the underlying dropped connection is not
reproducible locally.