### PR TITLE
TOOL-30973 appliance-build.bootstrap hardcodes 'noble' apt suite, breaks every os-upgrade branch build

### DIFF
--- a/bootstrap/roles/appliance-build.bootstrap/tasks/main.yml
+++ b/bootstrap/roles/appliance-build.bootstrap/tasks/main.yml
@@ -23,17 +23,31 @@
   vars:
     mirror_url: "{{ lookup('env', 'DELPHIX_PACKAGE_MIRROR_MAIN') }}"
   block:
-    - name: Configure noble apt source
+    # Different branches mirror different Ubuntu releases (e.g. os-upgrade mirrors the next
+    # release under test, not the current one), so the suite name can't be hardcoded. The
+    # mirror's own directory listing is the source of truth for which suite a given branch
+    # actually publishes.
+    - name: Determine the Ubuntu suite this branch's mirror publishes
+      ansible.builtin.uri:
+        url: "{{ mirror_url }}/dists/"
+        return_content: true
+      register: mirror_dists_index
+
+    - name: Resolve the base suite name (the one entry without a -backports/-security/-updates suffix)
+      ansible.builtin.set_fact:
+        ubuntu_suite: "{{ (mirror_dists_index.content | regex_findall('href=\"([a-z]+)/\"')) | first }}"
+
+    - name: Configure base apt source
       ansible.builtin.apt_repository:
-        repo: "deb {{ mirror_url }} noble main restricted multiverse universe"
+        repo: "deb {{ mirror_url }} {{ ubuntu_suite }} main restricted multiverse universe"
         state: present
-    - name: Configure noble-updates apt source
+    - name: Configure updates apt source
       ansible.builtin.apt_repository:
-        repo: "deb {{ mirror_url }} noble-updates main restricted multiverse universe"
+        repo: "deb {{ mirror_url }} {{ ubuntu_suite }}-updates main restricted multiverse universe"
         state: present
-    - name: Configure noble-security apt source
+    - name: Configure security apt source
       ansible.builtin.apt_repository:
-        repo: "deb {{ mirror_url }} noble-security main"
+        repo: "deb {{ mirror_url }} {{ ubuntu_suite }}-security main"
         state: present
 
 - name: Stop unattended-upgrades systemd service in preparation for package removal


### PR DESCRIPTION
Will merge after 2026.5.0.0 release

TOOL-30973 appliance-build.bootstrap hardcodes 'noble' apt suite, breaks every os-upgrade branch build

## Problem

`bootstrap/roles/appliance-build.bootstrap/tasks/main.yml` hardcodes the Ubuntu suite name `noble` unconditionally for every branch's apt sources. `DELPHIX_PACKAGE_MIRROR_MAIN` (the mirror URL) is already branch-aware, but the suite name appended to it never was.

This works for `develop`, whose mirror really does serve `noble`. It fails for every `os-upgrade` build, since that branch's mirror only ever serves `resolute` (os-upgrade's whole purpose is testing the next Ubuntu release). Every os-upgrade appliance build has been failing identically:

```
E: The repository 'http://linux_package_mirror_v21-prod-usw2.ops.delphix.com/os-upgrade/.../ubuntu noble Release'
does not have a Release file.
```

## Fix

Derive the actual suite from the mirror's own directory listing instead of hardcoding it. The mirror publishes an autoindex at `{{ mirror_url }}/dists/` showing exactly which suite that branch serves, so this queries it and extracts the base suite name (the one entry without a `-backports`/`-security`/`-updates` suffix) at bootstrap time. Self-contained in this repo, no matching change needed elsewhere, and self-corrects if a branch's target release ever changes again.

## Testing

YAML syntax validated. Regex verified against the real mirror listings for both branches:
- `develop`: `noble/`, `noble-backports/`, `noble-security/`, `noble-updates/` -> resolves to `noble`
- `os-upgrade`: `resolute/`, `resolute-backports/`, `resolute-security/`, `resolute-updates/` -> resolves to `resolute`

`ansible-lint`/`shellcheck` not run locally yet (tooling not installed at time of writing).

## Timing

Hold this until after 2026.5.0.0 releases. This touches the bootstrap role used by every branch's build infrastructure, don't want to introduce risk there during an active release cycle.

