### PR TITLE
DLPX-98829 [Backport of DLPX-98830] HSC | Hyperscale | Drop masking-common role from internal/external-hyperscale playbook

### DIFF
--- a/live-build/variants/external-hyperscale/ansible/playbook.yml
+++ b/live-build/variants/external-hyperscale/ansible/playbook.yml
@@ -1,5 +1,5 @@
 #
-# Copyright 2025 Delphix
+# Copyright 2025, 2026 Delphix
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -22,13 +22,5 @@
     ansible_python_interpreter: /usr/bin/python3
   roles:
     - appliance-build.minimal-common
-    - appliance-build.masking-common
     - appliance-build.virtualization-common
-    #
-    # The hyperscale-common role requires the appliance configuration,
-    # essentially the 'masking' user creation, done by the masking-common
-    # role to be in place before the hyperscale-common role is applied.
-    # Thus, we need to ensure the hyperscale-common role is applied after
-    # the masking-common role.
-    #
     - appliance-build.hyperscale-common

--- a/live-build/variants/internal-hyperscale/ansible/playbook.yml
+++ b/live-build/variants/internal-hyperscale/ansible/playbook.yml
@@ -1,5 +1,5 @@
 #
-# Copyright 2025 Delphix
+# Copyright 2025, 2026 Delphix
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -24,16 +24,7 @@
     - appliance-build.minimal-common
     - appliance-build.minimal-internal
     - appliance-build.minimal-development
-    - appliance-build.masking-common
-    - appliance-build.masking-development
     - appliance-build.virtualization-common
     - appliance-build.virtualization-development
-    #
-    # The hyperscale-common role requires the appliance configuration,
-    # essentially the 'masking' user creation, done by the masking-common
-    # role to be in place before the hyperscale-common role is applied.
-    # Thus, we need to ensure the hyperscale-common role is applied after
-    # the masking-common role.
-    #
     - appliance-build.hyperscale-common
     - appliance-build.qa-internal


### PR DESCRIPTION
This is a cherry-pick of commit e558db23fa989138167429a106d8ee3ae0b5b826 from PR https://github.com/delphix/appliance-build/pull/896/ (`develop`) into `release`.

<details open>
<summary><h2> Problem </h2></summary>

HM-11725 removed the `masking-common` role from the internal/external
hyperscale playbook on `develop`. This fix needs to be backported to
`release`.
</details>

<details open>
<summary><h2> Solution </h2></summary>

Cherry-picked commit e558db23fa989138167429a106d8ee3ae0b5b826
(PR #896) from `develop` onto `release`.
</details>

<details open>
<summary><h2> Testing Done </h2></summary>

No additional testing beyond what was already done for PR #896 on
`develop`, since this is a straight cherry-pick of that change.
</details>
