### PR TITLE
DLPX-98834 install hotfix_metadata outside /usr/share/doc

### DIFF
--- a/live-build/config/hooks/configuration/81-upgrade-repository.binary
+++ b/live-build/config/hooks/configuration/81-upgrade-repository.binary
@@ -129,8 +129,12 @@ echo "$APPLIANCE_VARIANT" >variant
 
 test -n "$DELPHIX_APPLIANCE_VERSION"
 
+#
+# The platform substitution must be global: the "Links" field in the control
+# template names the platform twice.
+#
 sed -i "s/@@VERSION@@/$DELPHIX_APPLIANCE_VERSION/" delphix-entire.ctl
-sed -i "s/@@PLATFORM@@/$APPLIANCE_PLATFORM/" delphix-entire.ctl
+sed -i "s/@@PLATFORM@@/$APPLIANCE_PLATFORM/g" delphix-entire.ctl
 
 equivs-build delphix-entire.ctl
 

--- a/live-build/config/hooks/configuration/template.ctl
+++ b/live-build/config/hooks/configuration/template.ctl
@@ -3,10 +3,28 @@ Priority: optional
 Maintainer: Delphix Engineering <eng@delphix.com>
 Standards-Version: 3.9.2
 
+#
+# "hotfix_metadata" is read by the upgrade-verify "HotfixCheck", so it cannot
+# live in the "Extra-Files" documentation directory. dh_compress gzips any file
+# in /usr/share/doc larger than 4k, and that check only ever looks for the
+# uncompressed name, so the file silently disappeared out from under it once the
+# hotfix list grew past 4096 bytes (DLPX-98834).
+#
+# Debian Policy 12.3 covers this case directly: packages must not require files
+# in /usr/share/doc in order to function, and files read by programs belong
+# elsewhere (such as under /usr/share/<package>) with a symlink from the doc
+# directory. That's what the "Files" and "Links" fields below do; nothing needs
+# to change in the consumer, since the historical path still resolves.
+#
+# "packages.list" deliberately stays in "Extra-Files": it is always well over
+# 4k, and its consumers already read "packages.list.gz".
+#
 Package: delphix-entire-@@PLATFORM@@
 Provides: delphix-entire
 Version: @@VERSION@@
-Extra-Files: packages.list, variant, hotfix_metadata
+Extra-Files: packages.list, variant
+Files: hotfix_metadata /usr/share/delphix-entire-@@PLATFORM@@/
+Links: /usr/share/delphix-entire-@@PLATFORM@@/hotfix_metadata /usr/share/doc/delphix-entire-@@PLATFORM@@/hotfix_metadata
 Description: Entirety of Delphix Appliance
  This package depends on all of the packages that constitute the entirety of
  the Delphix Appliance. This set of packages provide the necessary tools to run


### PR DESCRIPTION
**RCA:** [DLPX-98834](https://perforce.atlassian.net/browse/DLPX-98834). Breaks `test_upgrade_linux_system` on every hotfix `platforms_upgrade` config since 2026-09-02 (AWS #216, GCP #3, AZURE #210/#204), and is 4 bytes away from breaking every upgrade-verify on `develop` and `release`.

## Problem

`hotfix_metadata` is an `Extra-Files` entry on the `delphix-entire` metapackage, so `equivs-build` writes it into `debian/docs` and it lands in `/usr/share/doc/delphix-entire-<platform>/`. `dh_compress` then gzips anything in that tree matching `find -size +4k`, which rounds up to 1K blocks, so the boundary is exact: 4096 bytes and under stays plain, 4097 and over gets gzipped.

The generated hotfix list crossed that line, and the file the upgrade-verify `HotfixCheck` wants stopped existing:

```
$ dpkg -c delphix-entire-aws_...develop-pre-push-4285_all.deb | grep share/doc
-rw-r--r-- root/root   780  ./usr/share/doc/delphix-entire-aws/README.Debian
-rw-r--r-- root/root   206  ./usr/share/doc/delphix-entire-aws/changelog.Debian.gz
-rw-r--r-- root/root   940  ./usr/share/doc/delphix-entire-aws/copyright
-rw-r--r-- root/root  1153  ./usr/share/doc/delphix-entire-aws/hotfix_metadata.gz
-rw-r--r-- root/root  6837  ./usr/share/doc/delphix-entire-aws/packages.list.gz
-rw-r--r-- root/root    12  ./usr/share/doc/delphix-entire-aws/variant
```

`HotfixCheck.verify()` probes `/opt/delphix/server/etc/hotfix_metadata` (the pre-6.0.10 location, absent on modern engines) then `/usr/share/doc/delphix-entire-<platform>/hotfix_metadata`, knows nothing about `.gz`, and throws an **uncaught** `DelphixFatalException` at `HotfixCheck.java:135`. That kills `upgrade-verify.jar` mid-report, after earlier checks have already reported SUCCESS, and reaches the user as a bare `exception.upgrade.verify.failed` / "An unexpected error has occurred. Contact Delphix support." Nothing in the error names the file, the check, or the size.

Sizes of `input-artifacts/hotfix_metadata` in S3 show the crossing, and how little headroom is left:

| build | date (UTC) | bytes | |
|---|---|---|---|
| ops `post-push` 4570-4607 | 08-22 .. 08-29 12:44 | 4076 | plain |
| ops `post-push` 4608-4626 | 09-01 00:52 .. | 4092 | plain, **4 bytes of headroom** |
| `release/post-push` 411-415 | 09-01 .. 09-03 | 4092 | plain, **4 bytes of headroom** |
| regression `pre-push` 4285-4293 | 09-02 .. 09-04 | 4099 | **gzipped** |

At ~8 bytes per 4-digit HF key, the next qualifying hotfix takes `develop` and `release` over as well, at which point every upgrade-verify fails, customers included.

## Solution

`dh_compress` is not misbehaving. Debian Policy 12.3 says packages "must not require the existence of any files in `/usr/share/doc/` in order to function", and that files read by programs "should be installed elsewhere, such as under `/usr/share/package/`, and then included via symbolic link". The file is simply in the wrong place, and suppressing the compression would leave that true.

The solution taken in this PR is to install `hotfix_metadata` under `/usr/share/delphix-entire-<platform>/` using equivs' existing `Files:` field (which routes through `debian/install`, not `debian/docs`), and to point the historical doc path at it with `Links:`. `dh_compress` never scans outside `usr/share/{doc,man,info,fonts/X11}`, so the file is plain at any size, and because the old path still resolves **nothing changes in `delphix-upgrade-verification`** — which is what makes this backportable to `release` as a data-only change.

`packages.list` deliberately stays in `Extra-Files`: it is always well over 4k and its consumers (`upgrade-scripts/execute`, `support_info.sh`) already read `packages.list.gz`.

The platform substitution in the hook needed a `g`: it was `sed -i "s/@@PLATFORM@@/$APPLIANCE_PLATFORM/"`, which replaces only the first occurrence per line, and the `Links:` line names the platform twice.

For the record, the live consumer set of this file is exactly one call site (`HotfixCheck.java:92`), enumerated across dlpx-app-gate, delphix-upgrade-verification, appliance-build, delphix-platform, dms-core-gate, dlpx-qa-gate, devops-gate and linux-pkg. Reader and file always ship together, since `verify-jar` installs the verification deb out of the target image and runs it in a container where that image's `delphix-entire` is installed, and the rollback path never runs verify. So there is no compat matrix on the path change. Two references look like consumers but are dead: `UpgradeImageTest.java`'s `HASHED_IMAGE_FILES` describes the illumos-era layout (`dx_prepare`, `dx.cpio`, `os.cpio`), and blackbox's `UPG_IMAGE_HOTFIX_METADATA_FILE` points at `/var/dlpx-update/{target_version}/hotfix_metadata`, which does not exist in a modern image.

## Testing Done

`shfmt -d` clean on the changed hook.

Replayed the hook's own substitution lines against the patched `template.ctl` with the real 4099-byte `hotfix_metadata` that broke pre-push #4285, using equivs 2.3.1 + debhelper 13.14.1ubuntu5 (the versions `appliance-build.bootstrap` provisions on noble):

```
Package: delphix-entire-aws
Extra-Files: packages.list, variant
Files: hotfix_metadata /usr/share/delphix-entire-aws/
Links: /usr/share/delphix-entire-aws/hotfix_metadata /usr/share/doc/delphix-entire-aws/hotfix_metadata

-rw-r--r--   4099  ./usr/share/delphix-entire-aws/hotfix_metadata
lrwxrwxrwx      0  ./usr/share/doc/delphix-entire-aws/hotfix_metadata -> ../../delphix-entire-aws/hotfix_metadata
-rw-r--r--   1943  ./usr/share/doc/delphix-entire-aws/packages.list.gz
-rw-r--r--      9  ./usr/share/doc/delphix-entire-aws/variant
```

No `@@` placeholders survive the substitution, and the generated `debian/control` is clean (equivs strips the comment block and consumes `Files:`/`Links:`/`Extra-Files:` rather than emitting them).

Also exercised the upgrade transition specifically, since the old package ships a regular file at the doc path and the new one ships a symlink there. `dpkg --root` install of old then new, no warnings:

```
Unpacking delphix-entire-aws (2.0-new) over (1.0-old) ...
Setting up delphix-entire-aws (2.0-new) ...

  lrwxrwxrwx  hotfix_metadata -> ../../delphix-entire-aws/hotfix_metadata
  test -f /usr/share/doc/delphix-entire-aws/hotfix_metadata  -> true
  entries readable through the old path: 534
  size via symlink: 4099 bytes
```

For contrast, the same build with a 4092-byte input produces a plain 4092-byte file even unpatched, which is what pins the threshold at 4096.

Still to do, not in this PR: a real `platforms_upgrade` hotfix run against an image built from this branch.

## Follow-ups

Filed separately, not required for this fix:

- `generate_hotfix_metadata.py` writes the `-f <HF>` hotfix twice when it already qualifies on its own merits (`main()` extends `fixed_hotfixes` with no de-dup against the base list). That duplicate `HF-911` line is 7 bytes and is what pushed hotfix builds from 4092 to 4099 while non-hotfix builds stayed under.
- `UpgradeVerificationCheckRunnerImpl` lets one check's exception abort the whole report, which is why this surfaced as "contact Delphix support" instead of a failed check.
- `HotfixCheck` could tolerate `hotfix_metadata.gz` as defence in depth.
- blackbox `test_verify_no_warnings_with_only_upgrade_image_hotfix_metadata` targets a path that no longer exists, so it has been passing vacuously. It is the test that should have caught this.
