### PR TITLE
DLPX-98670 protect running kernel's dependency closure from upgrade purge

### DIFF
--- a/upgrade/upgrade-scripts/common.sh
+++ b/upgrade/upgrade-scripts/common.sh
@@ -365,6 +365,63 @@ function xargs_apt_get() {
 		"$@"
 }
 
+#
+# List installed packages whose name contains "$1" (typically the
+# running kernel release, "$(uname -r)").
+#
+function get_installed_packages_matching() {
+	[[ -n "$1" ]] || die "pattern not specified"
+	local PACKAGES
+	PACKAGES="$(dpkg-query -Wf '${Package}\n')" || die "dpkg-query failed"
+	grep -F "$1" <<<"$PACKAGES" || true
+}
+
+#
+# Print "$@" plus everything those packages "Depends:"/"PreDepends:" on,
+# recursively, restricted to what's actually installed.
+#
+# This exists to compute the set of packages that must be protected
+# from a purge (DLPX-98670): "apt-get purge" also removes a package's
+# reverse dependents, so protecting a package by name is not enough --
+# if something it depends on is purged (because that dependency's own
+# name doesn't match the protection pattern), apt cascades the purge
+# back up and removes the protected package too. Protecting the full
+# forward dependency closure prevents that cascade.
+#
+function get_transitive_install_deps() {
+	[[ $# -gt 0 ]] || return 0
+	#
+	# The "grep -E '^[^ |]'" strips apt-cache's indented "Depends:"/
+	# " |Depends:" lines, keeping only the un-indented package name
+	# lines. This relies on apt-cache's human-oriented text formatting
+	# rather than a documented stable interface; verified against apt
+	# 2.8.3.
+	#
+	apt-cache depends --recurse \
+		--no-recommends --no-suggests --no-conflicts \
+		--no-breaks --no-replaces --no-enhances \
+		--installed "$@" | grep -E '^[^ |]'
+}
+
+#
+# Defense in depth for DLPX-98670: verify every package named in "$1" (a
+# newline-separated list, typically captured before a purge) is still
+# installed, and fail loudly if not.
+#
+# Without this, a gap in the purge protection above (or a future change
+# to the purge logic) would only surface as some unrelated service
+# silently failing to modprobe a deleted module at an arbitrary later
+# boot, with no diagnostic trail pointing back at the upgrade.
+#
+function verify_packages_installed() {
+	local PKG
+	while read -r PKG; do
+		[[ -n "$PKG" ]] || continue
+		dpkg-query -W "$PKG" &>/dev/null ||
+			die "package '$PKG' is missing after the upgrade purge"
+	done <<<"$1"
+}
+
 function verify_upgrade_not_in_progress() {
 	#
 	# This function only works properly if the UPGRADE_TYPE variable

--- a/upgrade/upgrade-scripts/execute
+++ b/upgrade/upgrade-scripts/execute
@@ -561,9 +561,41 @@ fi
 # work properly, we'll still have the currently running kernel available
 # to use as a fallback.
 #
-# shellcheck disable=SC2046
-apt_get purge -y $(apt-mark showauto | grep -v "$(uname -r)") ||
-	die "failed to remove no-longer-needed packages"
+# It's not enough to protect only packages whose *name* carries the
+# running kernel release: "apt-get purge" also removes a package's
+# reverse dependents, so a dropped dependency of a kernel package (e.g.
+# "wireless-regdb", which "linux-modules-extra-$(uname -r)" depends on
+# but doesn't itself name the kernel) drags the kernel package down with
+# it (DLPX-98670). So instead we protect every installed kernel-named
+# package plus their full installed dependency closure.
+#
+RUNNING_KERNEL_PACKAGES="$(get_installed_packages_matching "$(uname -r)")"
+
+#
+# Note: a failure inside either process substitution below (e.g.
+# "apt-mark" or "apt-cache") isn't propagated to "comm" or this
+# assignment; "comm" would just see a truncated stream. We don't
+# guard against that explicitly here because the "verify_packages_installed"
+# check after the purge below still catches the resulting damage and
+# fails the upgrade loudly.
+#
+# shellcheck disable=SC2046,SC2086
+PURGE_PACKAGES="$(comm -23 \
+	<(apt-mark showauto | sort -u) \
+	<(get_transitive_install_deps $RUNNING_KERNEL_PACKAGES | sort -u))"
+
+if [[ -n "$PURGE_PACKAGES" ]]; then
+	# shellcheck disable=SC2086
+	apt_get purge -y $PURGE_PACKAGES ||
+		die "failed to remove no-longer-needed packages"
+fi
+
+#
+# Assert the purge above didn't take out any running-kernel package,
+# rather than deferring a silent failure to an arbitrary later boot
+# (DLPX-98670).
+#
+verify_packages_installed "$RUNNING_KERNEL_PACKAGES"
 
 #
 # Additionally, we've seen packages get removed but remain in the "rc"


### PR DESCRIPTION
## Summary

- `execute`'s final package purge protected the running kernel's own packages by name only (`apt-mark showauto | grep -v "$(uname -r)"`), but `apt-get purge` also removes a package's reverse dependents — so a dropped dependency that doesn't itself carry the kernel release in its name (e.g. `wireless-regdb`, which `linux-modules-extra-$(uname -r)` depends on) cascades the purge back up and takes the kernel package with it.
- The failure is silent at apply time (the module is already loaded) and only surfaces as a management-stack outage at some arbitrary later boot (see DLPX-98412).
- Protects the running kernel's full installed dependency closure (via `apt-cache depends --recurse --installed`) instead of just package names, and asserts after the purge that none of those packages went missing, so a gap fails the upgrade loudly instead of deferring it to a later boot.

Jira: https://perforce.atlassian.net/browse/DLPX-98670

## Test plan

- [x] `shellcheck -x` clean on both changed files (only pre-existing, unrelated `SC1091`/`SC2119` info notices remain)
- [x] Manually verified the new `common.sh` functions against this dev VM's real package state (a `linux-modules-extra`/`wireless-regdb`-shaped kernel), confirming the dependency closure protects the vulnerable package and `verify_packages_installed` accepts a healthy system / rejects a missing one
- [ ] No automated test added — this directory (`upgrade/upgrade-scripts/tests/`) has no CI cadence today (existing tests there are manual, root-required, run-by-hand); a temporary reproduction script was used locally to validate the fix and then dropped rather than added as unreachable dead code
