### PR TITLE
DLPX-98904 internal-claude: pre-install the DCenter CLI (dc)

### DIFF
--- a/live-build/misc/ansible-roles/appliance-build.claude-internal/tasks/main.yml
+++ b/live-build/misc/ansible-roles/appliance-build.claude-internal/tasks/main.yml
@@ -83,6 +83,52 @@
     creates: /usr/local/bin/claude
   changed_when: true
 
+# The DCenter CLI, so skills can run `dc` on the image itself rather than over ssh to
+# dlpxdc.co -- a clone carries authorized_keys but no private key to make that hop with. It
+# gets its own virtualenv because dlpxdccommand pins boto3/botocore, which would fight the
+# awscli install in minimal-internal.
+- name: Install python3-venv for the DCenter client
+  ansible.builtin.apt:
+    name: python3-venv
+    state: present
+
+# The index is delphix-virtual-pypi, not the delphix-local one dcoa's README documents:
+# delphix-local carries dlpxdccommand but no setuptools, so pip cannot resolve its build
+# dependencies there and fails on "No matching distribution found for setuptools>=40.8.0".
+- name: Install the DCenter client into /opt/dcenter-client
+  ansible.builtin.pip:
+    name: dlpxdccommand
+    virtualenv: /opt/dcenter-client
+    virtualenv_command: /usr/bin/python3 -m venv
+    extra_args: >-
+      --no-cache-dir
+      --index-url
+      https://artifactory.delphix.com/artifactory/api/pypi/delphix-virtual-pypi/simple/
+
+# A wrapper rather than a symlink into the venv's bin, which also holds python3 and pip:
+# that directory on PATH would send every bare `python3` on the image into this virtualenv.
+- name: Install the dc wrapper into /usr/local/bin
+  ansible.builtin.copy:
+    dest: /usr/local/bin/dc
+    mode: "0755"
+    content: |
+      #!/usr/bin/env bash
+      #
+      # Installed by appliance-build.claude-internal -- edit that role, not this file.
+      #
+      # DLPX_DC_API_HOST is pinned because the dlpxdccommand build on Artifactory defaults
+      # to a decommissioned API gateway (2.0.3 defaults to r46rgdk3u4..., which NXDOMAINs)
+      # while reporting the same --version as a working client, so the bad default cannot
+      # be spotted from the version. This value is DEFAULT_API_HOST in dcoa's
+      # components/dc-command/src/main/python/dlpxdccommand/command/dc_cmds.py.
+      #
+      # Credentials are left to the caller: interactively, run `dc login` once; in
+      # automation, export DLPX_DEFAULT_CREDENTIALS=true to authenticate off the standard
+      # AWS credential chain instead of a dcoa profile.
+      #
+      export DLPX_DC_API_HOST="${DLPX_DC_API_HOST:-sknncxtzxf.execute-api.us-west-2.amazonaws.com}"
+      exec /opt/dcenter-client/bin/dc "$@"
+
 - name: Create /export/home/delphix/src directory
   ansible.builtin.file:
     path: /export/home/delphix/src


### PR DESCRIPTION
<details open>
<summary><h2> Problem </h2></summary>

The `internal-claude` variant has no `dc`, so a skill that provisions or manages
a DCenter VM has to reach `dlpxdc.co` over ssh. A clone carries
`authorized_keys` but no private key of its own, so that hop has nothing to
authenticate with:

```
$ ssh dlpxdc.co dc list
Permission denied (publickey,password)
```

Every consumer works around it by installing the client itself at runtime. The
`devops-gate` claude-automation ZFS merge job carries ~30 lines of `SETUP_CMD`
doing exactly that, and its four traps (the wrong pip index, a decommissioned
API host, PATH-shadowing `python3`, and credential ordering) are rediscovered
per consumer.
</details>

<details open>
<summary><h2> Solution </h2></summary>

The solution taken in this PR is to install the DCenter client on the image, in
the `claude-internal` role:

- `dlpxdccommand` goes into its own virtualenv at `/opt/dcenter-client` rather
  than the system python, since it pins `boto3`/`botocore` and would fight the
  `awscli` install in `minimal-internal`. That also needs `python3-venv`, which
  the shared base does not carry (`python3-pip` it does).
- The index is `delphix-virtual-pypi`, not the `delphix-local` one dcoa's README
  documents. `delphix-local` carries `dlpxdccommand` but no `setuptools`, so pip
  cannot resolve the build dependencies from it and dies with `No matching
  distribution found for setuptools>=40.8.0`.
- `dc` on `PATH` is a wrapper at `/usr/local/bin/dc`, not a symlink into the
  venv's `bin`, which also holds `python`/`python3`/`pip`. That directory on
  `PATH` would redirect every bare `python3` run on the image into this venv.

The wrapper pins `DLPX_DC_API_HOST`, which is load-bearing: the published client
defaults to a decommissioned API gateway and reports the same `--version` as a
working client, so the bad default cannot be spotted from the version; e.g. with
2.0.3 out of Artifactory:

```
$ grep 'DEFAULT_API_HOST = ' .../dlpxdccommand/command/dc_cmds.py
DEFAULT_API_HOST = "r46rgdk3u4.execute-api.us-west-2.amazonaws.com"

$ getent hosts r46rgdk3u4.execute-api.us-west-2.amazonaws.com   # nothing
$ getent hosts sknncxtzxf.execute-api.us-west-2.amazonaws.com   # the pinned value
18.160.181.57   sknncxtzxf.execute-api.us-west-2.amazonaws.com
```

A `/etc/profile.d` entry would not do here, since non-login shells (e.g. a
Jenkins `sh` step) never source it. The `${DLPX_DC_API_HOST:-...}` form leaves
the host overridable for a non-prod DCoA.

Credentials stay with the caller, so both consumers work: `dc login`
interactively, which sets up the `dcoa` boto profile, or
`DLPX_DEFAULT_CREDENTIALS=true` in automation, which builds the boto3 session
with `profile_name=None` and picks up whatever the runner already binds.
Forcing the latter on the image would bypass the profile `dc login` writes.
</details>

<details open>
<summary><h2> Testing Done </h2></summary>

### Local verification

- `pip install dlpxdccommand` from `delphix-virtual-pypi` into a clean
  `python3 -m venv` on noble / python 3.12 resolves and produces `bin/dc`
  (2.0.3), i.e. the same shape the role builds.
- The `DEFAULT_API_HOST` / `getent` evidence above comes from that install; it
  is what the pin is for.
- `shellcheck` clean on the rendered wrapper script, and
  `ansible-playbook --syntax-check` clean on
  `live-build/variants/internal-claude/ansible/playbook.yml`.
- `ansible-lint` is not installed on this workstation, so that one is unrun. The
  new tasks are named, FQCN, and set an explicit `mode`, so no
  `.ansible-lint-ignore` entries should be needed.

### ab-pre-push build #14974: IN PROGRESS

- Build: https://selfservice-jenkins.eng-tools-prd.aws.delphixcloud.com/job/appliance-build-orchestrator-pre-push/14974/
- Tested: `appliance-build@f6663dd` (against `develop`)
- Variants: `internal-claude` (requested explicitly, since the default variant
  set omits it), platform `aws`, imported into DCenter as the same variant.
- Tests are off: this variant carries no product stack for the blackbox and
  dx-integration suites to exercise.
- Status: running. Once the import lands, the remaining check is a clone from
  that group running `dc user self` and `dc list`, which is the one thing a
  build cannot show.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
